### PR TITLE
#1773 Bugfix org.zkoss.zk.ui.WrongValueException: Too many characters…

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WStringEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WStringEditor.java
@@ -127,7 +127,8 @@ public class WStringEditor extends WEditor implements ContextMenuListener
     {
 		if (gridField != null)
 		{
-	        getComponent().setMaxlength(gridField.getFieldLength());
+	        //remove can cause throws an exception org.zkoss.zk.ui.WrongValueException.
+			//getComponent().setMaxlength(gridField.getFieldLength());
 	        int displayLength = gridField.getDisplayLength();
 	        if (displayLength <= 0 || displayLength > MAX_DISPLAY_LENGTH)
 	        {


### PR DESCRIPTION
… are entered. At most 10 characters are allowed when a window is open https://github.com/adempiere/adempiere/issues/1773

(cherry picked from commit e45df24c6c9f6ac8bc6bce39b5ca189be820dcd3)