### PR TITLE
Turns the Doc Status Indicator text into a link and shows all fields in grid.

### DIFF
--- a/migration/391lts-392lts/04440_2340_ImproveDocumentStatusIndicators.xml
+++ b/migration/391lts-392lts/04440_2340_ImproveDocumentStatusIndicators.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="#2340 Document Status Indicator Improvements" ReleaseNo="3.9.2" SeqNo="4440">
+    <Comments>See https://github.com/adempiere/adempiere/issues/2340 and also https://github.com/adempiere/adempiere/issues/1243</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74901" Table="AD_Field">
+        <Data AD_Column_ID="176" Column="IsDisplayed" oldValue="true">false</Data>
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="110">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74900" Table="AD_Field">
+        <Data AD_Column_ID="176" Column="IsDisplayed" oldValue="true">false</Data>
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="100">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74903" Table="AD_Field">
+        <Data AD_Column_ID="176" Column="IsDisplayed" oldValue="true">false</Data>
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="130">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74902" Table="AD_Field">
+        <Data AD_Column_ID="176" Column="IsDisplayed" oldValue="true">false</Data>
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="120">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74904" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="140">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74905" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="150">110</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74906" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="160">120</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74908" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" isOldNull="true">130</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="90" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74908" Table="AD_Field">
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="100" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74899" Table="AD_Field">
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="110" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74898" Table="AD_Field">
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="120" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74897" Table="AD_Field">
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="130" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74896" Table="AD_Field">
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="140" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74895" Table="AD_Field">
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="150" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74892" Table="AD_Field">
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="160" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="74891" Table="AD_Field">
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid" oldValue="false">true</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/migration/391lts-392lts/04440_2340_ImproveDocumentStatusIndicators.xml
+++ b/migration/391lts-392lts/04440_2340_ImproveDocumentStatusIndicators.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
   <Migration EntityType="D" Name="#2340 Document Status Indicator Improvements" ReleaseNo="3.9.2" SeqNo="4440">
-    <Comments>See https://github.com/adempiere/adempiere/issues/2340 and also https://github.com/adempiere/adempiere/issues/1243</Comments>
+    <Comments>See https://github.com/adempiere/adempiere/issues/2340 and also https://github.com/adempiere/adempiere/issues/1243
+Do not show font/color fields. Remove the mandatory condition on the columns.</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="107" Action="U" Record_ID="74901" Table="AD_Field">
         <Data AD_Column_ID="176" Column="IsDisplayed" oldValue="true">false</Data>
@@ -84,6 +85,30 @@
     <Step SeqNo="160" StepType="AD">
       <PO AD_Table_ID="107" Action="U" Record_ID="74891" Table="AD_Field">
         <Data AD_Column_ID="62478" Column="IsDisplayedGrid" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="170" StepType="AD">
+      <Comments>Remove mandatory</Comments>
+      <PO AD_Table_ID="101" Action="U" Record_ID="74883" Table="AD_Column">
+        <Data AD_Column_ID="124" Column="IsMandatory" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="180" StepType="AD">
+      <Comments>Remove mandatory</Comments>
+      <PO AD_Table_ID="101" Action="U" Record_ID="74884" Table="AD_Column">
+        <Data AD_Column_ID="124" Column="IsMandatory" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="190" StepType="AD">
+      <Comments>Remove mandatory</Comments>
+      <PO AD_Table_ID="101" Action="U" Record_ID="74885" Table="AD_Column">
+        <Data AD_Column_ID="124" Column="IsMandatory" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="200" StepType="AD">
+      <Comments>Remove mandatory</Comments>
+      <PO AD_Table_ID="101" Action="U" Record_ID="74886" Table="AD_Column">
+        <Data AD_Column_ID="124" Column="IsMandatory" oldValue="true">false</Data>
       </PO>
     </Step>
   </Migration>

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/graph/WDocumentStatusIndicator.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/graph/WDocumentStatusIndicator.java
@@ -21,6 +21,7 @@ import org.adempiere.webui.component.Label;
 import org.adempiere.webui.component.Panel;
 import org.adempiere.webui.component.Row;
 import org.adempiere.webui.component.Rows;
+import org.adempiere.webui.component.ToolBarButton;
 import org.adempiere.webui.component.Window;
 import org.adempiere.webui.component.ZkCssHelper;
 import org.adempiere.webui.panel.ADForm;
@@ -83,20 +84,20 @@ public class WDocumentStatusIndicator extends Panel implements EventListener
 	 */
 	private void init()
 	{
-		Label nameLabel = new Label();
-		nameLabel.setText(m_documentStatus.getName());
+		// Appears as a link
+		ToolBarButton nameLabel = new ToolBarButton(m_documentStatus.getName());
+		nameLabel.setLabel(m_documentStatus.getName());
 		
-		nameLabel.setStyle("text-decoration: underline;");
 		statusLabel = new Label();
 		statusLabel.setWidth("60px");
 		
 		Hbox box = new Hbox();
-		box.setZclass("docStatus");
+		box.setSclass("docStatus");
 		box.appendChild(statusLabel);
 		box.appendChild(nameLabel);
 		appendChild(box);
 
-		this.addEventListener(Events.ON_CLICK, this);
+		nameLabel.addEventListener(Events.ON_CLICK, this);
 	}
 
 


### PR DESCRIPTION
Fixes #2340.
Fixes #1243 
Changes the component used in the dashboard Document Task panel to a ToolBarButton which appears as a link.  This is better than a label with underlined text as the cursor turns to a "finger" rather than a text I-bar when hovering over the field.  

The change also sets all fields in the Document Status Indicator window to "Is Displayed in Grid"="Y".

