### PR TITLE
Add Vertical Separator to the User Panel between Context and Preference

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/panel/UserPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/panel/UserPanel.java
@@ -96,13 +96,17 @@ public class UserPanel extends Vbox  implements EventListener
     	LayoutUtils.addSclass("desktop-header-font", context);
     	context.setParent(hbox);    	
 
+    	Separator sep = new Separator("vertical");
+    	sep.setBar(true);
+    	sep.setParent(hbox);
+
     	preference.setLabel(Msg.getMsg(Env.getCtx(), "Preference"));
     	preference.addEventListener(Events.ON_CLICK, this);
     	preference.setStyle("text-align:right");
     	LayoutUtils.addSclass("desktop-header-font", preference);
     	preference.setParent(hbox);
 
-    	Separator sep = new Separator("vertical");
+    	sep = new Separator("vertical");
     	sep.setBar(true);
     	sep.setParent(hbox);
 


### PR DESCRIPTION
Fixes #2320.

Makes it look like this.

![image](https://user-images.githubusercontent.com/5507616/52431326-fea2e600-2ad5-11e9-8342-31dfa8f20979.png)
