### PR TITLE
Hotfix/3.8.0#002 #773 add date range to auto fact reconciliation

### DIFF
--- a/migration/380lts-390lts/90460-AddAcctDateToAutoFactRecon.xml
+++ b/migration/380lts-390lts/90460-AddAcctDateToAutoFactRecon.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add account date as a parameter to auto acct fact reconcile" ReleaseNo="3.9.0" SeqNo="460">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="285" Action="I" Record_ID="55696" Table="AD_Process_Para">
+        <Data AD_Column_ID="2824" Column="Help">The Accounting Date indicates the date to be used on the General Ledger account entries generated from this document. It is also used for any currency conversion.</Data>
+        <Data AD_Column_ID="2817" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2830" Column="IsRange">true</Data>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID">55696</Data>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="3737" Column="FieldLength">7</Data>
+        <Data AD_Column_ID="2821" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID">53221</Data>
+        <Data AD_Column_ID="2820" Column="Updated">2017-02-18 12:44:08.62</Data>
+        <Data AD_Column_ID="2819" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID">15</Data>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2826" Column="SeqNo">40</Data>
+        <Data AD_Column_ID="3738" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="2818" Column="Created">2017-02-18 12:44:08.62</Data>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3739" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="7728" Column="EntityType">D</Data>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="2822" Column="Name">Account Date</Data>
+        <Data AD_Column_ID="4017" Column="ColumnName">DateAcct</Data>
+        <Data AD_Column_ID="2823" Column="Description">Accounting Date</Data>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID">263</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="286" Action="I" Record_ID="55696" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="2835" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID">55696</Data>
+        <Data AD_Column_ID="2842" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2832" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="2838" Column="Updated">2017-02-18 12:44:16.487</Data>
+        <Data AD_Column_ID="2836" Column="Created">2017-02-18 12:44:16.487</Data>
+        <Data AD_Column_ID="2837" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="3743" Column="Help">The Accounting Date indicates the date to be used on the General Ledger account entries generated from this document. It is also used for any currency conversion.</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="2840" Column="Name">Account Date</Data>
+        <Data AD_Column_ID="2841" Column="Description">Accounting Date</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/migration/380lts-release/01740-AddAcctDateToAutoFactRecon.xml
+++ b/migration/380lts-release/01740-AddAcctDateToAutoFactRecon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add account date as a parameter to auto acct fact reconcile" ReleaseNo="3.9.0" SeqNo="460">
+  <Migration EntityType="D" Name="Add account date as a parameter to auto acct fact reconcile" ReleaseNo="" SeqNo="1740">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="285" Action="I" Record_ID="55696" Table="AD_Process_Para">
         <Data AD_Column_ID="2824" Column="Help">The Accounting Date indicates the date to be used on the General Ledger account entries generated from this document. It is also used for any currency conversion.</Data>


### PR DESCRIPTION
A simple addition of a date range to the automatic acct fact reconciliation process to allow the user to limit the date range performed.  This helps limit the reconciliations to the periods under investigation and prevents matching with future accounting facts.  For example, the sum of unreconciled facts in Accounts Payable should match the AP aging report at the end of the last period.  However, if the auto matching process is run, it will reconcile facts in the current period as well, changing the unreconciled fact list in the last period.  This can be fixed by resetting the match manually.  The date range on the auto process just saves some time.
