### PR TITLE
Bug fix at ProcessParameterPanel 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ lib/
 out/
 posterita/posterita/dist/
 posterita/posterita/web/WEB-INF/classes/
+install/build/
 install/lib/
 install/CInstall.jar
 zkwebui/WEB-INF/classes/metainfo/zk/lang-addon.xml

--- a/client/src/org/compiere/apps/ProcessParameterPanel.java
+++ b/client/src/org/compiere/apps/ProcessParameterPanel.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.logging.Level;
 import javax.swing.Box;
 import javax.swing.JLabel;
+import javax.swing.JScrollPane;
+
 import org.adempiere.exceptions.DBException;
 import org.compiere.grid.ed.VEditor;
 import org.compiere.grid.ed.VEditorFactory;
@@ -125,7 +127,7 @@ public class ProcessParameterPanel extends CPanel implements VetoableChangeListe
 			setMode(MODE_VERTICAL);
 			this.setLayout(mainLayout);
 			centerPanel.setLayout(centerLayout);
-			this.add(centerPanel, BorderLayout.CENTER);
+			this.add(new JScrollPane(centerPanel), BorderLayout.CENTER);
 		}	//	jbInit
 
 		/**


### PR DESCRIPTION
When initial client setup form is open i miss some top fields
like client, org etc
This is solved with a JScrollBar at ProcessParameterPanel .centerPanel