### PR TITLE
#2069, Remove bad constraint for C_BPartner_Location on M_Movement,

### DIFF
--- a/migration/390lts-391/04420_2069_Drop_Bad_Constraint.xml
+++ b/migration/390lts-391/04420_2069_Drop_Bad_Constraint.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Constraint error set BP Location on Material Movement #2069" ReleaseNo="3.9.1" SeqNo="4420">
+    <Comments>See: https://github.com/adempiere/adempiere/issues/2069</Comments>
+    <Step DBType="ALL" Parse="N" SeqNo="10" StepType="SQL">
+      <Comments>Remove constraint</Comments>
+      <SQLStatement>ALTER TABLE M_Movement DROP CONSTRAINT cbpartnerlocation_mmovement</SQLStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Hi Everybody, this issue remove a bad constraint in **M_Movement** table, the problem is that the column **M_Movement.C_BPartner_Location_ID** have a constraint that make reference to **C_Location.C_Location_ID** instead **C_BPartner_Location.C_BPartner_Location_ID**


Fixes: #2069 
reference to issue: https://github.com/adempiere/adempiere/issues/2069