### PR TITLE
#495 Correct handling of field/gridField updates in ProcessParameterPanel and VBrowserSearch

### DIFF
--- a/base/src/org/compiere/apps/ProcessParameter.java
+++ b/base/src/org/compiere/apps/ProcessParameter.java
@@ -359,7 +359,6 @@ public abstract class ProcessParameter {
 	 * @param propertyName
 	 */
 	public void fieldChange(GridField field, Object newValue, String propertyName) {
-		//	set new value
 		if(field != null) {
 			//	Process dependences
 			processDependencies (field);
@@ -417,21 +416,23 @@ public abstract class ProcessParameter {
 	 * @param name
 	 */
 	private void processNewValue(Object value, String name) {
-		if (value == null)
-			value = new String("");
 
-		if (value instanceof String)
-			Env.setContext(Env.getCtx(), m_WindowNo, name, (String) value);
-		else if (value instanceof Integer)
-			Env.setContext(Env.getCtx(), m_WindowNo, name, ((Integer) value)
-					.intValue());
-		else if (value instanceof Boolean)
-			Env.setContext(Env.getCtx(), m_WindowNo, name, ((Boolean) value)
-					.booleanValue());
-		else if (value instanceof Timestamp)
-			Env.setContext(Env.getCtx(), m_WindowNo, name, (Timestamp) value);
-		else
-			Env.setContext(Env.getCtx(), m_WindowNo, name, value.toString());
+		// Not required.  Context is set by the girdField.
+//		if (value == null)
+//			value = new String("");
+//
+//		if (value instanceof String)
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, (String) value);
+//		else if (value instanceof Integer)
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, ((Integer) value)
+//					.intValue());
+//		else if (value instanceof Boolean)
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, ((Boolean) value)
+//					.booleanValue());
+//		else if (value instanceof Timestamp)
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, (Timestamp) value);
+//		else
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, value.toString());
 
 		dynamicDisplay();
 	}

--- a/client/src/org/compiere/grid/ed/VLookup.java
+++ b/client/src/org/compiere/grid/ed/VLookup.java
@@ -915,6 +915,7 @@ public class VLookup extends JComponent
 		catch (PropertyVetoException pve)
 		{
 			log.log(Level.SEVERE, m_columnName, pve);
+			return;
 		}
 		//  is the value updated ?
 		boolean updated = false;

--- a/client/src/org/eevolution/grid/BrowserSearch.java
+++ b/client/src/org/eevolution/grid/BrowserSearch.java
@@ -394,21 +394,23 @@ public abstract class BrowserSearch {
 	 * @param name
 	 */
 	private void processNewValue(Object value, String name) {
-		if (value == null)
-			value = new String("");
 
-		if (value instanceof String)
-			Env.setContext(Env.getCtx(), m_WindowNo, name, (String) value);
-		else if (value instanceof Integer)
-			Env.setContext(Env.getCtx(), m_WindowNo, name, ((Integer) value)
-					.intValue());
-		else if (value instanceof Boolean)
-			Env.setContext(Env.getCtx(), m_WindowNo, name, ((Boolean) value)
-					.booleanValue());
-		else if (value instanceof Timestamp)
-			Env.setContext(Env.getCtx(), m_WindowNo, name, (Timestamp) value);
-		else
-			Env.setContext(Env.getCtx(), m_WindowNo, name, value.toString());
+		//  Not sure this is required or should be done here.  Env context is set 
+		//  by the gridField when its value is changed.
+//		if (value == null)
+//			value = new String("");
+//		if (value instanceof String)
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, (String) value);
+//		else if (value instanceof Integer)
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, ((Integer) value)
+//					.intValue());
+//		else if (value instanceof Boolean)
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, ((Boolean) value)
+//					.booleanValue());
+//		else if (value instanceof Timestamp)
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, (Timestamp) value);
+//		else
+//			Env.setContext(Env.getCtx(), m_WindowNo, name, value.toString());
 
 		dynamicDisplay();
 	}


### PR DESCRIPTION
If using fields and gridFields together, the change event process is
field editor -> vetoable change ->gridField.setValue() -> field.setValue() -> property change
Changed the vetoableChange listeners to set the gridField value and added a
propertyChange listener to respond to the field changes to provide dynamic display.
In VLookup, if a veto is received, abort the change.