### PR TITLE
#2347 WPayment.java has an error in the query: C_BPartner_ID is ambiguous.

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WPayment.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WPayment.java
@@ -745,7 +745,7 @@ public class WPayment extends Window
 		SQL = "SELECT a.C_BP_BankAccount_ID, NVL(b.Name, ' ')||'_'||NVL(a.AccountNo, ' ') AS Acct "
 			+ "FROM C_BP_BankAccount a"
 			+ " LEFT OUTER JOIN C_Bank b ON (a.C_Bank_ID=b.C_Bank_ID) "
-			+ "WHERE C_BPartner_ID=?"
+			+ "WHERE a.C_BPartner_ID=?"
 			+ "AND a.IsActive='Y' AND a.IsACH='Y'";
 		try
 		{


### PR DESCRIPTION
Fixes #2347 

The error is in the query that loads the business partner bank accounts for direct debit payments.  The C_BPartner_ID column was added to the C_Bank table in #1904 and so needs to be qualified in this query.