### PR TITLE
#1912 Bug fixes for landedCost and LandedCostAllocation

### DIFF
--- a/base/src/org/compiere/process/LandedCostDistribute.java
+++ b/base/src/org/compiere/process/LandedCostDistribute.java
@@ -56,7 +56,7 @@ public class LandedCostDistribute extends SvrProcess
 
 		String error = m_lc.allocateCosts();
 		
-		generateCostDetail();
+		//generateCostDetail();
 		
 		if (error == null || error.length() == 0)
 			return "@OK@";


### PR DESCRIPTION
LandedCostDistribute should not create cost detail entries
https://github.com/adempiere/adempiere/issues/1912

**Status for working with landed Costs and landedCostAllocation:**
**Window Purchase Invoice, Line InvoiceLine**
Step 1: Generate a Landed Cost entry with the button _Generate Landed Cost_
Result: depending on the parameter create by product one or several LandedCost entries are generated

Now you can distribute the costs and generated the corresponding landed cost allocation entries with the button _distribute Costs_. This is preliminary because when the invoice is completed all landed cost allocations will be deleted and generated again.
The process generates also the Costdetail entries for the calculation of the new costs of the corresponding products.

Step 2: Complete the Invoice
All landed cost allocations are deleted and are generated again with the method MInvoiceLine.allocateLandedCosts(). The Costdetails will not be generated and must be generated by using the button Distribute Costs.

**Problem 2:**
    The process Distribute costs should not generate the cost detail entries. As the invoice is not completed the distribution is preliminary. So when the invoice is cancelled or deactivated you have included non-existing costs in your product costs. This problem is evident when you are using costing method average invoice.

In the following screenshot the invoice is cancelled from the document state _InProcess_, but the Cost Details are still in the calculation of the new average cost.
![invoiceaftercancel](https://user-images.githubusercontent.com/15349639/44318102-d1605f80-a3f1-11e8-8dbb-53b1e2bd1c34.PNG)
