### PR TITLE
#431 Fixes the way totals are grouped in the report dataengine.

### DIFF
--- a/base/src/org/compiere/print/PrintDataColumn.java
+++ b/base/src/org/compiere/print/PrintDataColumn.java
@@ -24,6 +24,10 @@ package org.compiere.print;
  *
  * 	@author 	Jorg Janke
  * 	@version 	$Id: PrintDataColumn.java,v 1.2 2006/07/30 00:53:02 jjanke Exp $
+ * 
+ *  @author Michael McKay, mckayERP@gmail.com
+ * 		<li>BR [ <a href="https://github.com/adempiere/adempiere/issues/431">#431</a> ] Report Groups do not handle single values well
+
  */
 public class PrintDataColumn
 {
@@ -59,7 +63,24 @@ public class PrintDataColumn
 	private int			m_columnSize;
 	private String		m_alias;
 	private boolean		m_pageBreak;
-	private String m_FormatPattern;
+	private String 		m_FormatPattern;
+	
+	/** The sort order index or -1 if not set.  
+	 *  Lower numbers are sorted first.  If there
+	 *  is no sort order index or the sort order index
+	 *  is the same for two columns, sorting will be
+	 *  assumed to occur in the order of display of 
+	 *  the columns.  The sort order affects the level
+	 *  of the groups in the report.   
+	 */
+	private int			sortOrderIndex = -1;
+
+	/** The display order index or -1 if not set.  
+	 *  Lower numbers are displayed on the left.  If there
+	 *  is no display order index (<0) or the display order index
+	 *  is the same for two columns, the display order is undefined.   
+	 */
+	private int			displayOrderIndex = -1;
 
 	/*************************************************************************/
 
@@ -141,6 +162,34 @@ public class PrintDataColumn
 	
 	public String getFormatPattern() {
 		return m_FormatPattern;
+	}
+	
+	/**
+	 * @return the sortOrderIndex
+	 */
+	public int getSortOrderIndex() {
+		return sortOrderIndex;
+	}
+	
+	/**
+	 * @param sortOrderIndex the sortOrderIndex to set
+	 */
+	public void setSortOrderIndex(int sortOrderIndex) {
+		this.sortOrderIndex = sortOrderIndex;
+	}
+	
+	/**
+	 * @return the displayOrderIndex
+	 */
+	public int getDisplayOrderIndex() {
+		return displayOrderIndex;
+	}
+	
+	/**
+	 * @param displayOrderIndex the displayOrderIndex to set
+	 */
+	public void setDisplayOrderIndex(int displayOrderIndex) {
+		this.displayOrderIndex = displayOrderIndex;
 	}
 
 }	//	PrintDataColumn

--- a/base/src/org/compiere/print/PrintDataGroup.java
+++ b/base/src/org/compiere/print/PrintDataGroup.java
@@ -63,7 +63,7 @@ public class PrintDataGroup
 	}	//	addGroup
 
 	/**
-	 * 	Get Grouyp Column Count.
+	 * 	Get Group Column Count.
 	 *  TOTAL is included as a column
 	 * 	@return number of groups
 	 */


### PR DESCRIPTION
Fixes #431.

Groupings were originally done in the order of display not the order of sorting/grouping.  This change adds a recursive method that checks the groupings in the correct order and adds the summary functions, if any.  Groups can be displayed in any column and the summaries will respect the sort order/groupings.

To see the effects, try these steps before and after the code changes:

1. In GardenWorld, add an invoice to the tree farm for a plum tree and set the project on the invoice header to standard.  Complete the invoice.  (You only need do this once to create the project dimension).
2. Open the aging report and select the current date, account date, not sales transactions and show invoices.
3. Modify the print format to show the currency, business partner group, business partner, project, invoice and open amount.
4. Set the order by and group by on the first four columns to match the displayed order.
5. Set the open amount function to sum

Run the report.  Note the results are ok.  Change the sort order of the fields  to put project at the top without changing the display order and try again.  The result are a bit wonky.

![image](https://user-images.githubusercontent.com/5507616/47055847-8e1f3480-d187-11e8-9b2e-9da8b1938520.png)


With this change, the summary results are consist and follow the sort order/grouping regardless of the column position of the grouped column.

With the report sorted by project but with the project displayed in the fourth column, it looks like this:

![image](https://user-images.githubusercontent.com/5507616/47055570-ff5de800-d185-11e8-90a6-b1a6269d1239.png)
