### PR TITLE
patch in ProcessUtil.startScriptProcess when error msg startsWith "@Error@"

### DIFF
--- a/base/src/org/adempiere/util/ProcessUtil.java
+++ b/base/src/org/adempiere/util/ProcessUtil.java
@@ -254,7 +254,7 @@ public final class ProcessUtil {
 		
 			msg = engine.eval(rule.getScript()).toString();
 			//transaction should rollback if there are error in process
-			if ("@Error@".equals(msg))
+			if (msg!=null && msg.startsWith("@Error@"))
 				success = false;
 			
 			//	Parse Variables


### PR DESCRIPTION
this conforms to ad-processes written in java. Error messages have to start with "@Error@".