### PR TITLE
#421 Ensures embedded tabs are updated

### DIFF
--- a/client/src/org/compiere/grid/GridController.java
+++ b/client/src/org/compiere/grid/GridController.java
@@ -159,7 +159,8 @@ import org.compiere.util.Util;
  * @contributor fer_luck @ centuryon  FR [ 1757088 ]
  * 
  * @author mckayERP www.mckayERP.com
- * 				<li> #283 GridController in swing will not set value to null in vetoableChange 
+ * 		<li> BF [ <a href="https://github.com/adempiere/adempiere/issues/281">#283</a> ] GridController in swing will not set value to null in vetoableChange
+ * 		<li> BF [ <a href="https://github.com/adempiere/adempiere/issues/421">#421</a> ] Embedded tab is not updated
  */
 public class GridController extends CPanel
 	implements DataStatusListener, ListSelectionListener, Evaluatee,
@@ -756,6 +757,7 @@ public class GridController extends CPanel
 			return;
 		cardLayout.first(cardPanel);
 		m_singleRow = true;
+		m_mTab.dataRefresh(m_mTab.getCurrentRow());  // Fix for #421
 		dynamicDisplay(0);
 	//	vPanel.requestFocus();
 	}   //  switchSingleRow


### PR DESCRIPTION
Fixes #421.

In a window tab that has an embedded tab, like the Bill of Materials & Formula window, its possible to have the embedded tab and header record out of sync when there are several header records.  This happens when the header is put in grid view and then sorted differently by clicking on a column. On switching back to the form view, the embedded tab will show records associated with the original header, not the currently displayed header.

The fix is simply to refresh the tab data when the switch from grid to form view is made.