### PR TITLE
adempiere:#1370 Enhance the process AllocationAuto with allocation of…

### DIFF
--- a/base/src/org/compiere/model/MInvoice.java
+++ b/base/src/org/compiere/model/MInvoice.java
@@ -1877,7 +1877,8 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 		// Set the definite document number after completed (if needed)
 		setDefiniteDocumentNo();
 		// allocate prepaid Orders
-		if (isAllocateImmediate() && getC_Order_ID() > 0 && getC_Order().getC_POS_ID() == 0) {
+		if (isAllocateImmediate() && getC_Order_ID() > 0 && getC_Order().getC_POS_ID() == 0
+				&& getReversal_ID() ==0) {
 			allocatePrepayments();
 		}
 


### PR DESCRIPTION
… prepayments

https://github.com/adempiere/adempiere/issues/1370
The automatic allocation must be omitted if the document is a reversion document (reversal_ID is not null)