### PR TITLE
 #221 Find fails with index out of range

### DIFF
--- a/client/src/org/compiere/apps/search/Find.java
+++ b/client/src/org/compiere/apps/search/Find.java
@@ -123,7 +123,8 @@ import org.compiere.util.ValueNamePair;
  * @Author Michael McKay (mjmckay)                                            
  * @date	December 21, 2011                                            
  *		<li>BF3431195 Advanced Lookup not working in ZK                       
- *      See https://sourceforge.net/tracker/?func=detail&aid=3431195&group_id=176962&atid=955896                  
+ *      See https://sourceforge.net/tracker/?func=detail&aid=3431195&group_id=176962&atid=955896
+ *      <li>#221 Find fails with index out of range if a VLookup field used as a selection column ahead of a range.                    
  */
 public final class Find extends CDialog
 		implements ActionListener, ChangeListener, DataStatusListener
@@ -647,6 +648,7 @@ public final class Find extends CDialog
 		
 		//	Editor
 		VEditor editor = null;
+		VEditor editor2 = null; //#221
 		CLabel label = null;
 		if (mField.isLookup())
 		{
@@ -708,10 +710,9 @@ public final class Find extends CDialog
 					
 					box.add((Component) editor);
 					
-					VEditor editor2 = VEditorFactory.getEditor(mField, false);
+					editor2 = VEditorFactory.getEditor(mField, false); //#221
 					editor2.setMandatory(false);
 		            editor2.setReadWrite(true);
-		            m_sEditors2.add (editor2);
 		            if (editor2 instanceof CTextField) {
 						((CTextField)editor2).addActionListener(this);
 		            }
@@ -792,9 +793,7 @@ public final class Find extends CDialog
 						scontentPanel.add(label,   new GridBagConstraints(lpos, m_sLine, 1, 1, 0.0, 0.0
 							,GridBagConstraints.NORTHEAST, GridBagConstraints.NONE, new Insets(7, 5, 5, 5), 0, 0));
 					scontentPanel.add((Component)editor,   new GridBagConstraints(fpos, m_sLine, 1, 1, 0.0, 0.0
-						,GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(5, 0, 5, 5), 0, 0));
-					
-					m_sEditors2.add (null);
+						,GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(5, 0, 5, 5), 0, 0));					
 				}
 		}
 		
@@ -804,6 +803,7 @@ public final class Find extends CDialog
 		}
 		
 		m_sEditors.add(editor);
+		m_sEditors2.add(editor2); // #221
 	}	//	addSelectionColumn
 
 


### PR DESCRIPTION
If a VLookup field used as a selection column ahead of a range, the multiple columns can get out-of-sync.

This fix ensures the second set of editors remains in sync.
