### PR TITLE
#1552, Change Dictionary definition for posting employee, reference to

### DIFF
--- a/base/src/org/eevolution/model/I_HR_Payroll.java
+++ b/base/src/org/eevolution/model/I_HR_Payroll.java
@@ -168,6 +168,19 @@ public interface I_HR_Payroll
 	  */
 	public boolean isIgnoreDefaultPayroll();
 
+    /** Column name IsPostPerEmployee */
+    public static final String COLUMNNAME_IsPostPerEmployee = "IsPostPerEmployee";
+
+	/** Set IsPostPerEmployee.
+	  * A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N
+	  */
+	public void setIsPostPerEmployee (boolean IsPostPerEmployee);
+
+	/** Get IsPostPerEmployee.
+	  * A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N
+	  */
+	public boolean isPostPerEmployee();
+
     /** Column name Name */
     public static final String COLUMNNAME_Name = "Name";
 
@@ -216,19 +229,6 @@ public interface I_HR_Payroll
 	/** Get Process Now	  */
 	public boolean isProcessing();
 
-    /** Column name UUID */
-    public static final String COLUMNNAME_UUID = "UUID";
-
-	/** Set Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public void setUUID (String UUID);
-
-	/** Get Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public String getUUID();
-
     /** Column name Updated */
     public static final String COLUMNNAME_Updated = "Updated";
 
@@ -244,6 +244,19 @@ public interface I_HR_Payroll
 	  * User who updated this records
 	  */
 	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
 
     /** Column name Value */
     public static final String COLUMNNAME_Value = "Value";

--- a/base/src/org/eevolution/model/I_HR_Process.java
+++ b/base/src/org/eevolution/model/I_HR_Process.java
@@ -18,8 +18,7 @@ package org.eevolution.model;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
-
-import org.compiere.model.MTable;
+import org.compiere.model.*;
 import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for HR_Process
@@ -268,32 +267,6 @@ public interface I_HR_Process
 	  * The record is active in the system
 	  */
 	public boolean isActive();
-
-    /** Column name IsPostPerEmployee */
-    public static final String COLUMNNAME_IsPostPerEmployee = "IsPostPerEmployee";
-
-	/** Set IsPostPerEmployee.
-	  * A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N
-	  */
-	public void setIsPostPerEmployee (boolean IsPostPerEmployee);
-
-	/** Get IsPostPerEmployee.
-	  * A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N
-	  */
-	public boolean isPostPerEmployee();
-
-    /** Column name IsReversal */
-    public static final String COLUMNNAME_IsReversal = "IsReversal";
-
-	/** Set Reversal.
-	  * This is a reversing transaction
-	  */
-	public void setIsReversal (boolean IsReversal);
-
-	/** Get Reversal.
-	  * This is a reversing transaction
-	  */
-	public boolean isReversal();
 
     /** Column name Name */
     public static final String COLUMNNAME_Name = "Name";

--- a/base/src/org/eevolution/model/X_HR_Payroll.java
+++ b/base/src/org/eevolution/model/X_HR_Payroll.java
@@ -31,7 +31,7 @@ public class X_HR_Payroll extends PO implements I_HR_Payroll, I_Persistent
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20170731L;
+	private static final long serialVersionUID = 20180728L;
 
     /** Standard Constructor */
     public X_HR_Payroll (Properties ctx, int HR_Payroll_ID, String trxName)
@@ -42,6 +42,8 @@ public class X_HR_Payroll extends PO implements I_HR_Payroll, I_Persistent
 			setC_Charge_ID (0);
 			setHR_Contract_ID (0);
 			setHR_Payroll_ID (0);
+			setIsPostPerEmployee (false);
+// N
 			setName (null);
 			setPaymentRule (null);
         } */
