### PR TITLE
#2130 Enhanced validation for active employee

### DIFF
--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHREmployee.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHREmployee.java
@@ -116,7 +116,9 @@ public class MHREmployee extends X_HR_Employee
 		StringBuffer whereClause = new StringBuffer();
 		whereClause.append("EXISTS(SELECT 1 FROM HR_Employee e " + 
 				"WHERE e.C_BPartner_ID = C_BPartner.C_BPartner_ID " +
-				"AND e.EmployeeStatus = '13' ");
+				"AND (e.EmployeeStatus = ? OR EmployeeStatus IS NULL) ");
+		//	For Active
+		params.add(MHREmployee.EMPLOYEESTATUS_Active);
 		//	look if it is a not regular payroll
 		MHRPayroll payroll = MHRPayroll.getById(process.getCtx(), process.getHR_Payroll_ID(), process.get_TrxName());
 		// This payroll not content periods, NOT IS a Regular Payroll > ogi-cd 28Nov2007

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHREmployee.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHREmployee.java
@@ -114,7 +114,9 @@ public class MHREmployee extends X_HR_Employee
 	{
 		List<Object> params = new ArrayList<Object>();
 		StringBuffer whereClause = new StringBuffer();
-		whereClause.append(" C_BPartner.C_BPartner_ID IN (SELECT e.C_BPartner_ID FROM HR_Employee e WHERE 1=1 ");
+		whereClause.append("EXISTS(SELECT 1 FROM HR_Employee e " + 
+				"WHERE e.C_BPartner_ID = C_BPartner.C_BPartner_ID " +
+				"AND e.EmployeeStatus = '13' ");
 		//	look if it is a not regular payroll
 		MHRPayroll payroll = MHRPayroll.getById(process.getCtx(), process.getHR_Payroll_ID(), process.get_TrxName());
 		// This payroll not content periods, NOT IS a Regular Payroll > ogi-cd 28Nov2007
@@ -175,12 +177,15 @@ public class MHREmployee extends X_HR_Employee
 		return list.toArray(new MBPartner[list.size()]);
 	}	//	getEmployees
 	
-	public static MHREmployee getActiveEmployee(Properties ctx, int partnerId, String trxName)
-	{
-		return new Query(ctx, Table_Name, COLUMNNAME_C_BPartner_ID+"=?", trxName)
+	public static MHREmployee getActiveEmployee(Properties ctx, int partnerId, String trxName) {
+		
+		List<Object> params = new ArrayList<Object>();
+		params.add(partnerId);
+		params.add(MHREmployee.EMPLOYEESTATUS_Active);
+		return new Query(ctx, Table_Name, COLUMNNAME_C_BPartner_ID+"=? AND (EmployeeStatus = ? OR EmployeeStatus IS NULL)", trxName)
 							.setOnlyActiveRecords(true)
-							.setParameters(partnerId)
-							.setOrderBy(COLUMNNAME_HR_Employee_ID+" DESC") // just in case...
+							.setParameters(params)
+							.setOrderBy(COLUMNNAME_StartDate+" DESC") // just in case...
 							.first();
 	}
 


### PR DESCRIPTION
Fixes: #2130
Hi everyone, here a pull request for validate active employee for payroll, a example:

I have two employees:
 - Garden Admin
 - Joe Block

Joe Block also is a customer, currently if Joe Block is not from payroll then I must change flag **IsActive** to **N**, it is not good if we need use Joe Block as a customer.

This change just make a validation from **Employee Status** (if it is setted) and sort by **Start Date** field instead **HR_Employee_ID**

![screenshot_20181108_112718](https://user-images.githubusercontent.com/2333092/48208582-83e8f400-e349-11e8-8c56-ba022bcc08f5.png)

