### PR TITLE
Bugfix/#2083 remove migration apply

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -46,10 +46,11 @@
 	<exec dir="${env_directory}" executable="/bin/bash" failonerror="true">
     	<arg value="${RUN_DBRestore}"/>
   	</exec>
-  	
+  	<!--
   	<echo message="Run Migrate XML"/>
 	<exec dir="${AD_directory}" executable="/bin/bash" failonerror="true">
     	<arg value="${RUN_MigrateXML}"/>
   	</exec>
+  	-->
   </target>
 </project>

--- a/utils/myEnvironment_CI.sh
+++ b/utils/myEnvironment_CI.sh
@@ -17,7 +17,7 @@ echo Setting myEnvironment ....
 #	If not in the path, provide a link called netscape to your browser
 
 # 	Homes ...
-ADEMPIERE_HOME=$HOME/build/adempiere/adempiere/adempiere/Adempiere
+ADEMPIERE_HOME=$TRAVIS_BUILD_DIR/adempiere/Adempiere
 export ADEMPIERE_HOME
 #JAVA_HOME=/usr/local/jdk8
 #export JAVA_HOME


### PR DESCRIPTION
Hi everybody. This pull request is for comment a lines for travis build, the current steps for apply on travis are:
1.  Run build.xml: It allows validate bad syntax, library or source dependence unresolved and complete build of ADempiere project
2. Run Setup: it run a silent setup for make a deploy of ADempiere
3. Run DB Import: allows import a adempiere user and create Database
4. Run DB restore: restore a seed from source /data
5. **Run Migration Apply XML: Apply all XML for version** (here is error)

The problem is that when is runned all XML the log for travis is too long and running is ended without complete log of sucess.

I search some pages for find a fixed of it:
- https://github.com/travis-ci/travis-ci/issues/1382
- https://github.com/travis-ci/docs-travis-ci-com/issues/281
- https://github.com/travis-ci/travis-ci/issues/1113
- [Timeout](https://stackoverflow.com/questions/26082444/how-to-work-around-travis-cis-4mb-output-limit)

Meanwhile, I will to comment line for build on Step of Run Migration Apply.
fixes #2083 

Best regard