### PR TITLE
Feature/allocate inmediate enhance

### DIFF
--- a/adempiere.iml
+++ b/adempiere.iml
@@ -207,6 +207,7 @@
       <sourceFolder url="file://$MODULE_DIR$/org.adempiere.pos/src/main/java/ui/swing" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/org.adempiere.pos/src/main/java/ui/zk" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/org.adempiere.request/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/org.adempiere.project/src/main/java" isTestSource="false" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="inheritedJdk" />

--- a/base/src/org/compiere/model/I_C_DocType.java
+++ b/base/src/org/compiere/model/I_C_DocType.java
@@ -326,6 +326,15 @@ public interface I_C_DocType
 	  */
 	public boolean isActive();
 
+    /** Column name IsAllocateImmediate */
+    public static final String COLUMNNAME_IsAllocateImmediate = "IsAllocateImmediate";
+
+	/** Set IsAllocateImmediate	  */
+	public void setIsAllocateImmediate (boolean IsAllocateImmediate);
+
+	/** Get IsAllocateImmediate	  */
+	public boolean isAllocateImmediate();
+
     /** Column name IsCopyDocNoOnReversal */
     public static final String COLUMNNAME_IsCopyDocNoOnReversal = "IsCopyDocNoOnReversal";
 

--- a/base/src/org/compiere/model/I_C_Invoice.java
+++ b/base/src/org/compiere/model/I_C_Invoice.java
@@ -559,14 +559,6 @@ public interface I_C_Invoice
 	  */
 	public boolean isActive();
 
-    /** Column name IsAllocateImmediate */
-    public static final String COLUMNNAME_IsAllocateImmediate = "IsAllocateImmediate";
-
-	/** Set IsAllocateImmediate	  */
-	public void setIsAllocateImmediate (boolean IsAllocateImmediate);
-
-	/** Get IsAllocateImmediate	  */
-	public boolean isAllocateImmediate();
 
     /** Column name IsApproved */
     public static final String COLUMNNAME_IsApproved = "IsApproved";

--- a/base/src/org/compiere/model/MInvoice.java
+++ b/base/src/org/compiere/model/MInvoice.java
@@ -1877,7 +1877,7 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 		// Set the definite document number after completed (if needed)
 		setDefiniteDocumentNo();
 		// allocate prepaid Orders
-		if (isAllocateImmediate() && getC_Order_ID() > 0 && getC_Order().getC_POS_ID() == 0
+		if (getC_DocType().isAllocateImmediate() && getC_Order_ID() > 0 && getC_Order().getC_POS_ID() == 0
 				&& getReversal_ID() ==0) {
 			allocatePrepayments();
 		}

--- a/base/src/org/compiere/model/X_C_DocType.java
+++ b/base/src/org/compiere/model/X_C_DocType.java
@@ -594,6 +594,27 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 		return false;
 	}
 
