### PR TITLE
#1481 JNLP file is not secure. Security warning appears.

### DIFF
--- a/client/build.xml
+++ b/client/build.xml
@@ -77,6 +77,8 @@
         <include name="**/*.htm"/>
         <include name="**/*.html"/>
         <include name="**/*.properties"/>
+      	<!-- Include APPLICATION_TEMPLATE.JNLP in adempiere.jar -->
+        <include name="**/*.JNLP"/>
         <exclude name="**/package.html"/>
       </fileset>
     </copy>

--- a/client/src/JNLP-INF/APPLICATION_TEMPLATE.JNLP
+++ b/client/src/JNLP-INF/APPLICATION_TEMPLATE.JNLP
@@ -1,0 +1,30 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<jnlp spec = "1.8+" version = "3.9.0LTS"
+    codebase = "*" 
+    href = "*">  
+    <information>
+        <title>Adempiere Client 3.9.0LTS</title>
+        <vendor>ADempiere, Inc.</vendor>
+        <homepage href = "http://www.adempiere.org"/>
+        <offline-allowed/>
+        <description>Adempiere ERP+CRM - Smart Business Solution for Distribution and Service - globally</description>
+        <description kind = "short">Adempiere ERP+CRM</description>
+        <description kind = "one-line">Adempiere ERP+CRM</description>
+        <description kind = "tooltip">Adempiere ERP+CRM</description>
+        <icon href = "*"/>
+        <shortcut online="true">
+            <desktop/>
+            <menu submenu="Adempiere 3.9.0LTS"/>
+        </shortcut>
+    </information>  
+    <security>
+        <all-permissions/>  
+    </security>
+    <resources>
+        <j2se version = "1.7+" href = "http://java.sun.com/products/autodl/j2se" initial-heap-size = "32m" max-heap-size = "512m"/>
+        <jar href = "Adempiere.jar" main = "true" download = "eager"/>
+        <jar href = "AdempiereCLib.jar" main = "false" download = "eager"/>
+        <jar href = "CompiereJasperReqs.jar" main = "false" download = "eager"/>
+    </resources>  
+    <application-desc main-class = "org.compiere.Adempiere"/>  
+</jnlp>

--- a/serverRoot/src/web/adempiere.jnlp
+++ b/serverRoot/src/web/adempiere.jnlp
@@ -3,18 +3,18 @@
 	codebase = "$$context/adempiereHome" 
 	href = "$$context/adempiere.jnlp">  
 	<information>
-		<title>Adempiere Client 3.9.0LTS $$context</title>
+		<title>Adempiere Client 3.9.0LTS</title>
 		<vendor>ADempiere, Inc.</vendor>
 		<homepage href = "http://www.adempiere.org"/>
 		<offline-allowed/>
-		<description>Adempiere ERP+CRM ($$context) - Smart Business Solution for Distribution and Service - globally</description>
-		<description kind = "short">Adempiere ERP+CRM ($$context)</description>
+		<description>Adempiere ERP+CRM - Smart Business Solution for Distribution and Service - globally</description>
+		<description kind = "short">Adempiere ERP+CRM</description>
 		<description kind = "one-line">Adempiere ERP+CRM</description>
-		<description kind = "tooltip">Adempiere ERP+CRM ($$context)</description>
+		<description kind = "tooltip">Adempiere ERP+CRM</description>
 		<icon href = "$$context/C32.gif"/>
 		<shortcut online="true">
 			<desktop/>
-			<menu submenu="Adempiere 3.9.0LTS $$context"/>
+			<menu submenu="Adempiere 3.9.0LTS"/>
 		</shortcut>
 	</information>  
 	<security>
@@ -25,7 +25,6 @@
 		<jar href = "Adempiere.jar" main = "true" download = "eager"/>
 		<jar href = "AdempiereCLib.jar" main = "false" download = "eager"/>
 		<jar href = "CompiereJasperReqs.jar" main = "false" download = "eager"/>
-		<property name="adempiereJNLP" value="$$context"/> 
 	</resources>  
 	<application-desc main-class = "org.compiere.Adempiere"/>  
 </jnlp>


### PR DESCRIPTION
Secures the JNLP file by including a matching APPLICATION_TEMPLATE.JNLP in Adempiere.jar.  See https://docs.oracle.com/javase/8/docs/technotes/guides/deploy/signed_jnlp.html.  Alone, this won't remove the security warning but it does prevent security errors visible in the console.