### PR TITLE
#421 Prevent unnecessary error on switch from grid to form view

### DIFF
--- a/client/src/org/compiere/grid/GridController.java
+++ b/client/src/org/compiere/grid/GridController.java
@@ -757,7 +757,14 @@ public class GridController extends CPanel
 			return;
 		cardLayout.first(cardPanel);
 		m_singleRow = true;
-		m_mTab.dataRefresh(m_mTab.getCurrentRow());  // Fix for #421
+		
+		// Refresh the data to ensure embedded tabs are updated with
+		// the selected row. Check if the table model is open before 
+		// trying to refresh.  It may not have been opened yet, in 
+		// which case, the refresh will cause an error. See issue #421
+		if (m_mTab.getTableModel().isOpen()) 
+			m_mTab.dataRefresh(m_mTab.getCurrentRow());  // Fix for #421
+		
 		dynamicDisplay(0);
 	//	vPanel.requestFocus();
 	}   //  switchSingleRow


### PR DESCRIPTION
Fixes #421.  

The refresh of data on the switch from grid to form view causes an error when the table model has not been opened.  A test to check that the table is open is required.