@@ -208,6 +210,30 @@ public class X_HR_Payroll extends PO implements I_HR_Payroll, I_Persistent
 	public boolean isIgnoreDefaultPayroll () 
 	{
 		Object oo = get_Value(COLUMNNAME_IsIgnoreDefaultPayroll);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set IsPostPerEmployee.
+		@param IsPostPerEmployee 
+		A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N
+	  */
+	public void setIsPostPerEmployee (boolean IsPostPerEmployee)
+	{
+		set_Value (COLUMNNAME_IsPostPerEmployee, Boolean.valueOf(IsPostPerEmployee));
+	}
+
+	/** Get IsPostPerEmployee.
+		@return A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N
+	  */
+	public boolean isPostPerEmployee () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsPostPerEmployee);
 		if (oo != null) 
 		{
 			 if (oo instanceof Boolean) 

--- a/base/src/org/eevolution/model/X_HR_Process.java
+++ b/base/src/org/eevolution/model/X_HR_Process.java
@@ -21,23 +21,19 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.Properties;
-
-import org.compiere.model.I_Persistent;
-import org.compiere.model.MTable;
-import org.compiere.model.PO;
-import org.compiere.model.POInfo;
+import org.compiere.model.*;
 import org.compiere.util.Env;
 
 /** Generated Model for HR_Process
  *  @author Adempiere (generated) 
  *  @version Release 3.9.0 - $Id$ */
-public class X_HR_Process extends PO implements I_HR_Process, I_Persistent
+public class X_HR_Process extends PO implements I_HR_Process, I_Persistent 
 {
 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20180126L;
+	private static final long serialVersionUID = 20180728L;
 
     /** Standard Constructor */
     public X_HR_Process (Properties ctx, int HR_Process_ID, String trxName)
@@ -52,10 +48,6 @@ public class X_HR_Process extends PO implements I_HR_Process, I_Persistent
 			setDocStatus (null);
 // DR
 			setHR_Payroll_ID (0);
-			setIsPostPerEmployee (false);
-// N
-			setIsReversal (false);
-// N
 			setName (null);
 			setPosted (false);
 // N
@@ -93,7 +85,7 @@ public class X_HR_Process extends PO implements I_HR_Process, I_Persistent
 
 	public org.compiere.model.I_AD_Workflow getAD_Workflow() throws RuntimeException
     {
-		return (org.compiere.model.I_AD_Workflow) MTable.get(getCtx(), org.compiere.model.I_AD_Workflow.Table_Name)
+		return (org.compiere.model.I_AD_Workflow)MTable.get(getCtx(), org.compiere.model.I_AD_Workflow.Table_Name)
 			.getPO(getAD_Workflow_ID(), get_TrxName());	}
 
 	/** Set Workflow.
@@ -472,54 +464,6 @@ public class X_HR_Process extends PO implements I_HR_Process, I_Persistent
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
-	}
-
-	/** Set IsPostPerEmployee.
-		@param IsPostPerEmployee 
-		A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N
-	  */
-	public void setIsPostPerEmployee (boolean IsPostPerEmployee)
-	{
-		set_Value (COLUMNNAME_IsPostPerEmployee, Boolean.valueOf(IsPostPerEmployee));
-	}
-
-	/** Get IsPostPerEmployee.
-		@return A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N
-	  */
-	public boolean isPostPerEmployee () 
-	{
-		Object oo = get_Value(COLUMNNAME_IsPostPerEmployee);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
-	}
-
-	/** Set Reversal.
-		@param IsReversal 
-		This is a reversing transaction
-	  */
-	public void setIsReversal (boolean IsReversal)
-	{
-		set_ValueNoCheck (COLUMNNAME_IsReversal, Boolean.valueOf(IsReversal));
-	}
-
-	/** Get Reversal.
-		@return This is a reversing transaction
-	  */
-	public boolean isReversal () 
-	{
-		Object oo = get_Value(COLUMNNAME_IsReversal);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
 	}
 
 	/** Set Name.

--- a/migration/390lts-391/03630_1552_HHRR_FlagPostIndividually.xml
+++ b/migration/390lts-391/03630_1552_HHRR_FlagPostIndividually.xml
@@ -3,10 +3,15 @@
   <Migration EntityType="D" Name="HHRR_FlagPostIndividually" ReleaseNo="3.9.1" SeqNo="3630">
     <Comments>https://github.com/adempiere/adempiere/issues/1552
 HRProcess: flag to post individually for every employee</Comments>
+    <Step DBType="ALL" Parse="Y" SeqNo="0" StepType="SQL">
+      <Comments>Delete for old implementations</Comments>
+      <SQLStatement>DELETE FROM AD_Field_Trl WHERE AD_Field_ID = 85495;
+DELETE FROM AD_Field WHERE AD_Field_ID = 85495;
+DELETE FROM AD_Column_Trl WHERE AD_Column_ID = 86835;
+DELETE FROM AD_Column WHERE AD_Column_ID = 86835;</SQLStatement>
+    </Step>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="276" Action="I" Record_ID="59806" Table="AD_Element">
-        <Data AD_Column_ID="2603" Column="Name">IsPostPerEmployee</Data>
-        <Data AD_Column_ID="2604" Column="Description">A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N</Data>
         <Data AD_Column_ID="2598" Column="Created">2018-01-26 15:40:17.406</Data>
         <Data AD_Column_ID="2600" Column="Updated">2018-01-26 15:40:17.406</Data>
         <Data AD_Column_ID="2597" Column="IsActive">true</Data>
@@ -14,7 +19,6 @@ HRProcess: flag to post individually for every employee</Comments>
         <Data AD_Column_ID="6285" Column="PO_Name" isNewNull="true"/>
         <Data AD_Column_ID="2605" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="2602" Column="ColumnName">IsPostPerEmployee</Data>
-        <Data AD_Column_ID="4299" Column="PrintName">IsPostPerEmployee</Data>
         <Data AD_Column_ID="6286" Column="PO_PrintName" isNewNull="true"/>
         <Data AD_Column_ID="6283" Column="PO_Description" isNewNull="true"/>
         <Data AD_Column_ID="58589" Column="FieldLength">1</Data>
@@ -27,6 +31,9 @@ HRProcess: flag to post individually for every employee</Comments>
         <Data AD_Column_ID="58590" Column="AD_Reference_Value_ID" isNewNull="true"/>
         <Data AD_Column_ID="2601" Column="UpdatedBy">0</Data>
         <Data AD_Column_ID="84316" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="4299" Column="PrintName">Post Per Employee</Data>
+        <Data AD_Column_ID="2604" Column="Description">A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N</Data>
+        <Data AD_Column_ID="2603" Column="Name">Post Per Employee</Data>
       </PO>
     </Step>
     <Step SeqNo="20" StepType="AD">
@@ -38,7 +45,6 @@ HRProcess: flag to post individually for every employee</Comments>
         <Data AD_Column_ID="2646" Column="Name">IsPostPerEmployee</Data>
         <Data AD_Column_ID="6450" Column="PO_Name" isNewNull="true"/>
         <Data AD_Column_ID="2648" Column="Help" isNewNull="true"/>
-        <Data AD_Column_ID="2647" Column="Description">A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N</Data>
         <Data AD_Column_ID="2649" Column="IsTranslated">false</Data>
         <Data AD_Column_ID="4300" Column="PrintName">IsPostPerEmployee</Data>
         <Data AD_Column_ID="6451" Column="PO_PrintName" isNewNull="true"/>
@@ -50,15 +56,16 @@ HRProcess: flag to post individually for every employee</Comments>
         <Data AD_Column_ID="2638" Column="AD_Language">es_MX</Data>
         <Data AD_Column_ID="2637" Column="AD_Element_ID">59806</Data>
         <Data AD_Column_ID="84317" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="2647" Column="Description">A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N</Data>
       </PO>
     </Step>
     <Step SeqNo="30" StepType="AD">
       <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
         <Data AD_Column_ID="2646" Column="Name" oldValue="IsPostPerEmployee">Posteo por empleado</Data>
-        <Data AD_Column_ID="2647" Column="Description" oldValue="A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N">Si el valor es Y la nomina sera aplicada por empleado, de lo contrario sera acumulada</Data>
         <Data AD_Column_ID="4300" Column="PrintName" oldValue="IsPostPerEmployee">Posteo por empleado</Data>
         <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>
         <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="59806">59806</Data>
+        <Data AD_Column_ID="2647" Column="Description" oldValue="A Payroll is posted per employee when the value is Yes, it is posted accumulated when the value is N">Si el valor es Y la nomina sera aplicada por empleado, de lo contrario sera acumulada</Data>
       </PO>
     </Step>
     <Step SeqNo="40" StepType="AD">
@@ -108,7 +115,6 @@ HRProcess: flag to post individually for every employee</Comments>
         <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
-        <Data AD_Column_ID="114" Column="AD_Table_ID">53092</Data>
         <Data AD_Column_ID="550" Column="CreatedBy">0</Data>
         <Data AD_Column_ID="2608" Column="AD_Element_ID">59806</Data>
         <Data AD_Column_ID="3369" Column="AD_Process_ID" isNewNull="true"/>
@@ -118,6 +124,7 @@ HRProcess: flag to post individually for every employee</Comments>
         <Data AD_Column_ID="226" Column="AD_Reference_ID">20</Data>
         <Data AD_Column_ID="552" Column="UpdatedBy">0</Data>
         <Data AD_Column_ID="84306" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">53093</Data>
       </PO>
     </Step>
     <Step SeqNo="60" StepType="AD">
@@ -152,7 +159,6 @@ HRProcess: flag to post individually for every employee</Comments>
         <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
         <Data AD_Column_ID="170" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
-        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
         <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
         <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
         <Data AD_Column_ID="59704" Column="PreferredWidth">0</Data>
@@ -175,9 +181,10 @@ HRProcess: flag to post individually for every employee</Comments>
         <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
         <Data AD_Column_ID="62479" Column="SeqNoGrid">180</Data>
         <Data AD_Column_ID="180" Column="DisplayLength">0</Data>
-        <Data AD_Column_ID="172" Column="AD_Tab_ID">53114</Data>
         <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
         <Data AD_Column_ID="84320" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">53115</Data>
+        <Data AD_Column_ID="177" Column="DisplayLogic">@#ShowAcct@=Y</Data>
       </PO>
     </Step>
     <Step SeqNo="80" StepType="AD">

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/compiere/acct/Doc_HRProcess.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/compiere/acct/Doc_HRProcess.java
@@ -119,7 +119,7 @@ public class   Doc_HRProcess extends Doc
 			if (C_BPartner_ID == 0)
 				C_BPartner_ID = line.getC_BPartner_ID();
 			//Close every employee
-			if (line.getC_BPartner_ID() != 0 && line.getC_BPartner_ID() != C_BPartner_ID && process.isPostPerEmployee()) {
+			if (line.getC_BPartner_ID() != 0 && line.getC_BPartner_ID() != C_BPartner_ID && process.getHR_Payroll().isPostPerEmployee()) {
 				closeBPartner(totalDebit, totalCredit, fact, as, C_BPartner_ID);
 				C_BPartner_ID = line.getC_BPartner_ID();
 				totalDebit = Env.ZERO;
@@ -157,7 +157,7 @@ public class   Doc_HRProcess extends Doc
 				}
 			}
 		}
-		if (process.isPostPerEmployee()) {
+		if (process.getHR_Payroll().isPostPerEmployee()) {
 			closeBPartner(totalDebit, totalCredit, fact, as, C_BPartner_ID);
 		} else {
 			if (totalDebit.signum() != 0


### PR DESCRIPTION
issue: https://github.com/adempiere/adempiere/issues/1552

Hi guys, it is a old discussion about definition of flag **IsPostingPerEmployee**, here a little change for improve definition. Let me explain:

The old change allows posting for employee on payroll process however, it was defined on **HR_Process** table instead **HR_Payroll** table, it change just:
 - Change Column from **HR_Process** table to **HR_Payroll**
 - Add a display logic for field: **@#ShowAcct@=Y**
 - Improve element name definition

See before and after:

- Before: ![screenshot_20180728_134524](https://user-images.githubusercontent.com/2333092/43359309-025dc0ca-9266-11e8-942b-979a70bc5654.png)

- After:
![screenshot_20180728_134509](https://user-images.githubusercontent.com/2333092/43359307-fcddf5a2-9265-11e8-8428-54088885cfa1.png)
![screenshot_20180728_134537](https://user-images.githubusercontent.com/2333092/43359313-12df49f0-9266-11e8-9115-626b61970667.png)
![screenshot_20180728_134552](https://user-images.githubusercontent.com/2333092/43359315-16d137a8-9266-11e8-8098-69e950f4e6a2.png)
![screenshot_20180728_134608](https://user-images.githubusercontent.com/2333092/43359318-1a60c294-9266-11e8-81ba-b714c9ed9bd3.png)
