### PR TITLE
#2030 Listener missing from ZK ui for Small View Controller

### DIFF
--- a/base/src/org/adempiere/controller/SmallViewController.java
+++ b/base/src/org/adempiere/controller/SmallViewController.java
@@ -67,8 +67,10 @@ public abstract class SmallViewController implements SmallViewEditable, Vetoable
 		StackTraceElement[] stElements = Thread.currentThread().getStackTrace();
         for (int i=1; i<stElements.length; i++) {
             StackTraceElement ste = stElements[i];
-            if (ste.getClassName().contains("webui")) {
+            if (ste.getClassName().contains("webui")
+            		|| ste.getClassName().contains("zk.ui")) {
                 m_IsSwing = false;
+                break;
             }
         }
 	}	
@@ -708,7 +710,7 @@ public abstract class SmallViewController implements SmallViewEditable, Vetoable
 	 * Validate all fields for values and mandatory
 	 * @return null if nothing happens
 	 */
-	public String 	validateFields() {
+	public String validateFields() {
 		log.config("");
 
 		StringBuffer sb = new StringBuffer();

--- a/client/src/org/eevolution/grid/Browser.java
+++ b/client/src/org/eevolution/grid/Browser.java
@@ -503,7 +503,7 @@ public abstract class Browser {
 		//	Valid null
 		LinkedHashMap<String, GridField> panelParameters = getPanelParameters();
 		if(panelParameters == null
-		|| panelParameters.size() == 0) {
+				|| panelParameters.size() == 0) {
 			whereClause = sql.toString();
 			return whereClause;
 		}


### PR DESCRIPTION
Hi verybody, i find a error with Smart Browser for ZK UI that affect:
 - Default values
 - Search field changes
 - Search result for SB

A little example of it behavior is emulated with follow steps:
 - Go to POS
 - Create a new POS order
 - Collect it order
 - Into the POS, go to process **POS Statement Close**:
   - Note that exist a **Transaction Date** field with current date
   - If you try change date, it not have effect over search.

The problem is that ZK UI don't know the listener for changes over search field on SmallViewController class and any change over field not have effects over values for query

fixes #2030 

reference to issue: https://github.com/adempiere/adempiere/issues/2030