### PR TITLE
Fix for #1926 ZK Exports migration XML files to different location th…

### DIFF
--- a/base/src/org/compiere/process/MigrationToXML.java
+++ b/base/src/org/compiere/process/MigrationToXML.java
@@ -38,6 +38,7 @@ import org.adempiere.util.ProcessUtil;
 import org.compiere.cm.StringUtil;
 import org.compiere.model.MMigration;
 import org.compiere.util.Env;
+import org.compiere.util.Msg;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -61,7 +62,7 @@ public class MigrationToXML extends SvrProcess {
 	protected String doIt() throws Exception {
 		MMigration migration = new MMigration(getCtx(), migrationId, get_TrxName());
 		if ( migration == null || migration.is_new() )
-			return "No migration to export";
+			return "@NoMigrationFound@";  // No migration found
 		
 		log.log(Level.FINE, "Creating xml document for migration: " + migration);
 		Document document = null;
@@ -105,8 +106,7 @@ public class MigrationToXML extends SvrProcess {
 			
 			try 
 			{
-				// TODO - translate "XML file"
-				FileFilter filter = new FileNameExtensionFilter("XML file", "xml");
+				FileFilter filter = new FileNameExtensionFilter(Msg.getMsg(getCtx(), "FileXML"), "xml");
 				JFileChooser chooser = new JFileChooser(path);  // User's default if null or empty
 				chooser.setMultiSelectionEnabled(false);
 				chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
@@ -123,7 +123,8 @@ public class MigrationToXML extends SvrProcess {
 				}
 				else
 				{
-					return "Operation cancelled.";
+					// Operation cancelled.
+					return "@OperationCancelled@";
 				}
 				
 			} catch (HeadlessException e) {
@@ -186,13 +187,16 @@ public class MigrationToXML extends SvrProcess {
 				
 			}
 			
-			// Don't delete the temporary file!! The download thread needs to access it.
-			// tempFile.delete();
+			// Don't delete the temporary file right away!! 
+			// The download thread needs to access it.
+			tempFile.deleteOnExit();
 			
-			return "Migration XML sent successfully. The download should start shortly.";  // TODO translate
+			// "Migration exported to XML successfully. The download should start shortly."
+			return "@XMLDownloadSuccessMessage@";
 		}
 
-		return "Exported migration to: " + fileName;  // TODO translate
+		// "Exported migration to: " + fileName
+		return "@ExportedMigrationXMLTo@: " + fileName;
 	}
 
 	@Override

--- a/base/src/org/compiere/process/MigrationToXML.java
+++ b/base/src/org/compiere/process/MigrationToXML.java
@@ -119,6 +119,14 @@ public class MigrationToXML extends SvrProcess {
 				if (result == JFileChooser.APPROVE_OPTION)
 				{
 					tempFile = chooser.getSelectedFile();
+					
+		            // Need to create the file, even if empty.  This won't overwrite 
+					// an existing file, but will make a new one if the file doesn't exist.
+		            // Without this, tempFile.isFile() below will return false if no
+		            // file exists when we need it to return true.
+		            tempFile.createNewFile();
+		            
+		            // Save the path used to the context
 					Env.setContext(getCtx(), "Last Used Path", tempFile.getAbsolutePath());
 				}
 				else
@@ -133,12 +141,18 @@ public class MigrationToXML extends SvrProcess {
 			}
 		}
 		
+		// If tempFile has not been initialized or is not a file
+		// then create a temporary file - this will happen if the
+		// interface type is not Swing, in which case a temporary 
+		// file is needed, or if something went wrong in the file 
+		// chooser above. The later shouldn't happen but "Au cas où..."
 		if (tempFile == null || !tempFile.isFile())
 		{
 			// Create the temporary file
 			tempFile = File.createTempFile("adempiere_", "_"+ fileName);
 		}		
 
+		// The tempFile should now exist somewhere
 		fileName = tempFile.getAbsolutePath();
 		
         log.log(Level.FINE, "Writing xml to file " + fileName);

--- a/base/src/org/compiere/process/MigrationToXML.java
+++ b/base/src/org/compiere/process/MigrationToXML.java
@@ -15,9 +15,16 @@
 
 package org.compiere.process;
 
+import java.awt.HeadlessException;
+import java.io.File;
 import java.io.FileWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.logging.Level;
 
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -26,7 +33,11 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.util.ProcessUtil;
+import org.compiere.cm.StringUtil;
 import org.compiere.model.MMigration;
+import org.compiere.util.Env;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -36,11 +47,15 @@ import org.w3c.dom.Element;
  * 
  * @author Paul Bowden, Adaxa Pty Ltd
  *
+ * @author Michael McKay, michael.mckay@mckayerp.com, 
+ *	 <li>Bug [ <a href="https://github.com/adempiere/adempiere/issues/1926">#1926</a> ] ZK Exports migration XML files to 
+ *       different location than what is selected in the dialogs.
  */
 public class MigrationToXML extends SvrProcess {
 
 	private int migrationId = 0;
 	private String fileName;
+	private File tempFile;
 
 	@Override
 	protected String doIt() throws Exception {
@@ -68,7 +83,64 @@ public class MigrationToXML extends SvrProcess {
         trans.setOutputProperty(OutputKeys.INDENT, "yes");
         trans.setOutputProperty(OutputKeys.STANDALONE, "yes");
 
-        log.log(Level.FINE, "Writing xml to file.");
+       
+		 //  Come up with a temporary filename.
+		fileName = migration.getReleaseNo() + "_" + migration.getSeqNo() +
+				"_" + StringUtil.replace(migration.getName().trim()," ","")
+				+ ".xml";
+
+		tempFile = null;
+		
+		//  #1926 - fix how the export process works.  The process needs to 
+		//  ask the user for the target file name in SWING and ZK.  Programmatic 
+		//  invocation of the process will default to a temporary file name 
+		//  saved in the user's default directory.
+		//  Interface type is set by the UI dialogs.
+		
+		// If this is the SWING interface, ask the user to select the file now
+		if (ProcessInfo.INTERFACE_TYPE_SWING.equals(this.getProcessInfo().getInterfaceType()))
+		{
+			// Try to recover the last used path from the context.
+			String path = Env.getContext(getCtx(), "Last Used Path");
+			
+			try 
+			{
+				// TODO - translate "XML file"
+				FileFilter filter = new FileNameExtensionFilter("XML file", "xml");
+				JFileChooser chooser = new JFileChooser(path);  // User's default if null or empty
+				chooser.setMultiSelectionEnabled(false);
+				chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+				chooser.setDialogTitle(getProcessInfo().getTitle());
+				chooser.setDialogType(JFileChooser.SAVE_DIALOG);
+				chooser.setFileFilter(filter); // XML only
+				chooser.setSelectedFile(tempFile);  // Doesn't seem to work - the selected file is blank
+				int result = chooser.showSaveDialog(null);
+			
+				if (result == JFileChooser.APPROVE_OPTION)
+				{
+					tempFile = chooser.getSelectedFile();
+					Env.setContext(getCtx(), "Last Used Path", tempFile.getAbsolutePath());
+				}
+				else
+				{
+					return "Operation cancelled.";
+				}
+				
+			} catch (HeadlessException e) {
+				e.printStackTrace();
+				throw new AdempiereException("Can't create file for XML export. " + e.getMessage());
+			}
+		}
+		
+		if (tempFile == null || !tempFile.isFile())
+		{
+			// Create the temporary file
+			tempFile = File.createTempFile("adempiere_", "_"+ fileName);
+		}		
+
+		fileName = tempFile.getAbsolutePath();
+		
+        log.log(Level.FINE, "Writing xml to file " + fileName);
         //create string from xml tree
         FileWriter fw = new FileWriter(fileName);
         StreamResult result = new StreamResult(fw);
@@ -76,7 +148,51 @@ public class MigrationToXML extends SvrProcess {
         trans.transform(source, result);
         fw.close();
         
-		return "Exported migration to: " + fileName;
+        // For zk, send the temporary file for download after it has been created
+		if (ProcessInfo.INTERFACE_TYPE_ZK.equals(this.getProcessInfo().getInterfaceType()))
+		{
+			// Force download of the file
+			String className = "org.zkoss.zul.Filedownload";
+			//Get Class
+			Class<?> Filedownload = null;
+			//use context classloader if available
+			ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+			if (classLoader == null)
+				classLoader = ProcessUtil.class.getClassLoader();
+			try
+			{
+				Filedownload = classLoader.loadClass(className);
+			}
+			catch (ClassNotFoundException ex)
+			{
+				log.log(Level.WARNING, className, ex);
+				throw new AdempiereException("Can't load the necessary class '" + className + "' to download the file. " + ex.getMessage());
+			}
+
+			Method save = null;
+			Object FileDownloader = Filedownload.newInstance();
+			File file = new File(fileName);			
+			try 
+			{
+				// Invoke the ZK Filedownload.save(file, contentType)
+				save = Filedownload.getMethod("save", java.io.File.class, java.lang.String.class);
+				save.invoke(FileDownloader, file, (String) null);
+			} 
+			catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) 
+			{
+				
+				log.log(Level.WARNING, "Can't download the file.", e);
+				throw new AdempiereException("Can't download the file. " + e.getMessage());
+				
+			}
+			
+			// Don't delete the temporary file!! The download thread needs to access it.
+			// tempFile.delete();
+			
+			return "Migration XML sent successfully. The download should start shortly.";  // TODO translate
+		}
+
+		return "Exported migration to: " + fileName;  // TODO translate
 	}
 
 	@Override
@@ -87,16 +203,19 @@ public class MigrationToXML extends SvrProcess {
 		{
 			if ( para.getParameterName().equals("AD_Migration_ID"))
 				migrationId =  para.getParameterAsInt();
-			else if ( para.getParameterName().equals("FileName"))
-				fileName = (String) para.getParameter();
+			
+			// File name removed as a parameter - #1926
+
+			
 		}
 		
 		// if run from Migration window
 		if ( migrationId == 0 )
 			migrationId = getRecord_ID();
 		
-		log.log(Level.FINE, "AD_Migration_ID = " + migrationId + ", filename = " + fileName);
+		
+		log.log(Level.FINE, "AD_Migration_ID = " + migrationId);
 
 	}
-
+	
 }

--- a/base/src/org/compiere/process/ProcessInfo.java
+++ b/base/src/org/compiere/process/ProcessInfo.java
@@ -52,6 +52,10 @@ import org.compiere.util.Util;
  *		<li>FR [ 352 ] T_Selection is better send to process like a HashMap instead read from disk
  *		@see https://github.com/adempiere/adempiere/issues/352
  *	@author Victor Perez , victor.perez@e-evolution.com, http://e-evolution.com
+ *	@author Michael McKay, michael.mckay@mckayerp.com, 
+ *	 <li>Bug [ <a href="https://github.com/adempiere/adempiere/issues/1926">#1926</a> ] ZK Exports migration XML files to 
+ *       different location than what is selected in the dialogs.
+
  */
 public class ProcessInfo implements Serializable
 {
@@ -177,6 +181,33 @@ public class ProcessInfo implements Serializable
 	private Throwable 			throwable = null;
 	/**	Table Name for open window after running	*/
 	private String 				resultTableName = null;
+	
+	// Bug #1926 - fix is to provide interface info to the process
+	/** A flag indicating the type of interface in use.  Value can be
+	 *  INTERFACE_TYPE_NOT_SET, INTERFACE_TYPE_ZK or INTERFACE_TYPE_SWING
+	 *  */
+	private String	interfaceType;
+	
+	// Values for the interface_type flag
+	/** 
+	 * A flag value for the interface type indicating the interface type
+	 * is not set.  This is a valid value if the process is not being run
+	 * through a UI dialog.
+	 */
+	public static String		INTERFACE_TYPE_NOT_SET = "not set";
+	
+	/**
+	 * A flag value for the interface type indicating the process is 
+	 * being run from a dialog in a web client
+	 */
+	public static String		INTERFACE_TYPE_ZK = "zk";
+
+	/**
+	 * A flag value for the interface type indicating the process is 
+	 * being run from a dialog in a SWING client
+	 */
+	public static String		INTERFACE_TYPE_SWING = "swing";
+
 	
 	/**
 	 *  String representation
@@ -1361,4 +1392,44 @@ public class ProcessInfo implements Serializable
 		return !Util.isEmpty(getResultTableName());
 	}
 	
+	/**
+	 * Get the interface type this process is being run from.  The interface type
+	 * can be used by the process to perform UI type actions from within the process
+	 * or in the {@link #postProcess(boolean)}
+	 * @return The InterfaceType which will be one of 
+	 * <li> {@link #INTERFACE_TYPE_NOT_SET}
+	 * <li> {@link #INTERFACE_TYPE_SWING} or
+	 * <li> {@link #INTERFACE_TYPE_ZK}
+	 */
+	public String getInterfaceType() {
+		
+		if (interfaceType == null || interfaceType.isEmpty())
+			interfaceType = INTERFACE_TYPE_NOT_SET;
+		
+		return interfaceType;
+	}
+
+	/**
+	 * Sets the Interface Type
+	 * @param uiType which must equal one of the following: 
+	 * <li> {@link #INTERFACE_TYPE_NOT_SET} (default)
+	 * <li> {@link #INTERFACE_TYPE_SWING} or
+	 * <li> {@link #INTERFACE_TYPE_ZK}
+	 * The interface should be set by UI dialogs that start the process.
+	 * @throws IllegalArgumentException if the interfaceType is not recognized.
+	 */
+	public void setInterfaceType(String uiType) {
+		// Limit value to known types
+		if (uiType.equals(INTERFACE_TYPE_NOT_SET)
+			||uiType.equals(INTERFACE_TYPE_ZK)
+			||uiType.equals(INTERFACE_TYPE_SWING) )
+		{
+			this.interfaceType = uiType;
+		}
+		else
+		{
+			throw new IllegalArgumentException("Unknown interface type " + uiType);
+		}
+	}
+
 }   //  ProcessInfo

--- a/client/src/org/compiere/apps/ProcessModalDialog.java
+++ b/client/src/org/compiere/apps/ProcessModalDialog.java
@@ -44,6 +44,9 @@ import org.compiere.util.Env;
  *		@see https://github.com/adempiere/adempiere/issues/323
  *		<a href="https://github.com/adempiere/adempiere/issues/571">
  * 		@see FR [ 571 ] Process Dialog is not MVC</a>
+ *	@author Michael McKay, michael.mckay@mckayerp.com, 
+ *	 <li>Bug [ <a href="https://github.com/adempiere/adempiere/issues/1926">#1926</a> ] ZK Exports migration XML files to 
+ *       different location than what is selected in the dialogs.
  */
 public class ProcessModalDialog extends CDialog implements IProcessDialog, ASyncProcess {
 	
@@ -168,6 +171,13 @@ public class ProcessModalDialog extends CDialog implements IProcessDialog, ASync
 		log.config("");
 		processInfo.setAD_User_ID (Env.getAD_User_ID(Env.getCtx()));
 		processInfo.setAD_Client_ID(Env.getAD_Client_ID(Env.getCtx()));
+		
+		// #1926 ZK Exports migration XML files to different location 
+		// than what is selected in the dialogs. Fix is to let the process
+		// know what interface is being used so it can manage the export 
+		// process correctly.
+		processInfo.setInterfaceType(ProcessInfo.INTERFACE_TYPE_SWING);
+		
 		processPanel = new ProcessPanel(this, windowNo, processInfo, ProcessPanel.COLUMNS_1);
 		processPanel.setAutoStart(autoStart);
 		processPanel.setIsOnlyPanel(isOnlyPanel);

--- a/migration/390lts-391/04000_1926_RemoveFileNameFromExptMigration.xml
+++ b/migration/390lts-391/04000_1926_RemoveFileNameFromExptMigration.xml
@@ -61,5 +61,145 @@
         <Data AD_Column_ID="50181" Column="ShowHelp" oldValue="Y">N</Data>
       </PO>
     </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53486" Table="AD_Message">
+        <Data AD_Column_ID="591" Column="Updated">2018-08-27 08:52:01.05</Data>
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2018-08-27 08:52:01.05</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Migration exported to XML successfully. The download should start shortly.</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">XMLDownloadSuccessMessage</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53486</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="609" Column="Created">2018-08-27 08:52:40.671</Data>
+        <Data AD_Column_ID="611" Column="Updated">2018-08-27 08:52:40.671</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Migration exported to XML successfully. The download should start shortly.</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53486</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53487" Table="AD_Message">
+        <Data AD_Column_ID="591" Column="Updated">2018-08-27 08:54:31.586</Data>
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2018-08-27 08:54:31.586</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Exported migration XML to</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">ExportedMigrationXMLTo</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53487</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2018-08-27 08:54:32.568</Data>
+        <Data AD_Column_ID="611" Column="Updated">2018-08-27 08:54:32.568</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Exported migration XML to</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53487</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53488" Table="AD_Message">
+        <Data AD_Column_ID="591" Column="Updated">2018-08-27 08:57:19.53</Data>
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2018-08-27 08:57:19.53</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Operation cancelled.</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">OperationCancelled</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53488</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="90" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2018-08-27 08:57:20.588</Data>
+        <Data AD_Column_ID="611" Column="Updated">2018-08-27 08:57:20.588</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Operation cancelled.</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53488</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="100" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53489" Table="AD_Message">
+        <Data AD_Column_ID="591" Column="Updated">2018-08-27 09:00:30.986</Data>
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2018-08-27 09:00:30.986</Data>
+        <Data AD_Column_ID="198" Column="MsgText">No migration found.</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">NoMigrationFound</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53489</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="110" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2018-08-27 09:00:32.257</Data>
+        <Data AD_Column_ID="611" Column="Updated">2018-08-27 09:00:32.257</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">No migration found.</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53489</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
   </Migration>
 </Migrations>

--- a/migration/390lts-391/04000_1926_RemoveFileNameFromExptMigration.xml
+++ b/migration/390lts-391/04000_1926_RemoveFileNameFromExptMigration.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Remove FileName as a parameter for Export Migration to xml" ReleaseNo="3.9.1" SeqNo="4000">
+    <Comments>https://github.com/adempiere/adempiere/issues/1926</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="286" Action="D" Record_ID="0" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="2836" Column="Created" isNewNull="true" oldValue="2009-06-15 00:38:12.0"/>
+        <Data AD_Column_ID="2838" Column="Updated" isNewNull="true" oldValue="2015-02-25 23:34:56.161576"/>
+        <Data AD_Column_ID="2835" Column="IsActive" isNewNull="true" oldValue="true"/>
+        <Data AD_Column_ID="2842" Column="IsTranslated" isNewNull="true" oldValue="true"/>
+        <Data AD_Column_ID="2840" Column="Name" isNewNull="true" oldValue="Nombre del Archivo"/>
+        <Data AD_Column_ID="2841" Column="Description" isNewNull="true" oldValue="Nombre del archivo local o URL"/>
+        <Data AD_Column_ID="3743" Column="Help" isNewNull="true" oldValue="Nombre de un archivo en el espacio local del directorio o URL (Archivo://.., http://.., ftp://..)"/>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID" isNewNull="true" oldValue="0"/>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID" isNewNull="true" oldValue="0"/>
+        <Data AD_Column_ID="2837" Column="CreatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="2832" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID" oldValue="53317">53317</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="84386" Column="UUID" isNewNull="true" isOldNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="285" Action="D" Record_ID="53317" Table="AD_Process_Para">
+        <Data AD_Column_ID="2822" Column="Name" isNewNull="true" oldValue="File Name"/>
+        <Data AD_Column_ID="2817" Column="IsActive" isNewNull="true" oldValue="true"/>
+        <Data AD_Column_ID="2820" Column="Updated" isNewNull="true" oldValue="2015-02-25 23:34:55.814933"/>
+        <Data AD_Column_ID="2818" Column="Created" isNewNull="true" oldValue="2009-06-15 00:38:12.0"/>
+        <Data AD_Column_ID="3738" Column="IsMandatory" isNewNull="true" oldValue="true"/>
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="4017" Column="ColumnName" isNewNull="true" oldValue="FileName"/>
+        <Data AD_Column_ID="2823" Column="Description" isNewNull="true" oldValue="Name of the local file or URL"/>
+        <Data AD_Column_ID="2824" Column="Help" isNewNull="true" oldValue="Name of a file in the local directory space - or URL (file://.., http://.., ftp://..)"/>
+        <Data AD_Column_ID="2830" Column="IsRange" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained" isNewNull="true" oldValue="true"/>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="3739" Column="DefaultValue" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="81287" Column="IsInfoOnly" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID" isNewNull="true" oldValue="53317"/>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID" isNewNull="true" oldValue="0"/>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID" isNewNull="true" oldValue="0"/>
+        <Data AD_Column_ID="7728" Column="EntityType" isNewNull="true" oldValue="D"/>
+        <Data AD_Column_ID="3737" Column="FieldLength" isNewNull="true" oldValue="200"/>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID" isNewNull="true" oldValue="53172"/>
+        <Data AD_Column_ID="2819" Column="CreatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID" isNewNull="true" oldValue="39"/>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="2826" Column="SeqNo" isNewNull="true" oldValue="10"/>
+        <Data AD_Column_ID="2821" Column="UpdatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID" isNewNull="true" oldValue="2295"/>
+        <Data AD_Column_ID="84385" Column="UUID" isNewNull="true" isOldNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="284" Action="U" Record_ID="53172" Table="AD_Process">
+        <Data AD_Column_ID="50181" Column="ShowHelp" oldValue="Y">N</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/migration/390lts-391/04000_1926_RemoveFileNameFromExptMigration.xml
+++ b/migration/390lts-391/04000_1926_RemoveFileNameFromExptMigration.xml
@@ -88,7 +88,7 @@
         <Data AD_Column_ID="611" Column="Updated">2018-08-27 08:52:40.671</Data>
         <Data AD_Column_ID="608" Column="IsActive">true</Data>
         <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="342" Column="MsgText">Migration exported to XML successfully. The download should start shortly.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Migración fue exportada exitosamente a XML. La descarga iniciará dentro de poco.</Data>
         <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
         <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
         <Data AD_Column_ID="6767" Column="AD_Message_ID">53486</Data>
@@ -120,7 +120,7 @@
         <Data AD_Column_ID="611" Column="Updated">2018-08-27 08:54:32.568</Data>
         <Data AD_Column_ID="608" Column="IsActive">true</Data>
         <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="342" Column="MsgText">Exported migration XML to</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Migración XML exportada a </Data>
         <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
         <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
@@ -155,7 +155,7 @@
         <Data AD_Column_ID="611" Column="Updated">2018-08-27 08:57:20.588</Data>
         <Data AD_Column_ID="608" Column="IsActive">true</Data>
         <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="342" Column="MsgText">Operation cancelled.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">La operación fue cancelada.</Data>
         <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
         <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
@@ -190,7 +190,7 @@
         <Data AD_Column_ID="611" Column="Updated">2018-08-27 09:00:32.257</Data>
         <Data AD_Column_ID="608" Column="IsActive">true</Data>
         <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="342" Column="MsgText">No migration found.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">No se encontró Migración.</Data>
         <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
         <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/ProcessPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/ProcessPanel.java
@@ -92,7 +92,9 @@ import org.zkoss.zul.Html;
  *		<li>FR [ 1051 ] Process Dialog have not scroll bar in zk
  *		<li>FR [ 1061 ] Process Modal Dialog in zk height is not autosize
  *	@author Michael Mckay michael.mckay@mckayerp.com
- *		<li>BF [ <a href="https://github.com/adempiere/adempiere/issues/495">495</a> ] Parameter Panel & SmartBrowser criteria do not set gridField value
+ *		<li>BF [ <a href="https://github.com/adempiere/adempiere/issues/495">#495</a> ] Parameter Panel & SmartBrowser criteria do not set gridField value
+ *		<li>BF [ <a href="https://github.com/adempiere/adempiere/issues/1926">#1926</a> ] ZK Exports migration XML files to 
+ *       different location than what is selected in the dialogs.
  * 	@version 	2006-12-01
  */
 public class ProcessPanel extends ProcessController implements SmallViewEditable, EventListener, ASyncProcess {
@@ -675,6 +677,13 @@ public class ProcessPanel extends ProcessController implements SmallViewEditable
 	 */
 	protected void runProcess() {
 		getProcessInfo().setPrintPreview(true);
+		
+		// #1926 ZK Exports migration XML files to different location 
+		// than what is selected in the dialogs. Fix is to let the process
+		// know what interface is being used so it can manage the export 
+		// process correctly.
+		getProcessInfo().setInterfaceType(ProcessInfo.INTERFACE_TYPE_ZK);
+		
 		ProcessCtl worker = new ProcessCtl(this, getWindowNo(), getProcessInfo(),null);
 		worker.run();
 		//	Run


### PR DESCRIPTION
…an what is selected in the dialogs.  Removed file name as a parameter from the Export Migration to XML process.  Changed ProcessInfo to include a field for interface type with getters and setters.  Set the interface type in the process dialogs in both SWING and ZK.  Use the interface type in the process to trigger the correct handling of the file download process.  In ZK, use reflexion to dymanically load the correct library.  In Swing, the library is available.