### PR TITLE
Add changes to StringBox and WStringEditor to enable SAHI testing.

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/component/StringBox.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/component/StringBox.java
@@ -37,7 +37,7 @@ public class StringBox extends Div implements org.zkoss.zul.api.Textbox
 	 */
 	private static final long serialVersionUID = 7089099079981906933L;
 
-	private Textbox textbox = new Textbox();
+	private Textbox textbox = null;
 	
 	private Obscure	m_obscure = null;
 
@@ -288,4 +288,5 @@ public class StringBox extends Div implements org.zkoss.zul.api.Textbox
 		super.setHeight(height);
 		textbox.setHeight("95%");
 	}
+	
 }

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WStringEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WStringEditor.java
@@ -75,6 +75,7 @@ public class WStringEditor extends WEditor implements ContextMenuListener
     public WStringEditor(GridField gridField, boolean tableEditor)
     {
         super(gridField.isAutocomplete() ? new Combobox() : new StringBox(), gridField);
+        this.getComponent().setAttribute("zk_component_prefix", "Field_" + gridField.getColumnName() + "_" + gridField.getAD_Tab_ID() + "_" + gridField.getWindowNo() + "_");
         this.tableEditor = tableEditor;
         init(gridField.getObscureType());
     }


### PR DESCRIPTION
The WStringEditor class needs to set the attributes for the ZK component to support sahi testing.  The StringBox class defines a testbox and then resets it as a new textbox later in the code.  This initial call is unnecessary.