### PR TITLE
adempiere:#1625 Zooming of Operational Period not possible in Forecast

### DIFF
--- a/migration/390lts-391/03790_1625_Zooming_of_Operational_Period_not_possible_in_Forecast_window.xml
+++ b/migration/390lts-391/03790_1625_Zooming_of_Operational_Period_not_possible_in_Forecast_window.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Zooming of Operational Period not possible Forecast window" ReleaseNo="3.9.1" SeqNo="3790">
+    <Comments>https://github.com/adempiere/adempiere/issues/1625</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="100" Action="U" Record_ID="53389" Table="AD_Table">
+        <Data AD_Column_ID="105" Column="AD_Window_ID" isOldNull="true">53181</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Solving the small bug "Zooming of Operational Period not possible in Forecast window" 
https://github.com/adempiere/adempiere/issues/1625