### PR TITLE
Fixed error with Table lookup when it is referenced with key column as

### DIFF
--- a/base/src/org/adempiere/util/ProcessAbstractClassGenerator.java
+++ b/base/src/org/adempiere/util/ProcessAbstractClassGenerator.java
@@ -17,8 +17,10 @@ import java.util.logging.Level;
 
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.Adempiere;
+import org.compiere.model.MColumn;
 import org.compiere.model.MProcess;
 import org.compiere.model.MProcessPara;
+import org.compiere.model.MRefTable;
 import org.compiere.process.SvrProcess;
 import org.compiere.util.CLogger;
 import org.compiere.util.DisplayType;
@@ -399,7 +401,8 @@ public class ProcessAbstractClassGenerator {
 		if (DisplayType.Location == parameter.getAD_Reference_ID()
 				|| DisplayType.Locator == parameter.getAD_Reference_ID()
 				|| (DisplayType.isLookup(parameter.getAD_Reference_ID()) 
-						&& DisplayType.List != parameter.getAD_Reference_ID())) {
+						&& DisplayType.List != parameter.getAD_Reference_ID()
+						&& !isReturnString(parameter))) {
 			variableName.append("Id");
 		}
 		//	
@@ -435,7 +438,8 @@ public class ProcessAbstractClassGenerator {
 		if (DisplayType.Location == parameter.getAD_Reference_ID()
 				|| DisplayType.Locator == parameter.getAD_Reference_ID()
 				|| (DisplayType.isLookup(parameter.getAD_Reference_ID())
-				&& DisplayType.List != parameter.getAD_Reference_ID())) {
+						&& DisplayType.List != parameter.getAD_Reference_ID()
+						&& !isReturnString(parameter))) {
 			variableName.append("Id");
 		}
 
@@ -458,7 +462,8 @@ public class ProcessAbstractClassGenerator {
 		if (DisplayType.Location == parameter.getAD_Reference_ID()
 				|| DisplayType.Locator == parameter.getAD_Reference_ID()
 				|| (DisplayType.isLookup(parameter.getAD_Reference_ID())
-				&& DisplayType.List != parameter.getAD_Reference_ID())) {
+						&& DisplayType.List != parameter.getAD_Reference_ID()
+						&& !isReturnString(parameter))) {
 			variableName.append("Id");
 		}
 
@@ -473,7 +478,8 @@ public class ProcessAbstractClassGenerator {
 	private String getType(MProcessPara parameter) {
 		Class<?> clazz = DisplayType.getClass(parameter.getAD_Reference_ID(), true);
 		//	Verify Type
-		if (clazz == String.class && DisplayType.isText(parameter.getAD_Reference_ID())) {
+		if (clazz == String.class && DisplayType.isText(parameter.getAD_Reference_ID())
+				|| (DisplayType.isLookup(parameter.getAD_Reference_ID()) && isReturnString(parameter))) {
 			return "String";
 		} else if (clazz == Integer.class) {
 			return "int";
@@ -621,5 +627,25 @@ public class ProcessAbstractClassGenerator {
 				.replaceAll(" ", "")
 				.replaceAll("/","");
 		return replaceSpecialCharacter(parameterName);
+	}
+	
+	/**
+	 * Verify if key column is string
+	 * Can be useful for EntytyType
+	 * @param processParameter
+	 * @return
+	 */
+	boolean isReturnString(MProcessPara processParameter) {
+		if(DisplayType.Table == processParameter.getAD_Reference_ID()) {
+			MRefTable referenceTable = MRefTable.getById(Env.getCtx(), processParameter.getAD_Reference_Value_ID());
+			if(referenceTable != null) {
+				MColumn keyColumn = MColumn.get(Env.getCtx(), referenceTable.getAD_Key());
+				if(DisplayType.isText(keyColumn.getAD_Reference_ID())) {
+					return true;
+				}
+			}
+		}
+		//	
+		return false;
 	}
 }


### PR DESCRIPTION
Hi everyone this pull request resolve a error when a abstract class is generated from ADempiere.

When a parameter is created as **Table** and it make reference to table with a key column as String, the parameter is called from process like ID instead String, see:
![screenshot_20190128_095119](https://user-images.githubusercontent.com/2333092/51841831-e79a1200-22e5-11e9-8f62-c697a3b80267.png)
![screenshot_20190128_095221](https://user-images.githubusercontent.com/2333092/51841832-e79a1200-22e5-11e9-969e-493155bd8bfb.png)
![screenshot_20190128_095258](https://user-images.githubusercontent.com/2333092/51841833-e832a880-22e5-11e9-9a11-b92046b0aff8.png)
![screenshot_20190128_095421](https://user-images.githubusercontent.com/2333092/51841834-e832a880-22e5-11e9-99f2-094b338fefa4.png)
<pre>
===========> ExportSurrogateKeyToMigration.process: java.lang.NumberFormatException [32]
java.lang.NumberFormatException
	at java.math.BigDecimal.<init>(BigDecimal.java:494)
	at java.math.BigDecimal.<init>(BigDecimal.java:383)
	at java.math.BigDecimal.<init>(BigDecimal.java:806)
	at org.compiere.process.ProcessInfoParameter.getParameterAsInt(ProcessInfoParameter.java:123)
	at org.compiere.process.ProcessInfo.getParameterAsInt(ProcessInfo.java:1106)
	at org.compiere.process.SvrProcess.getParameterAsInt(SvrProcess.java:609)
	at org.spin.process.ExportSurrogateKeyToMigrationAbstract.prepare(ExportSurrogateKeyToMigrationAbstract.java:45)
	at org.compiere.process.SvrProcess.process(SvrProcess.java:174)
	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:128)
	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:160)
	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:105)
	at org.compiere.apps.ProcessCtl.startProcess(ProcessCtl.java:623)
	at org.compiere.apps.ProcessCtl.run(ProcessCtl.java:372)
	at java.lang.Thread.run(Thread.java:745)
</pre>

With this change, the abstract class is generated with correct parameter type:

![screenshot_20190128_100835](https://user-images.githubusercontent.com/2333092/51841835-e832a880-22e5-11e9-8e3c-a8c21201a408.png)


String, case "AD_EntityType" with "EntityType" as key column