### PR TITLE
adempiere #2031 Field LandedCostType in LandedCost

### DIFF
--- a/base/src/org/compiere/model/MInvoiceLine.java
+++ b/base/src/org/compiere/model/MInvoiceLine.java
@@ -1139,6 +1139,8 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 			MLandedCostAllocation lca = new MLandedCostAllocation (this, lcs[0].getM_CostElement_ID());
 			lca.setM_Product_ID(iol.getM_Product_ID());
 			lca.setM_AttributeSetInstance_ID(iol.getM_AttributeSetInstance_ID());
+			lca.setC_LandedCostType_ID(lcs[0].getC_LandedCostType_ID());
+			lca.setM_InOutLine_ID(iol.getM_InOutLine_ID());
 			BigDecimal base = iol.getBase(LandedCostDistribution);
 			lca.setBase(base);
 			// MZ Goodwill


### PR DESCRIPTION
https://github.com/adempiere/adempiere/issues/2031

**error:**
For the case _various Landedcosts for one Invoiceline_ the fields _c_Landedcosttype_ID_ and _m_Inoutline_ID_ are not updated.