+	/** Set IsAllocateImmediate.
+		@param IsAllocateImmediate IsAllocateImmediate	  */
+	public void setIsAllocateImmediate (boolean IsAllocateImmediate)
+	{
+		set_Value (COLUMNNAME_IsAllocateImmediate, Boolean.valueOf(IsAllocateImmediate));
+	}
+
+	/** Get IsAllocateImmediate.
+		@return IsAllocateImmediate	  */
+	public boolean isAllocateImmediate ()
+	{
+		Object oo = get_Value(COLUMNNAME_IsAllocateImmediate);
+		if (oo != null)
+		{
+			 if (oo instanceof Boolean)
+				 return ((Boolean)oo).booleanValue();
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
 	/** Set Copy Document No On Reversal.
 		@param IsCopyDocNoOnReversal 
 		It Copy the Document No on Reversal Document instead of generate a new Sequence

--- a/base/src/org/compiere/model/X_C_Invoice.java
+++ b/base/src/org/compiere/model/X_C_Invoice.java
@@ -60,7 +60,6 @@ public class X_C_Invoice extends PO implements I_C_Invoice, I_Persistent
 // DR
 			setDocumentNo (null);
 			setGrandTotal (Env.ZERO);
-			setIsAllocateImmediate (false);
 // N
 			setIsApproved (false);
 // @IsApproved@
@@ -968,26 +967,7 @@ public class X_C_Invoice extends PO implements I_C_Invoice, I_Persistent
 		return (String)get_Value(COLUMNNAME_InvoiceCollectionType);
 	}
 
-	/** Set IsAllocateImmediate.
-		@param IsAllocateImmediate IsAllocateImmediate	  */
-	public void setIsAllocateImmediate (boolean IsAllocateImmediate)
-	{
-		set_Value (COLUMNNAME_IsAllocateImmediate, Boolean.valueOf(IsAllocateImmediate));
-	}
 
-	/** Get IsAllocateImmediate.
-		@return IsAllocateImmediate	  */
-	public boolean isAllocateImmediate () 
-	{
-		Object oo = get_Value(COLUMNNAME_IsAllocateImmediate);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
-	}
 
 	/** Set Approved.
 		@param IsApproved 

--- a/migration/390lts-391/03690_1370_InvoiceAllocateInmediate.xml
+++ b/migration/390lts-391/03690_1370_InvoiceAllocateInmediate.xml
@@ -16,17 +16,17 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="2601" Column="UpdatedBy">0</Data>
         <Data AD_Column_ID="84316" Column="UUID" isNewNull="true"/>
         <Data AD_Column_ID="6484" Column="EntityType">D</Data>
-        <Data AD_Column_ID="2603" Column="Name">IsAllocateImmediate</Data>
         <Data AD_Column_ID="2604" Column="Description" isNewNull="true"/>
         <Data AD_Column_ID="2598" Column="Created">2018-01-28 16:34:03.846</Data>
         <Data AD_Column_ID="2600" Column="Updated">2018-01-28 16:34:03.846</Data>
         <Data AD_Column_ID="2597" Column="IsActive">true</Data>
         <Data AD_Column_ID="6284" Column="PO_Help" isNewNull="true"/>
         <Data AD_Column_ID="6285" Column="PO_Name" isNewNull="true"/>
-        <Data AD_Column_ID="2605" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="2602" Column="ColumnName">IsAllocateImmediate</Data>
-        <Data AD_Column_ID="4299" Column="PrintName">IsAllocateImmediate</Data>
         <Data AD_Column_ID="6286" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="2603" Column="Name">Allocate Prepayments</Data>
+        <Data AD_Column_ID="2605" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="4299" Column="PrintName">Allocate Prepayments on corresponding Orders</Data>
       </PO>
     </Step>
     <Step SeqNo="20" StepType="AD">
@@ -38,7 +38,6 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="2644" Column="Updated">2018-01-28 16:34:05.563</Data>
         <Data AD_Column_ID="6449" Column="PO_Help" isNewNull="true"/>
         <Data AD_Column_ID="6450" Column="PO_Name" isNewNull="true"/>
-        <Data AD_Column_ID="2648" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="2647" Column="Description" isNewNull="true"/>
         <Data AD_Column_ID="2649" Column="IsTranslated">false</Data>
         <Data AD_Column_ID="6451" Column="PO_PrintName" isNewNull="true"/>
@@ -48,8 +47,9 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="2645" Column="UpdatedBy">0</Data>
         <Data AD_Column_ID="2643" Column="CreatedBy">0</Data>
         <Data AD_Column_ID="2638" Column="AD_Language">es_MX</Data>
-        <Data AD_Column_ID="4300" Column="PrintName">Asignar automaticamente</Data>
-        <Data AD_Column_ID="2646" Column="Name">Asignar automaticamente</Data>
+        <Data AD_Column_ID="4300" Column="PrintName">Asignar Prepagos</Data>
+        <Data AD_Column_ID="2646" Column="Name">Asignar Prepagos</Data>
+        <Data AD_Column_ID="2648" Column="Help">Asignar  Prepagos de Ordenes correspondientes</Data>
       </PO>
     </Step>
     <Step SeqNo="30" StepType="AD">
@@ -98,10 +98,10 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="84306" Column="UUID" isNewNull="true"/>
         <Data AD_Column_ID="6482" Column="EntityType">D</Data>
         <Data AD_Column_ID="114" Column="AD_Table_ID">217</Data>
-        <Data AD_Column_ID="111" Column="Name">IsAllocateImmediate</Data>
         <Data AD_Column_ID="116" Column="ColumnName">IsAllocateImmediate</Data>
         <Data AD_Column_ID="109" Column="AD_Column_ID">86860</Data>
-        <Data AD_Column_ID="124" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="111" Column="Name">Allocate Prepayments</Data>
       </PO>
     </Step>
     <Step SeqNo="40" StepType="AD">
@@ -110,7 +110,6 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="12959" Column="IsActive">true</Data>
         <Data AD_Column_ID="12952" Column="Updated">2018-01-28 16:35:07.533</Data>
         <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="12957" Column="Name">IsAllocateImmediate</Data>
         <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="12958" Column="UpdatedBy">0</Data>
@@ -118,6 +117,7 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="12953" Column="AD_Language">es_MX</Data>
         <Data AD_Column_ID="12955" Column="AD_Column_ID">86860</Data>
         <Data AD_Column_ID="84310" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="12957" Column="Name">Asignar Prepagos</Data>
       </PO>
     </Step>
     <Step SeqNo="50" StepType="AD">
@@ -132,7 +132,6 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
         <Data AD_Column_ID="182" Column="SortNo">0</Data>
         <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
-        <Data AD_Column_ID="168" Column="Name">IsAllocateImmediate</Data>
         <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
         <Data AD_Column_ID="170" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
@@ -162,6 +161,7 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="172" Column="AD_Tab_ID">167</Data>
         <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
         <Data AD_Column_ID="84320" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="168" Column="Name">Allocate Prepayments</Data>
       </PO>
     </Step>
     <Step SeqNo="60" StepType="AD">
@@ -171,7 +171,6 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="672" Column="Created">2018-06-11 03:43:01.387</Data>
         <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
         <Data AD_Column_ID="287" Column="Description" isNewNull="true"/>
-        <Data AD_Column_ID="286" Column="Name">IsAllocateImmediate</Data>
         <Data AD_Column_ID="288" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
@@ -180,6 +179,7 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
         <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
         <Data AD_Column_ID="84323" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="286" Column="Name">Asignar Prepagos</Data>
       </PO>
     </Step>
     <Step SeqNo="70" StepType="AD">
@@ -416,6 +416,10 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
       <PO AD_Table_ID="107" Action="U" Record_ID="3075" Table="AD_Field">
         <Data AD_Column_ID="181" Column="SeqNo" oldValue="330">350</Data>
       </PO>
+    </Step>
+    <Step DBType="ALL" Parse="Y" SeqNo="590" StepType="SQL">
+      <SQLStatement>DELETE FROM AD_Field WHERE AD_Field_ID = 85508 AND AD_Tab_ID = 263;</SQLStatement>
+      <RollbackStatement>UPDATE AD_Field set isactive = 'N' WHERE AD_Field_ID = 85508 AND AD_Tab_ID = 263;</RollbackStatement>
     </Step>
   </Migration>
 </Migrations>

--- a/migration/390lts-391/03690_1370_InvoiceAllocateInmediate.xml
+++ b/migration/390lts-391/03690_1370_InvoiceAllocateInmediate.xml
@@ -5,6 +5,17 @@
 https://github.com/adempiere/adempiere/issues/1370</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="276" Action="I" Record_ID="59818" Table="AD_Element">
+        <Data AD_Column_ID="6283" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="58589" Column="FieldLength">0</Data>
+        <Data AD_Column_ID="58588" Column="AD_Reference_ID">20</Data>
+        <Data AD_Column_ID="2594" Column="AD_Element_ID">59818</Data>
+        <Data AD_Column_ID="2596" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2595" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2599" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="58590" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2601" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84316" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="6484" Column="EntityType">D</Data>
         <Data AD_Column_ID="2603" Column="Name">IsAllocateImmediate</Data>
         <Data AD_Column_ID="2604" Column="Description" isNewNull="true"/>
         <Data AD_Column_ID="2598" Column="Created">2018-01-28 16:34:03.846</Data>
@@ -16,17 +27,6 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="2602" Column="ColumnName">IsAllocateImmediate</Data>
         <Data AD_Column_ID="4299" Column="PrintName">IsAllocateImmediate</Data>
         <Data AD_Column_ID="6286" Column="PO_PrintName" isNewNull="true"/>
-        <Data AD_Column_ID="6283" Column="PO_Description" isNewNull="true"/>
-        <Data AD_Column_ID="58589" Column="FieldLength">0</Data>
-        <Data AD_Column_ID="58588" Column="AD_Reference_ID">20</Data>
-        <Data AD_Column_ID="2594" Column="AD_Element_ID">59818</Data>
-        <Data AD_Column_ID="2596" Column="AD_Org_ID">0</Data>
-        <Data AD_Column_ID="2595" Column="AD_Client_ID">0</Data>
-        <Data AD_Column_ID="6484" Column="EntityType">C</Data>
-        <Data AD_Column_ID="2599" Column="CreatedBy">0</Data>
-        <Data AD_Column_ID="58590" Column="AD_Reference_Value_ID" isNewNull="true"/>
-        <Data AD_Column_ID="2601" Column="UpdatedBy">0</Data>
-        <Data AD_Column_ID="84316" Column="UUID" isNewNull="true"/>
       </PO>
     </Step>
     <Step SeqNo="20" StepType="AD">
@@ -37,12 +37,10 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="2642" Column="Created">2018-01-28 16:34:05.563</Data>
         <Data AD_Column_ID="2644" Column="Updated">2018-01-28 16:34:05.563</Data>
         <Data AD_Column_ID="6449" Column="PO_Help" isNewNull="true"/>
-        <Data AD_Column_ID="2646" Column="Name">IsAllocateImmediate</Data>
         <Data AD_Column_ID="6450" Column="PO_Name" isNewNull="true"/>
         <Data AD_Column_ID="2648" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="2647" Column="Description" isNewNull="true"/>
         <Data AD_Column_ID="2649" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="4300" Column="PrintName">IsAllocateImmediate</Data>
         <Data AD_Column_ID="6451" Column="PO_PrintName" isNewNull="true"/>
         <Data AD_Column_ID="6448" Column="PO_Description" isNewNull="true"/>
         <Data AD_Column_ID="2640" Column="AD_Org_ID">0</Data>
@@ -50,37 +48,26 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="2645" Column="UpdatedBy">0</Data>
         <Data AD_Column_ID="2643" Column="CreatedBy">0</Data>
         <Data AD_Column_ID="2638" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="4300" Column="PrintName">Asignar automaticamente</Data>
+        <Data AD_Column_ID="2646" Column="Name">Asignar automaticamente</Data>
       </PO>
     </Step>
     <Step SeqNo="30" StepType="AD">
-      <PO AD_Table_ID="276" Action="U" Record_ID="59818" Table="AD_Element">
-        <Data AD_Column_ID="6484" Column="EntityType" oldValue="U">C</Data>
-      </PO>
-    </Step>
-    <Step SeqNo="40" StepType="AD">
-      <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
-        <Data AD_Column_ID="2646" Column="Name" oldValue="IsAllocateImmediate">Asignar automaticamente</Data>
-        <Data AD_Column_ID="4300" Column="PrintName" oldValue="IsAllocateImmediate">Asignar automaticamente</Data>
-        <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>
-        <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="59818">59818</Data>
-      </PO>
-    </Step>
-    <Step SeqNo="50" StepType="AD">
       <PO AD_Table_ID="101" Action="I" Record_ID="86860" Table="AD_Column">
+        <Data AD_Column_ID="111" Column="Name">IsAllocateImmediate</Data>
+        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="120" Column="IsParent">false</Data>
+        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
         <Data AD_Column_ID="112" Column="Description" isNewNull="true"/>
         <Data AD_Column_ID="549" Column="Created">2018-01-28 16:35:05.441</Data>
         <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
         <Data AD_Column_ID="548" Column="IsActive">true</Data>
         <Data AD_Column_ID="551" Column="Updated">2018-01-28 16:35:05.441</Data>
         <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
-        <Data AD_Column_ID="111" Column="Name">IsAllocateImmediate</Data>
-        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
-        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
-        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
-        <Data AD_Column_ID="120" Column="IsParent">false</Data>
-        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
-        <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
         <Data AD_Column_ID="6483" Column="IsSyncDatabase">N</Data>
         <Data AD_Column_ID="119" Column="IsKey">false</Data>
         <Data AD_Column_ID="6245" Column="ReadOnlyLogic" isNewNull="true"/>
@@ -101,11 +88,9 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="62199" Column="IsAllowCopy">true</Data>
         <Data AD_Column_ID="127" Column="SeqNo">0</Data>
         <Data AD_Column_ID="109" Column="AD_Column_ID">86860</Data>
-        <Data AD_Column_ID="6482" Column="EntityType">C</Data>
         <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
-        <Data AD_Column_ID="114" Column="AD_Table_ID">318</Data>
         <Data AD_Column_ID="550" Column="CreatedBy">0</Data>
         <Data AD_Column_ID="2608" Column="AD_Element_ID">59818</Data>
         <Data AD_Column_ID="3369" Column="AD_Process_ID" isNewNull="true"/>
@@ -115,9 +100,11 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="226" Column="AD_Reference_ID">20</Data>
         <Data AD_Column_ID="552" Column="UpdatedBy">0</Data>
         <Data AD_Column_ID="84306" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="6482" Column="EntityType">D</Data>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">217</Data>
       </PO>
     </Step>
-    <Step SeqNo="60" StepType="AD">
+    <Step SeqNo="40" StepType="AD">
       <PO AD_Table_ID="752" Action="I" Record_ID="0" Table="AD_Column_Trl">
         <Data AD_Column_ID="12960" Column="Created">2018-01-28 16:35:07.533</Data>
         <Data AD_Column_ID="12959" Column="IsActive">true</Data>
@@ -133,219 +120,301 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="84310" Column="UUID" isNewNull="true"/>
       </PO>
     </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="87846" Table="AD_Field">
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="579" Column="Created">2018-06-11 03:42:59.414</Data>
+        <Data AD_Column_ID="581" Column="Updated">2018-06-11 03:42:59.414</Data>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo">0</Data>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="168" Column="Name">IsAllocateImmediate</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="170" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth">0</Data>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">87846</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">340</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">86860</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">340</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">0</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">167</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="87846" Table="AD_Field_Trl">
+        <Data AD_Column_ID="674" Column="Updated">2018-06-11 03:43:01.387</Data>
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2018-06-11 03:43:01.387</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="286" Column="Name">IsAllocateImmediate</Data>
+        <Data AD_Column_ID="288" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">87846</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
     <Step SeqNo="70" StepType="AD">
-      <PO AD_Table_ID="101" Action="U" Record_ID="86860" Table="AD_Column">
-        <Data AD_Column_ID="124" Column="IsMandatory" oldValue="false">true</Data>
-        <Data AD_Column_ID="117" Column="DefaultValue" isOldNull="true">N</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="87846" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="340">130</Data>
       </PO>
     </Step>
     <Step SeqNo="80" StepType="AD">
-      <PO AD_Table_ID="107" Action="I" Record_ID="85507" Table="AD_Field">
-        <Data AD_Column_ID="578" Column="IsActive">true</Data>
-        <Data AD_Column_ID="579" Column="Created">2018-01-28 16:36:04.208</Data>
-        <Data AD_Column_ID="581" Column="Updated">2018-01-28 16:36:04.208</Data>
-        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
-        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
-        <Data AD_Column_ID="169" Column="Description" isNewNull="true"/>
-        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
-        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
-        <Data AD_Column_ID="182" Column="SortNo">0</Data>
-        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
-        <Data AD_Column_ID="168" Column="Name">IsAllocateImmediate</Data>
-        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
-        <Data AD_Column_ID="170" Column="Help" isNewNull="true"/>
-        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
-        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
-        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
-        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
-        <Data AD_Column_ID="59704" Column="PreferredWidth">0</Data>
-        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
-        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
-        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
-        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
-        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
-        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
-        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
-        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
-        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
-        <Data AD_Column_ID="167" Column="AD_Field_ID">85507</Data>
-        <Data AD_Column_ID="7714" Column="EntityType">C</Data>
-        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
-        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
-        <Data AD_Column_ID="181" Column="SeqNo">450</Data>
-        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
-        <Data AD_Column_ID="174" Column="AD_Column_ID">86860</Data>
-        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
-        <Data AD_Column_ID="62479" Column="SeqNoGrid">450</Data>
-        <Data AD_Column_ID="180" Column="DisplayLength">0</Data>
-        <Data AD_Column_ID="172" Column="AD_Tab_ID">290</Data>
-        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
-        <Data AD_Column_ID="84320" Column="UUID" isNewNull="true"/>
+      <PO AD_Table_ID="107" Action="U" Record_ID="87846" Table="AD_Field">
+        <Data AD_Column_ID="177" Column="DisplayLogic" isOldNull="true">@DocBaseType@='API' | @DocBaseType@='ARI'</Data>
       </PO>
     </Step>
     <Step SeqNo="90" StepType="AD">
-      <PO AD_Table_ID="127" Action="I" Record_ID="85507" Table="AD_Field_Trl">
-        <Data AD_Column_ID="674" Column="Updated">2018-01-28 16:36:06.219</Data>
-        <Data AD_Column_ID="671" Column="IsActive">true</Data>
-        <Data AD_Column_ID="672" Column="Created">2018-01-28 16:36:06.219</Data>
-        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="287" Column="Description" isNewNull="true"/>
-        <Data AD_Column_ID="286" Column="Name">IsAllocateImmediate</Data>
-        <Data AD_Column_ID="288" Column="Help" isNewNull="true"/>
-        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
-        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
-        <Data AD_Column_ID="284" Column="AD_Field_ID">85507</Data>
-        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
-        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
-        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
-        <Data AD_Column_ID="84323" Column="UUID" isNewNull="true"/>
+      <PO AD_Table_ID="107" Action="U" Record_ID="87846" Table="AD_Field">
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isOldNull="true">123</Data>
       </PO>
     </Step>
     <Step SeqNo="100" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="85507" Table="AD_Field">
-        <Data AD_Column_ID="181" Column="SeqNo" oldValue="450">430</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="3072" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="130">140</Data>
       </PO>
     </Step>
     <Step SeqNo="110" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="3670" Table="AD_Field">
-        <Data AD_Column_ID="181" Column="SeqNo" oldValue="430">440</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="3071" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="140">150</Data>
       </PO>
     </Step>
     <Step SeqNo="120" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="3900" Table="AD_Field">
-        <Data AD_Column_ID="181" Column="SeqNo" oldValue="440">450</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="3073" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="150">160</Data>
       </PO>
     </Step>
     <Step SeqNo="130" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="85507" Table="AD_Field">
-        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isOldNull="true">101</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="807" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="160">170</Data>
       </PO>
     </Step>
     <Step SeqNo="140" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="200048" Table="AD_Field">
-        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isOldNull="true">101</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="808" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="170">180</Data>
       </PO>
     </Step>
     <Step SeqNo="150" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="6532" Table="AD_Field">
-        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="false">true</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="54233" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="180">190</Data>
       </PO>
     </Step>
     <Step SeqNo="160" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="3670" Table="AD_Field">
-        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="false">true</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="54230" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="190">200</Data>
       </PO>
     </Step>
     <Step SeqNo="170" StepType="AD">
-      <PO AD_Table_ID="107" Action="I" Record_ID="85508" Table="AD_Field">
-        <Data AD_Column_ID="578" Column="IsActive">true</Data>
-        <Data AD_Column_ID="579" Column="Created">2018-01-28 16:38:39.865</Data>
-        <Data AD_Column_ID="581" Column="Updated">2018-01-28 16:38:39.865</Data>
-        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
-        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
-        <Data AD_Column_ID="169" Column="Description" isNewNull="true"/>
-        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
-        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
-        <Data AD_Column_ID="182" Column="SortNo">0</Data>
-        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
-        <Data AD_Column_ID="168" Column="Name">IsAllocateImmediate</Data>
-        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
-        <Data AD_Column_ID="170" Column="Help" isNewNull="true"/>
-        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
-        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
-        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
-        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
-        <Data AD_Column_ID="59704" Column="PreferredWidth">0</Data>
-        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
-        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
-        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
-        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
-        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
-        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
-        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
-        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
-        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
-        <Data AD_Column_ID="167" Column="AD_Field_ID">85508</Data>
-        <Data AD_Column_ID="7714" Column="EntityType">C</Data>
-        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
-        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
-        <Data AD_Column_ID="181" Column="SeqNo">450</Data>
-        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
-        <Data AD_Column_ID="174" Column="AD_Column_ID">86860</Data>
-        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
-        <Data AD_Column_ID="62479" Column="SeqNoGrid">450</Data>
-        <Data AD_Column_ID="180" Column="DisplayLength">0</Data>
-        <Data AD_Column_ID="172" Column="AD_Tab_ID">263</Data>
-        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
-        <Data AD_Column_ID="84320" Column="UUID" isNewNull="true"/>
+      <PO AD_Table_ID="107" Action="U" Record_ID="82920" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="200">210</Data>
       </PO>
     </Step>
     <Step SeqNo="180" StepType="AD">
-      <PO AD_Table_ID="127" Action="I" Record_ID="85508" Table="AD_Field_Trl">
-        <Data AD_Column_ID="674" Column="Updated">2018-01-28 16:38:41.742</Data>
-        <Data AD_Column_ID="671" Column="IsActive">true</Data>
-        <Data AD_Column_ID="672" Column="Created">2018-01-28 16:38:41.742</Data>
-        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="287" Column="Description" isNewNull="true"/>
-        <Data AD_Column_ID="286" Column="Name">IsAllocateImmediate</Data>
-        <Data AD_Column_ID="288" Column="Help" isNewNull="true"/>
-        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
-        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
-        <Data AD_Column_ID="284" Column="AD_Field_ID">85508</Data>
-        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
-        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
-        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
-        <Data AD_Column_ID="84323" Column="UUID" isNewNull="true"/>
+      <PO AD_Table_ID="107" Action="U" Record_ID="6567" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="210">220</Data>
       </PO>
     </Step>
     <Step SeqNo="190" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="85508" Table="AD_Field">
-        <Data AD_Column_ID="181" Column="SeqNo" oldValue="450">400</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="3125" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="220">230</Data>
       </PO>
     </Step>
     <Step SeqNo="200" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="3663" Table="AD_Field">
-        <Data AD_Column_ID="181" Column="SeqNo" oldValue="400">410</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="63065" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="230">240</Data>
       </PO>
     </Step>
     <Step SeqNo="210" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="3899" Table="AD_Field">
-        <Data AD_Column_ID="181" Column="SeqNo" oldValue="410">420</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="54232" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="240">250</Data>
       </PO>
     </Step>
     <Step SeqNo="220" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="13700" Table="AD_Field">
-        <Data AD_Column_ID="181" Column="SeqNo" oldValue="420">430</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="83990" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="245">260</Data>
       </PO>
     </Step>
     <Step SeqNo="230" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="53257" Table="AD_Field">
-        <Data AD_Column_ID="181" Column="SeqNo" oldValue="430">440</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="10345" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="250">270</Data>
       </PO>
     </Step>
     <Step SeqNo="240" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="53258" Table="AD_Field">
-        <Data AD_Column_ID="181" Column="SeqNo" oldValue="440">450</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="10346" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="260">280</Data>
       </PO>
     </Step>
     <Step SeqNo="250" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="85508" Table="AD_Field">
-        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isOldNull="true">101</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="10481" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="270">290</Data>
       </PO>
     </Step>
     <Step SeqNo="260" StepType="AD">
-      <PO AD_Table_ID="107" Action="U" Record_ID="3663" Table="AD_Field">
-        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="false">true</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="10480" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="280">300</Data>
       </PO>
     </Step>
     <Step SeqNo="270" StepType="AD">
-      <PO AD_Table_ID="101" Action="U" Record_ID="86715" Table="AD_Column">
-        <Data AD_Column_ID="548" Column="IsActive" oldValue="true">false</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="58859" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="290">310</Data>
       </PO>
     </Step>
     <Step SeqNo="280" StepType="AD">
-      <PO AD_Table_ID="101" Action="U" Record_ID="86588" Table="AD_Column">
-        <Data AD_Column_ID="548" Column="IsActive" oldValue="true">false</Data>
+      <PO AD_Table_ID="107" Action="U" Record_ID="10371" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="300">320</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="290" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10528" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="310">330</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="300" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10340" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="320">340</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="310" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3075" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="330">350</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="370" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3072" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="130">140</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="380" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3071" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="140">150</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="390" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3073" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="150">160</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="400" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="807" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="160">170</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="410" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="808" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="170">180</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="420" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="54233" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="180">190</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="430" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="54230" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="190">200</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="440" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="82920" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="200">210</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="450" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6567" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="210">220</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="460" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3125" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="220">230</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="470" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="63065" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="230">240</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="480" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="54232" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="240">250</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="490" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="83990" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="245">260</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="500" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10345" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="250">270</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="510" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10346" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="260">280</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="520" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10481" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="270">290</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="530" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10480" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="280">300</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="540" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="58859" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="290">310</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="550" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10371" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="300">320</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="560" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10528" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="310">330</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="570" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10340" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="320">340</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="580" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3075" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="330">350</Data>
       </PO>
     </Step>
   </Migration>

--- a/migration/390lts-391/03690_1370_InvoiceAllocateInmediate.xml
+++ b/migration/390lts-391/03690_1370_InvoiceAllocateInmediate.xml
@@ -54,14 +54,11 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
     </Step>
     <Step SeqNo="30" StepType="AD">
       <PO AD_Table_ID="101" Action="I" Record_ID="86860" Table="AD_Column">
-        <Data AD_Column_ID="111" Column="Name">IsAllocateImmediate</Data>
         <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
         <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
         <Data AD_Column_ID="120" Column="IsParent">false</Data>
         <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
         <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
-        <Data AD_Column_ID="124" Column="IsMandatory">true</Data>
-        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
         <Data AD_Column_ID="112" Column="Description" isNewNull="true"/>
         <Data AD_Column_ID="549" Column="Created">2018-01-28 16:35:05.441</Data>
         <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
@@ -75,7 +72,6 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
         <Data AD_Column_ID="110" Column="Version">0</Data>
         <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
-        <Data AD_Column_ID="116" Column="ColumnName">IsAllocateImmediate</Data>
         <Data AD_Column_ID="113" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="3360" Column="IsUpdateable">true</Data>
         <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
@@ -86,8 +82,8 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="56149" Column="IsAutocomplete">false</Data>
         <Data AD_Column_ID="68024" Column="IsRange">false</Data>
         <Data AD_Column_ID="62199" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue">N</Data>
         <Data AD_Column_ID="127" Column="SeqNo">0</Data>
-        <Data AD_Column_ID="109" Column="AD_Column_ID">86860</Data>
         <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
@@ -102,6 +98,10 @@ https://github.com/adempiere/adempiere/issues/1370</Comments>
         <Data AD_Column_ID="84306" Column="UUID" isNewNull="true"/>
         <Data AD_Column_ID="6482" Column="EntityType">D</Data>
         <Data AD_Column_ID="114" Column="AD_Table_ID">217</Data>
+        <Data AD_Column_ID="111" Column="Name">IsAllocateImmediate</Data>
+        <Data AD_Column_ID="116" Column="ColumnName">IsAllocateImmediate</Data>
+        <Data AD_Column_ID="109" Column="AD_Column_ID">86860</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">true</Data>
       </PO>
     </Step>
     <Step SeqNo="40" StepType="AD">


### PR DESCRIPTION
This pullrequest moves the flag IsAllocateinmediate from table c_Invoice to table c_Doctype
As attach 3 videos covering the cases:

- amount of purchase order = amount of payment = amount of invoice
- amount of payment < amount of purchase order, amount of invoice = amount of order
- amount of payment < amount of purchase order, amount of invoice < amount of order

[AllocateInmediate.zip](https://github.com/adempiere/adempiere/files/2093313/AllocateInmediate.zip)


