### PR TITLE
Hotfix/3.8.0#002 #283 grid controller set null

### DIFF
--- a/client/src/org/compiere/grid/GridController.java
+++ b/client/src/org/compiere/grid/GridController.java
@@ -1254,8 +1254,8 @@ public class GridController extends CPanel
 		int row = m_mTab.getCurrentRow();
 		int col = mTable.findColumn(e.getPropertyName());
 		//
-		if (e.getNewValue() == null && e.getOldValue() != null
-			&& e.getOldValue().toString().length() > 0)		//	some editors return "" instead of null
+		if ((e.getNewValue() == null || e.getNewValue().toString().isEmpty()) 
+			&& e.getOldValue() != null && e.getOldValue().toString().length() > 0)		//	some editors return "" instead of null
 		{
 			//  #283 Set value to null 
 			mTable.setValueAt (null, row, col);	//	-> dataStatusChanged -> dynamicDisplay

--- a/client/src/org/compiere/grid/GridController.java
+++ b/client/src/org/compiere/grid/GridController.java
@@ -1068,7 +1068,8 @@ public class GridController extends CPanel
 							//	log.log(Level.FINEST, "RW=" + rw + " " + mField);
 								boolean manMissing = false;
 							//  least expensive operations first        //  missing mandatory
-								if (rw && mField.getValue() == null && mField.isMandatory(true))    //  check context
+								if (rw && (mField.getValue() == null || mField.getValue().toString().isEmpty()) 
+										&& mField.isMandatory(true))    //  check context. Some fields can return "" instead of null
 									manMissing = true;
 								ve.setBackground(manMissing || mField.isError());
 							}

--- a/client/src/org/compiere/grid/ed/VMemo.java
+++ b/client/src/org/compiere/grid/ed/VMemo.java
@@ -166,6 +166,7 @@ public class VMemo extends CTextArea
 	public void setValue(Object value)
 	{
 		super.setValue(value);
+		m_oldText = getText();
 		m_firstChange = true;
 		//	Always position Top 
 		setCaretPosition(0);

--- a/client/src/org/compiere/grid/ed/VMemo.java
+++ b/client/src/org/compiere/grid/ed/VMemo.java
@@ -252,10 +252,10 @@ public class VMemo extends CTextArea
 	public void focusGained (FocusEvent e)
 	{
 		log.config(e.paramString());
-		if (e.getSource() instanceof VMemo)
-			requestFocus();
-		else
-			m_oldText = getText();
+		//if (e.getSource() instanceof VMemo)
+		//	requestFocus();
+		//else
+		//	m_oldText = getText();
 	}	//	focusGained
 
 	/**

--- a/client/src/org/compiere/grid/ed/VMemo.java
+++ b/client/src/org/compiere/grid/ed/VMemo.java
@@ -266,10 +266,18 @@ public class VMemo extends CTextArea
 	{
 		//  Indicate Change
 		log.fine( "focusLost");
+		
+		if (getText() == null && m_oldText == null)
+			return;
+		else if (getText().equals(m_oldText))
+			return;
+		//
 		try
 		{
 			String text = getText();
-			fireVetoableChange(m_columnName, text, null);   //  No data committed - done when focus lost !!!
+			fireVetoableChange(m_columnName, m_oldText, text);
+			//m_oldText = text;  set by setValue();
+			return;
 		}
 		catch (PropertyVetoException pve)	{}
 	}	//	focusLost

--- a/client/src/org/compiere/grid/ed/VMemo.java
+++ b/client/src/org/compiere/grid/ed/VMemo.java
@@ -201,11 +201,9 @@ public class VMemo extends CTextArea
 				s = Editor.startEditor (this, Msg.translate(Env.getCtx(), m_columnName), 
 					getText(), isEditable(), m_fieldLength);
 			menuEditor.setEnabled(true);
-			setValue(s);
 			try
 			{
-				fireVetoableChange(m_columnName, null, getText());
-				m_oldText = getText();
+				fireVetoableChange(m_columnName, m_oldText, s);
 			}
 			catch (PropertyVetoException pve)	{}
 		}

--- a/client/src/org/compiere/grid/ed/VMemo.java
+++ b/client/src/org/compiere/grid/ed/VMemo.java
@@ -306,20 +306,21 @@ private class CInputVerifier extends InputVerifier {
 	 public boolean verify(JComponent input) {
 
 
-		//NOTE: We return true no matter what since the InputVerifier is only introduced to fireVetoableChange in due time
-		if (getText() == null && m_oldText == null)
-			return true;
-		else if (getText().equals(m_oldText))
-			return true;
-		//
-		try
-		{
-			String text = getText();
-			fireVetoableChange(m_columnName, null, text);
-			m_oldText = text;
-			return true;
-		}
-		catch (PropertyVetoException pve)	{}
+//		NOTE: We return true no matter what since the InputVerifier is only introduced to fireVetoableChange in due time
+//		in which case, this code serves no purpose.  Code moved to focusLost where the binding should take place. 
+//		if (getText() == null && m_oldText == null)
+//			return true;
+//		else if (getText().equals(m_oldText))
+//			return true;
+//		//
+//		try
+//		{
+//			String text = getText();
+//			fireVetoableChange(m_columnName, m_oldText, text);
+//			//m_oldText = text;  set by setValue();
+//			return true;
+//		}
+//		catch (PropertyVetoException pve)	{}
 		return true;
 
 	 } // verify


### PR DESCRIPTION
#283, #341, #342 - These changes should fix the behavior of the text and memo fields when dealing with text and null values.  Tested with mandatory, read-only and normal fields of type text, string, memo, date, amount, filename.  The behavior for mandatory fields is:

1. Red (error) when initially null
2. Blue when there is a value
3. Red when the field value is deleted

The value is bound when the field looses focus.
