### PR TITLE
#1863 The parameter for the field of Smart Browser does not take the …

### DIFF
--- a/base/src/org/compiere/model/GridField.java
+++ b/base/src/org/compiere/model/GridField.java
@@ -591,7 +591,7 @@ public class GridField
 		 */
 
 		//	No defaults for these fields
-		if ((m_vo.IsKey && getColumnNameAlias() == null) || m_vo.displayType == DisplayType.RowID
+		if ((m_vo.IsKey && (getColumnNameAlias() == null || getColumnNameAlias().isEmpty())) || m_vo.displayType == DisplayType.RowID
 			|| DisplayType.isLOB(m_vo.displayType))
 			return null;
 		//	Set Parent to context if not explitly set


### PR DESCRIPTION
…default value defined when this field is marked as a key https://github.com/adempiere/adempiere/issues/1863

- adding support for ColumnAlias  is empty

(cherry picked from commit 110e4141f57f3336e4aac4b90c0964da40086597)

@SusanneCalderon thank you , to report the issue-