### PR TITLE
Fix for #2053. Add FileName parameter to MigrationLoader.

### DIFF
--- a/base/src/org/adempiere/process/MigrationLoader.java
+++ b/base/src/org/adempiere/process/MigrationLoader.java
@@ -72,7 +72,8 @@ public class MigrationLoader {
 			.process(org.compiere.process.MigrationFromXML.class)
 			.withTitle("Import Migration from XML")
 			.withParameter("FailOnError",failOnError)
-			.withParameter(MigrationFromXML.FILEPATHORNAME, fileName)
+			.withParameter(MigrationFromXML.FILEPATHORNAME, fileName) // Old parameter name
+			.withParameter(MigrationFromXML.FILENAME, fileName)  // New parameter name
 			.withParameter(MigrationFromXML.APPLY, apply)
 			.withParameter(MigrationFromXML.ISFORCE, force_arg)
 			.withParameter("Clean", clean)

--- a/base/src/org/compiere/process/MigrationFromXMLAbstract.java
+++ b/base/src/org/compiere/process/MigrationFromXMLAbstract.java
@@ -32,6 +32,8 @@ public abstract class MigrationFromXMLAbstract extends SvrProcess {
 	private static final int ID_FOR_PROCESS = 53175;
 	/**	Parameter Name for File Path or Name	*/
 	public static final String FILEPATHORNAME = "FilePathOrName";
+	/**	Parameter Name for File Name	*/  // Parameter changed name in DB
+	public static final String FILENAME = "FileName";
 	/**	Parameter Name for Apply	*/
 	public static final String APPLY = "Apply";
 	/**	Parameter Name for Force	*/
@@ -47,7 +49,7 @@ public abstract class MigrationFromXMLAbstract extends SvrProcess {
 	protected void prepare() {
 		filePathOrName = getParameterAsString(FILEPATHORNAME);
 		if (filePathOrName == null)
-			filePathOrName = getParameterAsString("FileName");
+			filePathOrName = getParameterAsString(FILENAME);
 		isApply = getParameterAsBoolean(APPLY);
 		isForce = getParameterAsBoolean(ISFORCE);
 	}


### PR DESCRIPTION
Fixes #2053.  Adds the FileName parameter to the MigrationLoader to address the required parameters before and after the parameter name is changed in another commit.  Fixes the problem where RUN_MigrationXML fails with an unfilled required parameter.