### PR TITLE
#2167, Add enhancement for allows file types, reference to issue:

### DIFF
--- a/base/src/org/compiere/model/MAttachment.java
+++ b/base/src/org/compiere/model/MAttachment.java
@@ -43,7 +43,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 import org.compiere.util.MimeType;
 import org.w3c.dom.Document;
@@ -63,7 +62,9 @@ import org.xml.sax.SAXException;
   * @author Silvano Trinchero
  *      <li>BF [ 2992291] MAttachment.addEntry not closing streams if an exception occur
  *        http://sourceforge.net/tracker/?func=detail&aid=2992291&group_id=176962&atid=879332
- *
+ *	@author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ *	<li> FR [ 2167 ] Validate MimeType and file extension
+ * 	@see https://github.com/adempiere/adempiere/issues/2167
  *  @version $Id: MAttachment.java,v 1.4 2006/07/30 00:58:37 jjanke Exp $
  */
 public class MAttachment extends X_AD_Attachment
@@ -89,10 +90,6 @@ public class MAttachment extends X_AD_Attachment
 		.first();
 		return retValue;
 	}	//	get
-	
-	/**	Static Logger	*/
-	private static CLogger	s_log	= CLogger.getCLogger (MAttachment.class);
-
 	
 	/**************************************************************************
 	 * 	Standard Constructor
@@ -258,6 +255,13 @@ public class MAttachment extends X_AD_Attachment
 		log.fine("addEntry - " + file);
 		//
 		String name = file.getName();
+		//	Validate Mime Type
+		if(!MimeType.isValidMimeType(name)) {
+			log.severe("Invalid Mime Type for " + name + " only is allowed " + MimeType.getAllowedFileTypes());
+			log.severe("Restricted files " + MimeType.getRestrictedFileTypes());
+			return false;
+		}
+		
 		byte[] data = null;
 		
 		// F3P: BF [2992291] modified to be able to close streams in "finally" block 		

--- a/client/src/org/compiere/apps/Attachment.java
+++ b/client/src/org/compiere/apps/Attachment.java
@@ -49,6 +49,7 @@ import org.compiere.swing.CPanel;
 import org.compiere.swing.CTextArea;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
+import org.compiere.util.MimeType;
 import org.compiere.util.Msg;
 
 /**
@@ -535,6 +536,12 @@ public final class Attachment extends CDialog
 					System.getProperty("file.separator") +
 					m_attachment.getEntryName(index);
             File tempFile = new File(fileName);
+            //	Validate File Type
+            if(!MimeType.isValidMimeType(tempFile.getAbsolutePath())) {
+            	log.severe("Invalid Mime Type for " + tempFile.getName() + " only is allowed " + MimeType.getAllowedFileTypes());
+    			log.severe("Restricted files " + MimeType.getRestrictedFileTypes());
+    			return false;
+            }
             m_attachment.getEntryFile(index, tempFile);
         
             if (Env.isWindows())

--- a/migration/390lts-391/04405_2167_Allows_FileTypes.xml
+++ b/migration/390lts-391/04405_2167_Allows_FileTypes.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Validate MimeType and file extension #2167" ReleaseNo="3.9.1" SeqNo="4405">
+    <Comments>See: https://github.com/adempiere/adempiere/issues/2167</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="50009" Action="I" Record_ID="50150" Table="AD_SysConfig">
+        <Data AD_Column_ID="50192" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="50193" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="50187" Column="AD_SysConfig_ID">50150</Data>
+        <Data AD_Column_ID="50188" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="50189" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="50191" Column="Updated">2018-12-05 18:08:23.651</Data>
+        <Data AD_Column_ID="50190" Column="Created">2018-12-05 18:08:23.651</Data>
+        <Data AD_Column_ID="50194" Column="IsActive">true</Data>
+        <Data AD_Column_ID="50195" Column="Name">ATTACHMENT_FILE_TYPES_ALLOWED</Data>
+        <Data AD_Column_ID="50196" Column="Value">50000</Data>
+        <Data AD_Column_ID="50197" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="53271" Column="ConfigurationLevel">S</Data>
+        <Data AD_Column_ID="53270" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="84421" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="50009" Action="U" Record_ID="50150" Table="AD_SysConfig">
+        <Data AD_Column_ID="50196" Column="Value" oldValue="50000"> </Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="50009" Action="I" Record_ID="50151" Table="AD_SysConfig">
+        <Data AD_Column_ID="50192" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="50193" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="50187" Column="AD_SysConfig_ID">50151</Data>
+        <Data AD_Column_ID="50188" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="50189" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="50191" Column="Updated">2018-12-05 18:08:55.084</Data>
+        <Data AD_Column_ID="50190" Column="Created">2018-12-05 18:08:55.084</Data>
+        <Data AD_Column_ID="50194" Column="IsActive">true</Data>
+        <Data AD_Column_ID="50195" Column="Name">ATTACHMENT_FILE_TYPES_RESTRICTED</Data>
+        <Data AD_Column_ID="50196" Column="Value">.exe, .sh, .py, .run, .msi, .bat</Data>
+        <Data AD_Column_ID="50197" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="53271" Column="ConfigurationLevel">S</Data>
+        <Data AD_Column_ID="53270" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="84421" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="50009" Action="U" Record_ID="50150" Table="AD_SysConfig">
+        <Data AD_Column_ID="53271" Column="ConfigurationLevel" oldValue="S">C</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="50009" Action="U" Record_ID="50151" Table="AD_SysConfig">
+        <Data AD_Column_ID="53271" Column="ConfigurationLevel" oldValue="S">C</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Hi all, this issue allows define if a file can be attached to record or not.

Now you can configure the allowed files and restricted files with a little change on **System Configurator** window:

The follow is variable used for allowed files and restricted
<pre>
ATTACHMENT_FILE_TYPES_ALLOWED
ATTACHMENT_FILE_TYPES_RESTRICTED
</pre>

The format for add new files for allows and restrict is simple, just use comma separed value:

<pre>
.pdf, .png, .jpg, .jpeg, .xls, .xlsx, .doc, .docx, .txt, .log, .properties
</pre>

Here a pic of result for restricted files:

![screenshot_20181205_193733](https://user-images.githubusercontent.com/2333092/49551345-4a15f980-f8c5-11e8-81ec-7f952f91cb6f.png)


Fixes: #2167