### PR TITLE
#2120 Add custom name for export file from payment print form

### DIFF
--- a/base/src/org/compiere/util/PaymentExportList.java
+++ b/base/src/org/compiere/util/PaymentExportList.java
@@ -17,8 +17,12 @@
 package org.compiere.util;
 
 import org.compiere.model.MBPBankAccount;
+import org.compiere.model.MBank;
+import org.compiere.model.MBankAccount;
+import org.compiere.model.MPaySelection;
 import org.compiere.model.MPaySelectionCheck;
 import org.compiere.model.MPayment;
+import org.compiere.model.MPaymentBatch;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -62,6 +66,8 @@ public abstract class PaymentExportList implements PaymentExport {
 	private int exportedPayments = 0;
 	/**	Error Message	*/
 	private StringBuffer errorMessage = new StringBuffer();
+	/**	File	*/
+	private File file = null;
 	
 	/**
 	 * Open File Writer
@@ -75,6 +81,7 @@ public abstract class PaymentExportList implements PaymentExport {
 		//	Open it
 		try {
 			fileWriter = new FileWriter(file);
+			this.file = file;
 		} catch (IOException e) {
 			addError(e.getLocalizedMessage());
 		}
@@ -97,6 +104,101 @@ public abstract class PaymentExportList implements PaymentExport {
 		} catch (IOException e) {
 			addError(e.getLocalizedMessage());
 		}
+	}
+	
+	/**
+	 * Open File from Payment Selection
+	 * @param file
+	 * @param checks
+	 */
+	public void openFileWriter(File file, List<MPaySelectionCheck> checks) {
+		MPaySelectionCheck check = checks.get(0);
+		MPaySelection paymentSelection = check.getParent();
+		MBankAccount bankAccount = MBankAccount.get(Env.getCtx(), paymentSelection.getC_BankAccount_ID());
+		MBank bank = MBank.get(Env.getCtx(), bankAccount.getC_Bank_ID());
+		String fileName = getFileName(file, bank.getName(), paymentSelection.getDocumentNo());
+		openFileWriter(fileName);
+	}
+	
+	/**
+	 * Open File from Payments
+	 * @param file
+	 * @param bankAccount
+	 * @param payments
+	 * @param suffix
+	 */
+	public void openFileWriter(File file, MBankAccount bankAccount, List<MPayment> payments, String suffix) {
+		if(Util.isEmpty(suffix)) {
+			suffix = "";
+		}
+		MPayment firstPayment = payments.get(0);
+		MPaymentBatch paymentBatch = (MPaymentBatch) firstPayment.getC_PaymentBatch();
+		MBank bank = MBank.get(Env.getCtx(), bankAccount.getC_Bank_ID());
+		String fileName = getFileName(file, bank.getName(), paymentBatch.getDocumentNo() + suffix);
+		openFileWriter(fileName);
+	}
+	
+	/**
+	 * Open file with new name and delete if exist
+	 * @param file
+	 * @param bankName
+	 * @param documentNo
+	 */
+	public void openFileWriter(File file, String bankName, String documentNo) {
+		String fileName = getFileName(file, bankName, documentNo);
+		openFileWriter(fileName);
+	}
+	
+	/**
+	 * Open File with a new name
+	 * @param file
+	 * @param newName
+	 */
+	public void openFileWriter(String newName) {
+		File newFile = new File(newName);
+		deleteIfExist(newFile);
+		openFileWriter(newFile);
+	}
+	
+	/**
+	 * Get Parent File Path
+	 * @param file
+	 * @return
+	 */
+	public String getParentFileName(File file) {
+		StringBuffer pathName = new StringBuffer();
+		if(file.isFile() || !file.exists()) {
+			pathName.append(file.getParent());
+		} else {
+			pathName.append(file.getAbsolutePath());
+		}
+		//	Return
+		return pathName.toString();
+	}
+	
+	/**
+	 * Get File Name for document
+	 * @param file
+	 * @param bankName
+	 * @param documentNo
+	 * @return
+	 */
+	public String getFileName(File file, String bankName, String documentNo) {
+		if(file == null) {
+			return null;
+		}
+		//	Extension
+		String extension = ".txt";
+		//	Set new File Name
+		StringBuffer pathName = new StringBuffer(getParentFileName(file));
+		//	Add Separator
+		pathName.append(File.separator)
+				.append(bankName)
+				.append("_")
+				.append(documentNo)
+				.append(extension);
+		//	Return
+		return pathName.toString().replace(" ", "_");
 	}
 	
 	/**
@@ -364,6 +466,14 @@ public abstract class PaymentExportList implements PaymentExport {
 		}
 		//	default
 		return null;
+	}
+	
+	/**
+	 * Get File Name of generated TXT
+	 * @return
+	 */
+	public File getFile() {
+		return file;
 	}
 	
 }	//	PaymentExport

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WPayPrint.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WPayPrint.java
@@ -361,6 +361,9 @@ public class WPayPrint extends PayPrint implements IFormController, EventListene
 				{
 					PaymentExportList custom = (PaymentExportList)clazz.newInstance();
 					no = custom.exportToFile(paySelectionChecks, tempFile, error);
+					if(custom.getFile() != null) {
+						tempFile = custom.getFile();
+					}
 				}
 				else if (PaymentExport.class.isAssignableFrom(clazz))
 				{
@@ -381,7 +384,7 @@ public class WPayPrint extends PayPrint implements IFormController, EventListene
 				log.log(Level.SEVERE, error.toString(), e);
 			}
 			if (no >= 0) {
-				Filedownload.save(new FileInputStream(tempFile), "plain/text", "paymentExport.txt");
+				Filedownload.save(new FileInputStream(tempFile), "plain/text", tempFile.getName());
 				FDialog.info(windowNo, form, "Saved",
 						Msg.getMsg(Env.getCtx(), "NoOfLines") + "=" + no);
 
@@ -548,7 +551,7 @@ public class WPayPrint extends PayPrint implements IFormController, EventListene
 		if (paySelectionChecks == null || paySelectionChecks.size() == 0)
 		{
 			FDialog.error(windowNo, form, "VPayPrintNoRecords",
-				"(" + Msg.translate(Env.getCtx(), "C_PaySelectionLine_ID") + " #0");
+				"(" + Msg.translate(Env.getCtx(), "C_PaySelectionLine_ID") + " #0)");
 			return false;
 		}
 		paymentBatch = MPaymentBatch.getForPaySelection (Env.getCtx(), paySelectionId, null);


### PR DESCRIPTION
Fixes #2120 

Hi all, this pull request will be allows create a file for export payment with custom name, see a example: 

![screenshot_20181106_155800](https://user-images.githubusercontent.com/2333092/48090426-3ea7b380-e1dd-11e8-86ea-1ffa02a761c9.png)
![screenshot_20181106_155847](https://user-images.githubusercontent.com/2333092/48090623-cf7e8f00-e1dd-11e8-9ab8-9dc62bb629f1.png)


