### PR TITLE
#508 Buttons on VLookup fields in Find window don't work.

### DIFF
--- a/client/src/org/compiere/apps/APanel.java
+++ b/client/src/org/compiere/apps/APanel.java
@@ -149,6 +149,9 @@ import org.eevolution.form.VBrowser;
  *		@see https://github.com/adempiere/adempiere/issues/114
  *		<li>FR [ 248 ] Smart Browse not open on modal inside a window
  * 		@see https://github.com/adempiere/adempiere/issues/248
+ *  @author Michael McKay michael.mckay@mckayERP.com, http://www.mckayerp.com
+ *      <li><a href="https://github.com/adempiere/adempiere/issues/508">
+ *          BF [ #508 ] Initialize m_curTab before initial query</a>
  *  @sponsor www.metas.de
  */
 public final class APanel extends CPanel
@@ -708,6 +711,7 @@ public final class APanel extends CPanel
 			}
 			//  Window Init
 			window.addChangeListener(this);
+			m_curWinTab = window;
 
 			/**
 			 *  Init Model
@@ -741,6 +745,7 @@ public final class APanel extends CPanel
 				/**
 				 *  Window Tabs
 				 */
+				
 				int tabSize = mWindow.getTabCount();
 				boolean goSingleRow = query != null;	//	Zoom Query
 				for (int tab = 0; tab < tabSize; tab++)
@@ -753,7 +758,9 @@ public final class APanel extends CPanel
 					//  Query first tab
 					if (tab == 0)
 					{
-						//  initial user query for single workbench tab
+						m_curTab = gTab; // #508 m_curTab needs to be set or VLookup buttons in find window opened 
+										 // in the call initialQuery won't work and a NPE will be created in 
+										 // info.java.
 						if (m_mWorkbench.getWindowCount() == 1)
 						{
 							if (query != null && query.getZoomTableName() != null && query.getZoomColumnName() != null


### PR DESCRIPTION
#508.  Initialized m_curTab as tab 0 when the window is being initialized to prevent a NPE.

Also moved the initialization of m_curWinTab up a few lines to be closer to the window section where it fits with the logical flow.
