### PR TITLE
#1928 Add missing jasper report libraries to the eclipse web deployme…

### DIFF
--- a/.settings/org.eclipse.wst.common.component
+++ b/.settings/org.eclipse.wst.common.component
@@ -42,6 +42,12 @@
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/org.adempiere.production/src/main/java/base"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/org.eevolution.fleet/src/main/java/base"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/org.adempiere.crm/src/main/java"/>
+        <dependent-module archiveName="jasperreports-fonts-6.6.0.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/adempiere/JasperReportsTools/lib/jasperreports-fonts-6.6.0.jar">
+            <dependency-type>uses</dependency-type>
+        </dependent-module>
+        <dependent-module archiveName="jasperreports-6.6.0.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/adempiere/JasperReportsTools/lib/jasperreports-6.6.0.jar">
+            <dependency-type>uses</dependency-type>
+        </dependent-module>
 		<property name="java-output-path" value="build/classes"/>
 		<property name="context-root" value="webui"/>
 	</wb-module>


### PR DESCRIPTION
…nt descriptor.  Only relevant to eclipse users but helps when running adempiere on a server in eclipse.