### PR TITLE
#2059 Process Parameters: NPE for reference type Search

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WSearchEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WSearchEditor.java
@@ -702,7 +702,7 @@ public class WSearchEditor extends WEditor implements ContextMenuListener, Value
 				this.getADTabPanel().getListPanel().addKeyListener();
 			GridPanel gridQuick = null;
 			ADTabPanel tabPanel = (ADTabPanel)getADTabPanel();
-			if(tabPanel.getQuickPanel() != null) {
+			if(tabPanel != null && tabPanel.getQuickPanel() != null) {
 				gridQuick = tabPanel.getQuickPanel();
 				gridQuick.addKeyListener();
 			}


### PR DESCRIPTION
Fixes #2059
In WbUI process parameters with the reference Search create a NPE.

Solution: Class WSearchEditor, line 705
replace `
			if(tabPanel.getQuickPanel() != null) {`

with `
			if(tabPanel != null && tabPanel.getQuickPanel() != null) {`
Result:
![imagen](https://user-images.githubusercontent.com/15349639/46551738-c8d6c200-c895-11e8-8459-50f170c16a9e.png)


