### PR TITLE
Fix the multi-selection in WSearchEditor to match VLookup.  

### DIFF
--- a/client/src/org/compiere/grid/ed/VLookup.java
+++ b/client/src/org/compiere/grid/ed/VLookup.java
@@ -925,7 +925,7 @@ public class VLookup extends JComponent
 
 		if (updatedValue == null && m_value == null)
 			updated = true;
-		else if (updatedValue != null && value.equals(m_value))
+		else if (updatedValue != null && updatedValue.equals(m_value))
 			updated = true;
 		if (!updated)
 		{

--- a/client/src/org/compiere/grid/ed/VLookup.java
+++ b/client/src/org/compiere/grid/ed/VLookup.java
@@ -918,7 +918,7 @@ public class VLookup extends JComponent
 
 		Object updatedValue = value;
 
-		if (updatedValue instanceof Object[] && ((Object[])updatedValue).length > 0)
+		if (updatedValue != null && updatedValue instanceof Object[] && ((Object[])updatedValue).length > 0)
 		{
 			updatedValue = ((Object[])updatedValue)[0];
 		}

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WSearchEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WSearchEditor.java
@@ -494,22 +494,27 @@ public class WSearchEditor extends WEditor implements ContextMenuListener, Value
 				
 		//  is the value updated ?
 		boolean updated = false;
-		if (value instanceof Object[] && ((Object[])value).length > 0)
+		
+		Object updatedValue = value;
+
+		if (updatedValue instanceof Object[] && ((Object[])updatedValue).length > 0)
 		{
-			value = ((Object[])value)[0];
+			updatedValue = ((Object[])updatedValue)[0];
 		}
 		
-		if (value == null && getValue() == null)
+		// Avoid events if the value hasn't changed.
+		if (updatedValue == null && getValue() == null)
 			updated = true;
-		else if (value != null && value.equals(getValue()) && !m_needsUpdate)
+		else if (updatedValue != null && updatedValue.equals(getValue()) && !m_needsUpdate)
 			updated = true;
 		if (!updated)
 		{
-			setValue(value);
+			setValue(updatedValue);
 		}
 		
 		// Fire the change event after the change so listeners can react in the same thread.
-		ValueChangeEvent evt = new ValueChangeEvent(this, this.getColumnName(), oldValue, getValue());
+		// Pass value as it may be an array for multiple selection.  updatedValue will be a single value.
+		ValueChangeEvent evt = new ValueChangeEvent(this, this.getColumnName(), oldValue, value);
 		// -> ADTabpanel - valuechange
 		fireValueChange(evt);
 

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WSearchEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WSearchEditor.java
@@ -497,7 +497,7 @@ public class WSearchEditor extends WEditor implements ContextMenuListener, Value
 		
 		Object updatedValue = value;
 
-		if (updatedValue instanceof Object[] && ((Object[])updatedValue).length > 0)
+		if (updatedValue != null && updatedValue instanceof Object[] && ((Object[])updatedValue).length > 0)
 		{
 			updatedValue = ((Object[])updatedValue)[0];
 		}


### PR DESCRIPTION
The array of values returned by the info windows needs to be passed to the event listener.  Only the first value was being returned in WSearchEditor.  Some code cleanup in both files to test for changes to the field where the possible array was tested rather than the single value.