### PR TITLE
#426 Bugfix MPPOrderBOMLine release stock reservation

### DIFF
--- a/base/src/org/eevolution/model/MPPOrderBOMLine.java
+++ b/base/src/org/eevolution/model/MPPOrderBOMLine.java
@@ -194,12 +194,8 @@ public class MPPOrderBOMLine extends X_PP_Order_BOMLine
 	protected boolean beforeDelete()
 	{
 		// Release Reservation
-		if(MPPOrder.DOCSTATUS_InProgress.equals(getParent().getDocStatus()) || 
-		   MPPOrder.DOCSTATUS_Completed.equals(getParent().getDocStatus()))
-		{	
-			setQtyRequired(Env.ZERO);
-			reserveStock();
-		}			
+		setQtyRequired(Env.ZERO);
+		reserveStock();
 		return true;
 	}
 


### PR DESCRIPTION
This pull request fixes issue #426 and allows modified Manufacturing Order documents to correctly reserve/unreserve stock for their components.