### PR TITLE
#2028, fixed read only logic for POS order, reference to issue:

### DIFF
--- a/org.adempiere.pos/src/main/java/base/org/adempiere/pos/service/CPOS.java
+++ b/org.adempiere.pos/src/main/java/base/org/adempiere/pos/service/CPOS.java
@@ -106,10 +106,10 @@ public class CPOS {
 	private MBPartner 			partner;
 	/**	Price List Version		*/
 	private int 				priceListVersionId;
-	/**	Price List Id		*/
+	/**	Price List Id			*/
 	private int 				priceListId;
 	/** Context					*/
-	private Properties 		ctx;
+	private Properties 			ctx;
 	/**	Today's (login) date	*/
 	private Timestamp 			today;
 	/**	Order List				*/

--- a/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSOrderLinePanel.java
+++ b/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSOrderLinePanel.java
@@ -166,23 +166,6 @@ public class WPOSOrderLinePanel extends WPOSSubPanel implements WTableModelListe
 		boolean isUpdate = (event.getType() == ListDataEvent.CONTENTS_CHANGED);
 		int col = event.getColumn();
 		int row = posTable.getSelectedRow();
-		/*if(event.getColumn() == POSOrderLineTableHandle.POSITION_DELETE){
-			posTable.getModel().removeTableModelListener(this);
-			ListModelTable m_model = (ListModelTable)event.getModel();
-			for(int x = 0; x < posTable.getRowCount(); x++){
-				String value = m_model.getValueAt(x, 1).toString();
-				if(value.length() == 0){
-					IDColumn key = (IDColumn) m_model.getValueAt(x, 0);
-					orderLineId = key.getRecord_ID();
-					posPanel.deleteLine(orderLineId);
-					posTable.getModel().remove(x);
-				}
-			}
-
-			posTable.getModel().addTableModelListener(this);
-			posPanel.refreshHeader();
-			return;
-		}*/
 		if (!isUpdate
 				|| (col != POSOrderLineTableHandle.POSITION_QTYORDERED
 						&& col != POSOrderLineTableHandle.POSITION_PRICE)) {

--- a/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSQuantityPanel.java
+++ b/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSQuantityPanel.java
@@ -360,10 +360,7 @@ public class WPOSQuantityPanel extends WPOSSubPanel implements POSPanelInterface
 
 	@Override
 	public void changeViewPanel() {
-		if(posPanel.getQty().compareTo(Env.ZERO) == 0)
-			changeStatus(false);
-		else
-			changeStatus(true);
+		changeStatus(true);
 		fieldQuantity.setValue(posPanel.getQty());
 		fieldPrice.setValue(posPanel.getPrice());
 		fieldDiscountPercentage.setValue(posPanel.getDiscountPercentage());


### PR DESCRIPTION
https://github.com/adempiere/adempiere/issues/2028

fixes #2028 

Hi guys, it issue fixed a error know in POS ui, see the follow steps:

 - Create a POS order (From POS).
 - Add lines
 - Go to first (it can be over any line) and set quantity to 0 (Zero)
 - Wow.... The buttons for control are disabled for current line

For more info see issue