### PR TITLE
#1916 ReverseAccrual generates wrong seqNo in costdetail

### DIFF
--- a/base/src/org/adempiere/engine/AbstractCostingMethod.java
+++ b/base/src/org/adempiere/engine/AbstractCostingMethod.java
@@ -196,7 +196,16 @@ public abstract class AbstractCostingMethod implements ICostingMethod {
 			lastCostDetail.setDescription(lastCostDetail.getDescription() != null ? lastCostDetail.getDescription() : "" + "|Reversal " + costDetail.getM_Transaction_ID());
 			lastCostDetail.setIsReversal(true);
 			lastCostDetail.saveEx(transaction.get_TrxName());
-			
+			if (model.getDateAcct().compareTo(lastCostDetail.getDateAcct()) != 0){
+			    lastCostDetail = MCostDetail.getLastTransaction(model, transaction,
+                        accountSchema.getC_AcctSchema_ID(), dimension.getM_CostType_ID(),
+                        dimension.getM_CostElement_ID(),dateAccounting,
+                        costingLevel);
+			    costDetail.setSeqNo(lastCostDetail.getSeqNo() + 10);
+			    updateAmountCost();
+			    updateInventoryValue();
+            }
+
 		// Only uncomment to debug Trx.get(costDetail.get_TrxName(),
 		// false).commit();
 	}


### PR DESCRIPTION
https://github.com/adempiere/adempiere/issues/1916
**Problem:**
When you cancel a shipment with method reverse accrual the new reverse document is generated with the current date.
The new cost detail entry is also generated with the current date, but with a sequence number following the original document.
As the following cost detail have dateAcct< current date, they are not updated in quantity and value.
This problems exists for all documents which are cancelled with reverseaccrual and generate entries in cost detail.
![kardex_error](https://user-images.githubusercontent.com/15349639/44319625-4041b680-a3fa-11e8-8009-dc53ebef48d0.PNG)

**Solution:**
Include the new cost detail at the end of the current date.
![kardex_correct](https://user-images.githubusercontent.com/15349639/44319646-623b3900-a3fa-11e8-872b-7a2b265915a7.PNG)
