### PR TITLE
#1852 cannot RUN_MigrateXML.sh : 390lts-391 - A circular Problem. htt…

### DIFF
--- a/base/src/org/compiere/process/MigrationFromXMLAbstract.java
+++ b/base/src/org/compiere/process/MigrationFromXMLAbstract.java
@@ -46,6 +46,8 @@ public abstract class MigrationFromXMLAbstract extends SvrProcess {
 	@Override
 	protected void prepare() {
 		filePathOrName = getParameterAsString(FILEPATHORNAME);
+		if (filePathOrName == null)
+			filePathOrName = getParameterAsString("FileName");
 		isApply = getParameterAsBoolean(APPLY);
 		isForce = getParameterAsBoolean(ISFORCE);
 	}


### PR DESCRIPTION
…ps://github.com/adempiere/adempiere/issues/1852

- The problem is that the FileName not exist how core element, so when the synchronization is executed the system change column name by new element name , this change enable back compatibility

(cherry picked from commit c70572c991e4fa436e4d1aca1845899428850f27)