### PR TITLE
GenerateCostDetails does not delete details for inactive cost elements.

### DIFF
--- a/base/src/org/compiere/model/MCost.java
+++ b/base/src/org/compiere/model/MCost.java
@@ -48,10 +48,19 @@ import org.compiere.util.*;
  *  @author Teo Sarca
  *  	<li>BF [ 2847648 ] Manufacture & shipment cost errors
  *  		https://sourceforge.net/tracker/?func=detail&aid=2847648&group_id=176962&atid=934929
+ *  @author Michael McKay, mckayERP@gmail.com
+ *  	<li> BF [ <a href="https://github.com/adempiere/adempiere/issues/197">197</a> ] 
+ *  		GenerateCostDetails does not delete inactive cost types or methods
  */
 public class MCost extends X_M_Cost
 {
     /**
+	 * 
+	 */
+	private static final long serialVersionUID = -202208022079674900L;
+
+
+	/**
      *
      * @param product
      * @param as
@@ -1963,8 +1972,7 @@ public class MCost extends X_M_Cost
 			}
 			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(CostingLevel))
 			{
-				if (getM_AttributeSetInstance_ID() == 0
-					&& ce.isCostingMethod())
+				if (getM_AttributeSetInstance_ID() == 0)  //#197 Removed reference to ce.isCostingMethod()
 				{
 					log.saveError("FillMandatory", Msg.getElement(getCtx(), "M_AttributeSetInstance_ID"));
 					return false;

--- a/base/src/org/compiere/model/MCostElement.java
+++ b/base/src/org/compiere/model/MCostElement.java
@@ -37,6 +37,9 @@ import org.compiere.util.Msg;
  *  		<li>BF [ 2667470 ] MCostElement.getMaterialCostElement should check only material
  *  @author red1
  *  		<li>FR: [ 2214883 ] Remove SQL code and Replace for Query -- JUnit tested
+ *  @author Michael McKay, mckayERP@gmail.com
+ *  	<li> BF [ <a href="https://github.com/adempiere/adempiere/issues/197">197</a> ] 
+ *  		GenerateCostDetails does not delete inactive cost types or methods
  */
 public class MCostElement extends X_M_CostElement
 {
@@ -230,47 +233,48 @@ public class MCostElement extends X_M_CostElement
 	 */
 	protected boolean beforeSave (boolean newRecord)
 	{
-		//	Check Unique Costing Method
-		if (
-			(  COSTELEMENTTYPE_Material.equals(getCostElementType())
-//			|| COSTELEMENTTYPE_Resource.equals(getCostElementType())
-//			|| COSTELEMENTTYPE_BurdenMOverhead.equals(getCostElementType())
-//			|| COSTELEMENTTYPE_Overhead.equals(getCostElementType())
-			|| COSTELEMENTTYPE_OutsideProcessing.equals(getCostElementType())
-			)
-			&& (newRecord || is_ValueChanged(COLUMNNAME_CostingMethod)))
+		//  Check Unique Costing Element Type - only one active record of 
+		//  each type is allowed per client (#197)
+		if ( newRecord || is_ValueChanged(I_M_CostElement.COLUMNNAME_CostElementType)) 
 		{
-			String sql = "SELECT  COALESCE(MAX(M_CostElement_ID),0) FROM M_CostElement "
-				+ "WHERE AD_Client_ID=? AND CostingMethod=? AND CostElementType=?";
-			int id = DB.getSQLValue(get_TrxName(), sql, getAD_Client_ID(), getCostingMethod() , getCostElementType());
-			if (id > 0 && id != get_ID())
+			String where = I_M_CostElement.COLUMNNAME_CostElementType + "=?";
+
+			int count = new Query(getCtx(), I_M_CostElement.Table_Name, where, this.get_TrxName())
+					.setClient_ID()
+					.setOnlyActiveRecords(true)
+					.setParameters(getCostElementType())
+					.count();
+
+			if (count > 0)
 			{
-				log.saveError("AlreadyExists", Msg.getElement(getCtx(), "CostingMethod"));
+				log.saveError("AlreadyExists", Msg.getElement(getCtx(), "CostElementType"));
+				return false;
+			}
+		}
+	
+		//  Check for one active default - only one active default is allowed per client (#197)
+		if ((is_ValueChanged(COLUMNNAME_IsDefault) || is_ValueChanged(COLUMNNAME_IsActive)) 
+				&& isDefault() && isActive())
+		{
+			String where = I_M_CostElement.COLUMNNAME_IsDefault + "=?";
+			
+			int count = new Query(getCtx(), I_M_CostElement.Table_Name, where, this.get_TrxName())
+							.setClient_ID()
+							.setOnlyActiveRecords(true)
+							.setParameters(true)
+							.count();
+			
+			if (count > 0)
+			{
+				log.saveError("Error", Msg.parseTranslation(getCtx(), "@OnlyOneDefaultAllowed@"));
 				return false;
 			}
 		}
 
-		//	Maintain Calculated
-		/*
-		if (COSTELEMENTTYPE_Material.equals(getCostElementType()))
-		{
-			String cm = getCostingMethod();
-			if (cm == null || cm.length() == 0
-				|| COSTINGMETHOD_StandardCosting.equals(cm))
-				setIsCalculated(false);
-			else
-				setIsCalculated(true);
-		}
-		else
-		{
-			if (isCalculated())
-				setIsCalculated(false);
-			if (getCostingMethod() != null)
-				setCostingMethod(null);
-		}*/
-		
+		// All cost elements must have the org set to 0
 		if (getAD_Org_ID() != 0)
 			setAD_Org_ID(0);
+		
 		return true;
 	}	//	beforeSave
 	
@@ -280,49 +284,33 @@ public class MCostElement extends X_M_CostElement
 	 */
 	protected boolean beforeDelete ()
 	{
-		String cm = getCostingMethod();
-		if (cm == null
-			|| !COSTELEMENTTYPE_Material.equals(getCostElementType()))
-			return true;
 		
-		//	Costing Methods on AS level
-		MAcctSchema[] ass = MAcctSchema.getClientAcctSchema(getCtx(), getAD_Client_ID());
-		for (int i = 0; i < ass.length; i++)
-		{
-			if (ass[i].getCostingMethod().equals(getCostingMethod()))
-			{
-				log.saveError("CannotDeleteUsed", Msg.getElement(getCtx(), "C_AcctSchema_ID") 
-					+ " - " + ass[i].getName());
-				return false;
-			}
-		}
+		final Object[] parameter = new Object[] {getM_CostElement_ID()};
 		
-		//	Costing Methods on PC level
-		int M_Product_Category_ID = 0;
-		final String whereClause ="CostingMethod=?";
-		MProductCategoryAcct retValue = new Query(getCtx(), I_M_Product_Category_Acct.Table_Name, whereClause, null)
-		.setParameters(getCostingMethod())
-		.setClient_ID()
-		.first();
-		if (retValue != null)
-			M_Product_Category_ID = retValue.getM_Product_Category_ID();
-		if (M_Product_Category_ID != 0)
-		{
-			log.saveError("CannotDeleteUsed", Msg.getElement(getCtx(), "M_Product_Category_ID") 
-				+ " (ID=" + M_Product_Category_ID + ")");
-			return false;
-		}
+		// Delete the related details (#197)
+		String where = MCostDetail.COLUMNNAME_M_CostElement_ID + "=?";
+        StringBuffer sqlDelete = new StringBuffer("DELETE FROM " + MCostDetail.Table_Name + " WHERE ");
+        sqlDelete.append(where);
+        DB.executeUpdateEx(sqlDelete.toString(), parameter, get_TrxName());
+		
+		// Delete the related cost dimension (#197)
+		where = MCost.COLUMNNAME_M_CostElement_ID + "=?";
+		sqlDelete = new StringBuffer("DELETE FROM " + MCost.Table_Name + " WHERE ");
+		sqlDelete.append(where);
+        DB.executeUpdateEx(sqlDelete.toString(), parameter, get_TrxName());
+		
 		return true;
 	}	//	beforeDelete
 	
 	/**
+	 *  Deprecated as the cost element does not define the costing method.  Always returns false;
 	 * 	Is this a Costing Method
 	 *	@return true if not Material cost or no costing method.
 	 */
+	@Deprecated // #197
 	public boolean isCostingMethod()
 	{
-		return COSTELEMENTTYPE_Material.equals(getCostElementType())
-			&& getCostingMethod() != null;
+		return false;
 	}	//	isCostingMethod
 	
 	/**

--- a/migration/391lts-392/04390_0197_DeleteInactiveCostElements.xml
+++ b/migration/391lts-392/04390_0197_DeleteInactiveCostElements.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="#213 Add configurator for auto sync of AD changes." ReleaseNo="3.9.2" SeqNo="4390">
-    <Comments>See https://github.com/adempiere/adempiere/issues/197https://github.com/adempiere/adempiere/issues/197</Comments>
+  <Migration EntityType="D" Name="#197 Delete inactive Cost Elements in Garden World" ReleaseNo="3.9.2" SeqNo="4390">
+    <Comments>See https://github.com/adempiere/adempiere/issues/197</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="770" Action="D" Record_ID="104" Table="M_CostElement">
-        <Data AD_Column_ID="13452" Column="M_CostElement_ID" isNewNull="true" oldValue="104"/>
         <Data AD_Column_ID="13453" Column="AD_Client_ID" isNewNull="true" oldValue="11"/>
         <Data AD_Column_ID="13454" Column="AD_Org_ID" isNewNull="true" oldValue="0"/>
         <Data AD_Column_ID="13455" Column="IsActive" isNewNull="true" oldValue="false"/>
-        <Data AD_Column_ID="13456" Column="Created" isNewNull="true" oldValue="2005-07-31 11:24:31.0"/>
         <Data AD_Column_ID="13458" Column="Updated" isNewNull="true" oldValue="2018-10-14 07:56:20.0"/>
         <Data AD_Column_ID="13459" Column="UpdatedBy" isNewNull="true" oldValue="100"/>
         <Data AD_Column_ID="13461" Column="Description" isNewNull="true" isOldNull="true"/>
@@ -19,12 +17,13 @@
         <Data AD_Column_ID="13464" Column="IsCalculated" isNewNull="true" oldValue="false"/>
         <Data AD_Column_ID="59917" Column="IsDefault" isNewNull="true" oldValue="false"/>
         <Data AD_Column_ID="84916" Column="UUID" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="13452" Column="M_CostElement_ID" isNewNull="true" oldValue="104"/>
+        <Data AD_Column_ID="13456" Column="Created" isNewNull="true" oldValue="2005-07-31 11:24:31.0"/>
       </PO>
     </Step>
     <Step SeqNo="20" StepType="AD">
       <PO AD_Table_ID="770" Action="D" Record_ID="103" Table="M_CostElement">
         <Data AD_Column_ID="13455" Column="IsActive" isNewNull="true" oldValue="false"/>
-        <Data AD_Column_ID="13456" Column="Created" isNewNull="true" oldValue="2005-07-31 09:45:11.0"/>
         <Data AD_Column_ID="13458" Column="Updated" isNewNull="true" oldValue="2010-10-15 11:30:44.0"/>
         <Data AD_Column_ID="13459" Column="UpdatedBy" isNewNull="true" oldValue="100"/>
         <Data AD_Column_ID="13461" Column="Description" isNewNull="true" isOldNull="true"/>
@@ -34,6 +33,7 @@
         <Data AD_Column_ID="13454" Column="AD_Org_ID" isNewNull="true" oldValue="0"/>
         <Data AD_Column_ID="13462" Column="CostElementType" isNewNull="true" oldValue="M"/>
         <Data AD_Column_ID="13457" Column="CreatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="13456" Column="Created" isNewNull="true" oldValue="2005-07-31 09:45:11.0"/>
         <Data AD_Column_ID="13463" Column="CostingMethod" isNewNull="true" oldValue="A"/>
         <Data AD_Column_ID="13464" Column="IsCalculated" isNewNull="true" oldValue="false"/>
         <Data AD_Column_ID="59917" Column="IsDefault" isNewNull="true" oldValue="false"/>

--- a/migration/391lts-392/04390_0197_DeleteInactiveCostElements.xml
+++ b/migration/391lts-392/04390_0197_DeleteInactiveCostElements.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="#213 Add configurator for auto sync of AD changes." ReleaseNo="3.9.2" SeqNo="4390">
+    <Comments>See https://github.com/adempiere/adempiere/issues/197https://github.com/adempiere/adempiere/issues/197</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="770" Action="D" Record_ID="104" Table="M_CostElement">
+        <Data AD_Column_ID="13452" Column="M_CostElement_ID" isNewNull="true" oldValue="104"/>
+        <Data AD_Column_ID="13453" Column="AD_Client_ID" isNewNull="true" oldValue="11"/>
+        <Data AD_Column_ID="13454" Column="AD_Org_ID" isNewNull="true" oldValue="0"/>
+        <Data AD_Column_ID="13455" Column="IsActive" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="13456" Column="Created" isNewNull="true" oldValue="2005-07-31 11:24:31.0"/>
+        <Data AD_Column_ID="13458" Column="Updated" isNewNull="true" oldValue="2018-10-14 07:56:20.0"/>
+        <Data AD_Column_ID="13459" Column="UpdatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="13461" Column="Description" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="13460" Column="Name" isNewNull="true" oldValue="Average Invoice"/>
+        <Data AD_Column_ID="13462" Column="CostElementType" isNewNull="true" oldValue="M"/>
+        <Data AD_Column_ID="13457" Column="CreatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="13463" Column="CostingMethod" isNewNull="true" oldValue="I"/>
+        <Data AD_Column_ID="13464" Column="IsCalculated" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="59917" Column="IsDefault" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="84916" Column="UUID" isNewNull="true" isOldNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="770" Action="D" Record_ID="103" Table="M_CostElement">
+        <Data AD_Column_ID="13455" Column="IsActive" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="13456" Column="Created" isNewNull="true" oldValue="2005-07-31 09:45:11.0"/>
+        <Data AD_Column_ID="13458" Column="Updated" isNewNull="true" oldValue="2010-10-15 11:30:44.0"/>
+        <Data AD_Column_ID="13459" Column="UpdatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="13461" Column="Description" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="13460" Column="Name" isNewNull="true" oldValue="Average PO"/>
+        <Data AD_Column_ID="13452" Column="M_CostElement_ID" isNewNull="true" oldValue="103"/>
+        <Data AD_Column_ID="13453" Column="AD_Client_ID" isNewNull="true" oldValue="11"/>
+        <Data AD_Column_ID="13454" Column="AD_Org_ID" isNewNull="true" oldValue="0"/>
+        <Data AD_Column_ID="13462" Column="CostElementType" isNewNull="true" oldValue="M"/>
+        <Data AD_Column_ID="13457" Column="CreatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="13463" Column="CostingMethod" isNewNull="true" oldValue="A"/>
+        <Data AD_Column_ID="13464" Column="IsCalculated" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="59917" Column="IsDefault" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="84916" Column="UUID" isNewNull="true" isOldNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="770" Action="D" Record_ID="102" Table="M_CostElement">
+        <Data AD_Column_ID="13452" Column="M_CostElement_ID" isNewNull="true" oldValue="102"/>
+        <Data AD_Column_ID="13453" Column="AD_Client_ID" isNewNull="true" oldValue="11"/>
+        <Data AD_Column_ID="13454" Column="AD_Org_ID" isNewNull="true" oldValue="0"/>
+        <Data AD_Column_ID="13455" Column="IsActive" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="13456" Column="Created" isNewNull="true" oldValue="2005-07-31 09:43:59.0"/>
+        <Data AD_Column_ID="13458" Column="Updated" isNewNull="true" oldValue="2010-10-15 11:30:44.0"/>
+        <Data AD_Column_ID="13459" Column="UpdatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="13461" Column="Description" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="13460" Column="Name" isNewNull="true" oldValue="Fifo"/>
+        <Data AD_Column_ID="13462" Column="CostElementType" isNewNull="true" oldValue="M"/>
+        <Data AD_Column_ID="13457" Column="CreatedBy" isNewNull="true" oldValue="100"/>
+        <Data AD_Column_ID="13463" Column="CostingMethod" isNewNull="true" oldValue="F"/>
+        <Data AD_Column_ID="13464" Column="IsCalculated" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="59917" Column="IsDefault" isNewNull="true" oldValue="false"/>
+        <Data AD_Column_ID="84916" Column="UUID" isNewNull="true" isOldNull="true"/>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Fixes #197.  

Changes allow GenerateCostDetails to delete cost details related to inactive cost elements. 

Cost Elements can be deleted and will delete the related cost dimensions and cost details.  

Only one active default cost element per client is allowed and only one element of each cost type per client is allowed.  

Inactive cost elements in GW client have been removed.