### PR TITLE
Hotfix/3.8.0#002 #325 #363 process param

### DIFF
--- a/base/src/org/adempiere/process/MigrationLoader.java
+++ b/base/src/org/adempiere/process/MigrationLoader.java
@@ -6,6 +6,7 @@ import java.util.logging.Level;
 
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.Adempiere;
+import org.compiere.process.*;
 import org.compiere.process.ProcessInfo;
 import org.compiere.util.CLogMgt;
 import org.compiere.util.CLogger;
@@ -52,7 +53,8 @@ public class MigrationLoader {
 
 		try {
 			//Import Migration from XML
-			ProcessInfo processInfo = ProcessBuilder.create(context).process(53175)
+			ProcessInfo processInfo = ProcessBuilder.create(context)
+			.process(org.compiere.process.MigrationFromXML.class)
 			.withTitle("Import Migration from XML")
 			.withParameter("FailOnError",failOnError)
 			.withParameter("FileName", fileName)
@@ -65,25 +67,26 @@ public class MigrationLoader {
 				throw new AdempiereException(processInfo.getSummary());
 
 			processInfo = ProcessBuilder.create(context)
-					.process(258)
+					.process(org.compiere.process.SequenceCheck.class)
 					.withTitle("Sequence Check")
 					.execute();
 			log.log(Level.CONFIG, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
 
 			processInfo = ProcessBuilder.create(context)
-					.process(172)
+					.process(org.compiere.process.SynchronizeTerminology.class)
 					.withTitle("Synchronize Terminology")
 					.execute();
 			log.log(Level.CONFIG, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
 
 			processInfo = ProcessBuilder.create(context)
-					.process(295)
+					.process(org.compiere.process.RoleAccessUpdate.class)
 					.withTitle("Role Access Update")
+					.withParameter("AD_Client_ID", 0)
 					.executeUsingSystemRole();
 			log.log(Level.CONFIG, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
 
 			processInfo = ProcessBuilder.create(context)
-					.process(53733)
+					.process(org.compiere.process.CleanUpGW.class)
 					.withTitle("Updating Garden World")
 					.executeUsingSystemRole();
 			log.log(Level.CONFIG, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());

--- a/base/src/org/compiere/model/MProcess.java
+++ b/base/src/org/compiere/model/MProcess.java
@@ -57,7 +57,9 @@ public class MProcess extends X_AD_Process
 		if (className == null)
 			return null;
 
-		return new Query(Env.getCtx() , MProcess.Table_Name , MProcess.COLUMNNAME_Classname + "=?" , null).first();
+		return new Query(Env.getCtx() , MProcess.Table_Name , MProcess.COLUMNNAME_Classname + "=?" , null)
+						.setParameters(className)
+						.first();
 	}
 
 	/**

--- a/base/src/org/compiere/model/MProcess.java
+++ b/base/src/org/compiere/model/MProcess.java
@@ -53,7 +53,7 @@ public class MProcess extends X_AD_Process
      */
 	public static MProcess getUsingJavaClass(final Class<?> processClass)
 	{
-		String className = processClass.getClass().getCanonicalName();
+		String className = processClass.getCanonicalName();
 		if (className == null)
 			return null;
 


### PR DESCRIPTION
Update MigrationLoader to use class names and correct getProcessByClass.  Set mandatory parameter for Role Access Update.