### PR TITLE
Add Documentation Generator from ADempiere

### DIFF
--- a/base/src/org/spin/process/GenerateDocsFromMenu.java
+++ b/base/src/org/spin/process/GenerateDocsFromMenu.java
@@ -1,0 +1,427 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.									  *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.spin.process;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.I_AD_Browse;
+import org.adempiere.model.MBrowse;
+import org.compiere.model.I_AD_Form;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.I_AD_Window;
+import org.compiere.model.MForm;
+import org.compiere.model.MMenu;
+import org.compiere.model.MProcess;
+import org.compiere.model.MWindow;
+import org.compiere.model.Query;
+import org.compiere.util.Util;
+import org.spin.util.docs.AbstractDocumentationSource;
+import org.spin.util.docs.AbstractTextConverter;
+import org.spin.util.docs.FunctionalDocsForForm;
+import org.spin.util.docs.FunctionalDocsForMenu;
+import org.spin.util.docs.FunctionalDocsForProcess;
+import org.spin.util.docs.FunctionalDocsForSmartBrowse;
+import org.spin.util.docs.FunctionalDocsForWindow;
+import org.spin.util.docs.IIndex;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * reStructuredText converter, it can be used for export a simple String to reStructuredText format
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public class GenerateDocsFromMenu extends GenerateDocsFromMenuAbstract {
+	@Override
+	protected void prepare() {
+		super.prepare();
+	}
+	
+	/**	Converter	*/
+	private AbstractTextConverter textConverter = null;
+	/**	Index Converter	*/
+	private AbstractTextConverter indexConverter = null;
+	/**	Created	*/
+	private int created = 0;
+	/**	Folder Name	*/
+	public static final String FOLDER_NAME = "functional-guide";
+
+	@Override
+	protected String doIt() throws Exception {
+		Class<?> clazz = Class.forName(getDocsExportFormat());
+		if (!AbstractTextConverter.class.isAssignableFrom(clazz)) {
+			throw new AdempiereException("@DocsExportFormat@ @NotMatched@");
+		}
+		//	Instance
+		textConverter = (AbstractTextConverter) clazz.newInstance();
+		indexConverter = (AbstractTextConverter) clazz.newInstance();
+		((IIndex) indexConverter).addGroup("Functional Guide", FOLDER_NAME, 1);
+		loadMenu();
+		loadProcess();
+		loadWindow();
+		loadForm();
+		loadSmartBrowse();
+		//	Save Main index
+		if(indexConverter.getMainIndex() != null
+				&& !Util.isEmpty(indexConverter.getMainIndexFileName())) {
+			String folderName = getDirectory();
+			String fileName = FOLDER_NAME + File.separator + textConverter.getMainIndexFileName();
+			if(!Util.isEmpty(fileName)) {
+				writeFile(folderName, fileName, indexConverter.getMainIndex().toString());
+			}
+		}
+		return "@Created@ " + created;
+	}
+	
+	/**
+	 * Load Menu for documents
+	 * @throws IOException 
+	 */
+	private void loadMenu() throws IOException {
+		StringBuffer whereClause = new StringBuffer("AD_Client_ID = " + getAD_Client_ID() + " AND IsSummary = 'N'");
+		if(getRecord_ID() > 0) {
+			whereClause.append(" AND ").append("AD_Menu_ID = ").append(getRecord_ID());
+		}
+		//	Get Result
+		MMenu menuList[] = MMenu.get(getCtx(), whereClause.toString(), get_TrxName());
+		if(menuList == null
+				|| menuList.length == 0) {
+			return;
+		}
+		String folderName = getDirectory() + File.separator + FunctionalDocsForMenu.FOLDER_NAME;
+		String fileName = textConverter.getIndexFileName();
+		if(!Util.isEmpty(fileName)) {
+			indexConverter.addHeaderIndexName(FunctionalDocsForMenu.FOLDER_NAME);
+			indexConverter.newLine();
+			indexConverter.addSection("Menu");
+			indexConverter.newLine();
+			((IIndex) indexConverter).addTreeDefinition(1, true);
+			((IIndex) indexConverter).addGroup("Menu", FunctionalDocsForMenu.FOLDER_NAME, 2);
+		}
+		//	
+		for(MMenu menu : menuList) {
+			//	For Menu
+			documentForMenu(menu, folderName);
+			textConverter.clear();
+		}
+		if(!Util.isEmpty(fileName)) {
+			writeFile(folderName, fileName, indexConverter.toString());
+		}
+		//	Clear
+		indexConverter.clear();
+	}
+	
+	/**
+	 * Load Process for documents
+	 * @throws IOException 
+	 */
+	private void loadProcess() throws IOException {
+		List<MProcess> processList = new Query(getCtx(), I_AD_Process.Table_Name, null, get_TrxName())
+				.setOnlyActiveRecords(true)
+				.setClient_ID()
+				.list();
+		//	Get Result
+		if(processList == null
+				|| processList.size() == 0) {
+			return;
+		}
+		String folderName = getDirectory() + File.separator + FunctionalDocsForProcess.FOLDER_NAME;
+		String fileName = textConverter.getIndexFileName();
+		if(!Util.isEmpty(fileName)) {
+			indexConverter.addHeaderIndexName(FunctionalDocsForProcess.FOLDER_NAME);
+			indexConverter.newLine();
+			indexConverter.addSection("Process");
+			indexConverter.newLine();
+			((IIndex) indexConverter).addTreeDefinition(1, true);
+			((IIndex) indexConverter).addGroup("Process", FunctionalDocsForProcess.FOLDER_NAME, 2);
+		}
+		//	
+		for(MProcess process : processList) {
+			//	For Process
+			documentForProcess(process, folderName);
+			textConverter.clear();
+		}
+		//	
+		if(!Util.isEmpty(fileName)) {
+			writeFile(folderName, fileName, indexConverter.toString());
+		}
+		//	Clear
+		indexConverter.clear();
+	}
+	
+	/**
+	 * Load window for documents
+	 * @throws IOException 
+	 */
+	private void loadWindow() throws IOException {
+		List<MWindow> windowList = new Query(getCtx(), I_AD_Window.Table_Name, null, get_TrxName())
+				.setOnlyActiveRecords(true)
+				.setClient_ID()
+				.list();
+		//	Get Result
+		if(windowList == null
+				|| windowList.size() == 0) {
+			return;
+		}
+		String folderName = getDirectory() + File.separator + FunctionalDocsForWindow.FOLDER_NAME;
+		String fileName = textConverter.getIndexFileName();
+		if(!Util.isEmpty(fileName)) {
+			indexConverter.addHeaderIndexName(FunctionalDocsForWindow.FOLDER_NAME);
+			indexConverter.newLine();
+			indexConverter.addSection("Windows");
+			indexConverter.newLine();
+			((IIndex) indexConverter).addTreeDefinition(1, true);
+			((IIndex) indexConverter).addGroup("Window", FunctionalDocsForProcess.FOLDER_NAME, 2);
+		}
+		//	
+		for(MWindow window : windowList) {
+			//	For Window
+			documentForWindow(window, folderName);
+			textConverter.clear();
+		}
+		if(!Util.isEmpty(fileName)) {
+			writeFile(folderName, fileName, indexConverter.toString());
+		}
+		//	Clear
+		indexConverter.clear();
+	}
+	
+	/**
+	 * Load Form for documents
+	 * @throws IOException 
+	 */
+	private void loadForm() throws IOException {
+		List<MForm> formList = new Query(getCtx(), I_AD_Form.Table_Name, null, get_TrxName())
+				.setOnlyActiveRecords(true)
+				.setClient_ID()
+				.list();
+		//	Get Result
+		if(formList == null
+				|| formList.size() == 0) {
+			return;
+		}
+		String folderName = getDirectory() + File.separator + FunctionalDocsForForm.FOLDER_NAME;
+		String fileName = textConverter.getIndexFileName();
+		if(!Util.isEmpty(fileName)) {
+			indexConverter.addHeaderIndexName(FunctionalDocsForForm.FOLDER_NAME);
+			indexConverter.newLine();
+			indexConverter.addSection("Forms");
+			indexConverter.newLine();
+			((IIndex) indexConverter).addTreeDefinition(1, true);
+			((IIndex) indexConverter).addGroup("Form", FunctionalDocsForProcess.FOLDER_NAME, 2);
+		}
+		//	
+		for(MForm form : formList) {
+			//	For Window
+			documentForForm(form, folderName);
+			textConverter.clear();
+		}
+		if(!Util.isEmpty(fileName)) {
+			writeFile(folderName, fileName, indexConverter.toString());
+		}
+		//	Clear
+		indexConverter.clear();
+	}
+	
+	/**
+	 * Load Smart Browse for documents
+	 * @throws IOException 
+	 */
+	private void loadSmartBrowse() throws IOException {
+		List<MBrowse> smartBrowseList = new Query(getCtx(), I_AD_Browse.Table_Name, null, get_TrxName())
+				.setOnlyActiveRecords(true)
+				.setClient_ID()
+				.list();
+		//	Get Result
+		if(smartBrowseList == null
+				|| smartBrowseList.size() == 0) {
+			return;
+		}
+		String folderName = getDirectory() + File.separator + FunctionalDocsForSmartBrowse.FOLDER_NAME;
+		String fileName = textConverter.getIndexFileName();
+		if(!Util.isEmpty(fileName)) {
+			indexConverter.addHeaderIndexName(FunctionalDocsForSmartBrowse.FOLDER_NAME);
+			indexConverter.newLine();
+			indexConverter.addSection("Smart Browsers");
+			indexConverter.newLine();
+			((IIndex) indexConverter).addTreeDefinition(1, true);
+			((IIndex) indexConverter).addGroup("Smart Browsers", FunctionalDocsForProcess.FOLDER_NAME, 2);
+		}
+		//	
+		for(MBrowse smartBrowse : smartBrowseList) {
+			//	For Window
+			documentForSmartBrowse(smartBrowse, folderName);
+			textConverter.clear();
+		}
+		if(!Util.isEmpty(fileName)) {
+			writeFile(folderName, fileName, indexConverter.toString());
+		}
+		//	Clear
+		indexConverter.clear();
+	}
+	
+	/**
+	 * Create Document for menu
+	 * @param process
+	 * @throws IOException 
+	 */
+	private void documentForMenu(MMenu menu, String folderName) throws IOException {
+		AbstractDocumentationSource documentGenerator = new FunctionalDocsForMenu();
+		boolean isOk = documentGenerator.createDocumentation(textConverter, menu);
+		if(!isOk) { 
+			return;
+		}
+		//	Get
+		if(!Util.isEmpty(textConverter.getIndexFileName())) {
+			documentGenerator.addIndex(indexConverter, menu);
+		}
+		//	
+		String fileName = getValidName(documentGenerator.getDocumentName());
+		//	Write
+		writeFile(folderName, fileName, textConverter.toString());
+		//	Add to list
+		addLog("@AD_Menu_ID@ " + menu.getName());
+		created++;
+	}
+	
+	/**
+	 * Create Document for process
+	 * @param process
+	 * @param folderName
+	 * @throws IOException 
+	 */
+	private void documentForProcess(MProcess process, String folderName) throws IOException {
+		AbstractDocumentationSource documentGenerator = new FunctionalDocsForProcess();
+		boolean isOk = documentGenerator.createDocumentation(textConverter, process);
+		if(!isOk) { 
+			return;
+		}
+		//	Get
+		if(!Util.isEmpty(textConverter.getIndexFileName())) {
+			documentGenerator.addIndex(indexConverter, process);
+		}
+		String fileName = getValidName(documentGenerator.getDocumentName());
+		//	Write
+		writeFile(folderName, fileName, textConverter.toString());
+		//	Add to list
+		addLog("@AD_Process_ID@ " + process.getName());
+		created++;
+	}
+	
+	/**
+	 * Create Document for Window
+	 * @param window
+	 * @param folderName
+	 * @throws IOException 
+	 */
+	private void documentForWindow(MWindow window, String folderName) throws IOException {
+		AbstractDocumentationSource documentGenerator = new FunctionalDocsForWindow();
+		boolean isOk = documentGenerator.createDocumentation(textConverter, window);
+		if(!isOk) { 
+			return;
+		}
+		//	Get
+		if(!Util.isEmpty(textConverter.getIndexFileName())) {
+			documentGenerator.addIndex(indexConverter, window);
+		}
+		String fileName = getValidName(documentGenerator.getDocumentName());
+		//	Write
+		writeFile(folderName, fileName, textConverter.toString());
+		//	Add to list
+		addLog("@AD_Window_ID@ " + window.getName());
+		created++;
+	}
+	
+	/**
+	 * Create Document for Form
+	 * @param form
+	 * @param folderName
+	 * @throws IOException 
+	 */
+	private void documentForForm(MForm form, String folderName) throws IOException {
+		AbstractDocumentationSource documentGenerator = new FunctionalDocsForForm();
+		boolean isOk = documentGenerator.createDocumentation(textConverter, form);
+		if(!isOk) { 
+			return;
+		}
+		//	Get
+		if(!Util.isEmpty(textConverter.getIndexFileName())) {
+			documentGenerator.addIndex(indexConverter, form);
+		}
+		String fileName = getValidName(documentGenerator.getDocumentName());
+		//	Write
+		writeFile(folderName, fileName, textConverter.toString());
+		//	Add to list
+		addLog("@AD_Form_ID@ " + form.getName());
+		created++;
+	}
+	
+	/**
+	 * Create Document for Smart Browse
+	 * @param smartBrowse
+	 * @param folderName
+	 * @throws IOException 
+	 */
+	private void documentForSmartBrowse(MBrowse smartBrowse, String folderName) throws IOException {
+		AbstractDocumentationSource documentGenerator = new FunctionalDocsForSmartBrowse();
+		boolean isOk = documentGenerator.createDocumentation(textConverter, smartBrowse);
+		if(!isOk) { 
+			return;
+		}
+		//	Get
+		if(!Util.isEmpty(textConverter.getIndexFileName())) {
+			documentGenerator.addIndex(indexConverter, smartBrowse);
+		}
+		String fileName = getValidName(documentGenerator.getDocumentName());
+		//	Write
+		writeFile(folderName, fileName, textConverter.toString());
+		//	Add to list
+		addLog("@AD_Browse_ID@ " + smartBrowse.getName());
+		created++;
+	}
+	
+	/**
+	 * Write file
+	 * @param folderName
+	 * @param fileName
+	 * @param value
+	 * @throws IOException
+	 */
+	private void writeFile(String folderName, String fileName, String value) throws IOException {
+		File exportDir = new File(folderName);
+		exportDir.mkdirs();
+		//	Create File
+		File exportFile = new File(folderName + File.separator + fileName);
+		FileWriter writer = new FileWriter(exportFile);
+		writer.write(value);
+		writer.flush();
+		writer.close();
+	}
+	
+	/**
+	 * 
+	 * @param fileName
+	 * @return
+	 */
+	private String getValidName(String fileName) {
+		//	
+		return (fileName + "." + textConverter.getExtension()).toLowerCase();
+	}
+}

--- a/base/src/org/spin/process/GenerateDocsFromMenuAbstract.java
+++ b/base/src/org/spin/process/GenerateDocsFromMenuAbstract.java
@@ -1,0 +1,82 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.										*
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+
+package org.spin.process;
+
+import org.compiere.process.SvrProcess;
+
+/** Generated Process for (Generate Documentation from Menu)
+ *  @author ADempiere (generated) 
+ *  @version Release 3.9.0
+ */
+public abstract class GenerateDocsFromMenuAbstract extends SvrProcess {
+	/** Process Value 	*/
+	private static final String VALUE_FOR_PROCESS = "GenerateDocsFromMenu";
+	/** Process Name 	*/
+	private static final String NAME_FOR_PROCESS = "Generate Documentation from Menu";
+	/** Process Id 	*/
+	private static final int ID_FOR_PROCESS = 54128;
+	/**	Parameter Name for Export Format	*/
+	public static final String DOCSEXPORTFORMAT = "DocsExportFormat";
+	/**	Parameter Name for File_Directory	*/
+	public static final String FILE_DIRECTORY = "File_Directory";
+	/**	Parameter Value for Export Format	*/
+	private String docsExportFormat;
+	/**	Parameter Value for File_Directory	*/
+	private String directory;
+
+	@Override
+	protected void prepare() {
+		docsExportFormat = getParameterAsString(DOCSEXPORTFORMAT);
+		directory = getParameterAsString(FILE_DIRECTORY);
+	}
+
+	/**	 Getter Parameter Value for Export Format	*/
+	protected String getDocsExportFormat() {
+		return docsExportFormat;
+	}
+
+	/**	 Setter Parameter Value for Export Format	*/
+	protected void setDocsExportFormat(String docsExportFormat) {
+		this.docsExportFormat = docsExportFormat;
+	}
+
+	/**	 Getter Parameter Value for File_Directory	*/
+	protected String getDirectory() {
+		return directory;
+	}
+
+	/**	 Setter Parameter Value for File_Directory	*/
+	protected void setDirectory(String directory) {
+		this.directory = directory;
+	}
+
+	/**	 Getter Parameter Value for Process ID	*/
+	public static final int getProcessId() {
+		return ID_FOR_PROCESS;
+	}
+
+	/**	 Getter Parameter Value for Process Value	*/
+	public static final String getProcessValue() {
+		return VALUE_FOR_PROCESS;
+	}
+
+	/**	 Getter Parameter Value for Process Name	*/
+	public static final String getProcessName() {
+		return NAME_FOR_PROCESS;
+	}
+}

--- a/base/src/org/spin/util/docs/AbstractDocumentationSource.java
+++ b/base/src/org/spin/util/docs/AbstractDocumentationSource.java
@@ -1,0 +1,92 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.										*
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.spin.util.docs;
+
+import org.compiere.model.M_Element;
+import org.compiere.model.PO;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * It is a abstract class for used as contract of document converter
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public abstract class AbstractDocumentationSource {
+	
+	/**
+	 * Convert a simple PO in a textConverter
+	 * @param textConverter
+	 * @param source
+	 * @return
+	 */
+	public abstract boolean createDocumentation(AbstractTextConverter textConverter, PO source);
+	
+	/**
+	 * Create a Documentation
+	 * @param textConverter
+	 * @return
+	 */
+	public abstract boolean createDocumentation(AbstractTextConverter textConverter);
+	
+	/**
+	 * Create index
+	 * @param textConverter
+	 * @param source
+	 * @return
+	 */
+	public boolean addIndex(AbstractTextConverter textConverter, PO source) {
+		return false;
+	}
+	
+	/**
+	 * Get Folder Name for entity
+	 * @return
+	 */
+	public abstract String getFolderName();
+	
+	/**
+	 * Get Document Name
+	 * @return
+	 */
+	public abstract String getDocumentName();
+	
+	/**
+	 * Add feature
+	 * @param columnName
+	 */
+	public String getFeature(String columnName) {
+		M_Element element = M_Element.get(Env.getCtx(), columnName);
+		if(element != null
+				&& !Util.isEmpty(element.getHelp())) {
+			return element.getHelp().trim();
+		}
+		//	default
+		return null;
+	}
+	
+	/**
+	 * Get Valid Name
+	 */
+	protected String getValidValue(String value) {
+		String fileName = value;
+		fileName = fileName.replaceAll("[+^:&áàäéèëíìïóòöúùñÁÀÄÉÈËÍÌÏÓÒÖÚÙÜÑçÇ$,;*/()]", "");
+		fileName = fileName.replace(" ", "-").trim();
+		return fileName;
+	}
+}

--- a/base/src/org/spin/util/docs/AbstractTextConverter.java
+++ b/base/src/org/spin/util/docs/AbstractTextConverter.java
@@ -1,0 +1,266 @@
+/*************************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
+package org.spin.util.docs;
+
+import org.compiere.util.Util;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * Abstract class for Text converter
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public abstract class AbstractTextConverter {
+
+	/**
+	 * Default constructor
+	 */
+	public AbstractTextConverter() {
+		//	
+	}
+	
+	/**
+	 * Add simple text
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addText(String text);
+	
+	/**
+	 * Add simple text
+	 * @param text
+	 * @param margin
+	 * @return
+	 */
+	public abstract AbstractTextConverter addText(String text, int margin);
+	
+	/**
+	 * Add a text as bold
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addBold(String text);
+	
+	/**
+	 * Add text as Italic
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addItalic(String text);
+	
+	/**
+	 * Add text as Strikethrough
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addStrikethrough(String text);
+	
+	/**
+	 * Add text as code
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addCode(String text);
+	
+	/**
+	 * Add Quote with specific level
+	 * @param text
+	 * @param level
+	 * @return
+	 */
+	public abstract AbstractTextConverter addQuote(String text, int level);
+	
+	/**
+	 * Add Quote
+	 * @param text
+	 * @param level
+	 * @return
+	 */
+	public abstract AbstractTextConverter addQuote(String text);
+	
+	/**
+	 * Add Quote with numeric and with specific level
+	 * @param text
+	 * @param level
+	 * @return
+	 */
+	public abstract AbstractTextConverter addQuoteNumeric(String text, int level);
+	
+	/**
+	 * Add Numeric Quote
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addQuoteNumeric(String text);
+	
+	/**
+	 * Add Section
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addSection(String text);
+	
+	/**
+	 * Add sub-Section
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addSubSection(String text);
+	
+	/**
+	 * Add subsubsection
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addSubSubSection(String text);
+	
+	/**
+	 * Add Paragraph
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addParagraph(String text);
+	
+	/**
+	 * Add Part
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addPart(String text);
+	
+	/**
+	 * Add Chapter
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addChapter(String text);
+	
+	/**
+	 * Add External Link
+	 * @param text
+	 * @param link
+	 * @return
+	 */
+	public abstract AbstractTextConverter addExternalLink(String text, String link);
+	
+	/**
+	 * Add Note
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addNote(String text);
+	
+	/**
+	 * Add a table for text
+	 * @param table
+	 * @return
+	 */
+	public abstract AbstractTextConverter addTable(TableTextConverter table);
+	
+	/**
+	 * Clear values
+	 */
+	public abstract void clear();
+	
+	/**
+	 * Get File extension
+	 * @return
+	 */
+	public abstract String getExtension();
+	
+	/**
+	 * Add new Line
+	 * @return
+	 */
+	public abstract AbstractTextConverter newLine();
+	
+	/**
+	 * Add Internal Link
+	 * @param internalLink
+	 * @return
+	 */
+	public abstract AbstractTextConverter addSeeAlso(String internalLink);
+	
+	/**
+	 * Add internal link with name
+	 * @param name
+	 * @param internalLink
+	 * @return
+	 */
+	public abstract AbstractTextConverter addSeeAlso(String name, String internalLink);
+	
+	/**
+	 * Add Header Index Name used for make link from other file
+	 * @param indexName
+	 * @return
+	 */
+	public abstract AbstractTextConverter addHeaderIndexName(String indexName);
+	
+	/**
+	 * Add Comment that is not view for end user
+	 * @param comment
+	 * @return
+	 */
+	public abstract AbstractTextConverter addComment(String comment);
+	
+	/**
+	 * Get file name for index
+	 * @return
+	 */
+	public String getIndexFileName() {
+		return null;
+	}
+	
+	/**
+	 * Get Main index name for global index
+	 * @return
+	 */
+	public String getMainIndexFileName() {
+		return null;
+	}
+	
+	/**
+	 * Add Main index reference
+	 * @param title
+	 * @param path
+	 * @param margin
+	 * @return
+	 */
+	public AbstractTextConverter getMainIndex() {
+		return this;
+	}
+	
+	/**
+	 * add translation text
+	 * @param text
+	 * @return
+	 */
+	public abstract AbstractTextConverter addTranslationText(String text);
+	
+	
+	/**
+	 * Validate if is numeric
+	 * @param value
+	 * @return
+	 */
+	public boolean isNumeric(String value) {
+		if(Util.isEmpty(value)) {
+			return false;
+		}
+		//	
+		return value.matches("[+-]?\\d*(\\.\\d+)?");
+	}
+}

--- a/base/src/org/spin/util/docs/FunctionalDocsForForm.java
+++ b/base/src/org/spin/util/docs/FunctionalDocsForForm.java
@@ -1,0 +1,96 @@
+/*************************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
+package org.spin.util.docs;
+
+import java.io.File;
+
+import org.compiere.model.MForm;
+import org.compiere.model.MWindow;
+import org.compiere.model.PO;
+import org.compiere.util.Util;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * Documentation generator for Form entity
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public class FunctionalDocsForForm extends AbstractDocumentationSource {
+
+	public FunctionalDocsForForm() {
+		//	 Constructor
+	}
+
+	/**	Document	*/
+	private MForm form;
+	/**	Sub-Folder Name	*/
+	public static final String SUB_FOLDER_NAME = "form";
+	/**	Folder Name	*/
+	public static final String FOLDER_NAME = "functional-guide" + File.separator + SUB_FOLDER_NAME;
+	
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter, PO source) {
+		form = (MForm) source;
+		//	Add link from internal reference
+		textConverter.addHeaderIndexName((getFolderName() + "/" + getDocumentName()).toLowerCase());
+		//	Add Name
+		textConverter.addSection(form.getName());
+		textConverter.newLine();
+		//	Description
+		if(!Util.isEmpty(form.getDescription())) {
+			textConverter.addText(form.getDescription());
+			textConverter.newLine();
+		}
+		//	Help
+		if(!Util.isEmpty(form.getHelp())) {
+			textConverter.addSubSection("Help");
+			textConverter.addText(form.getHelp());
+			textConverter.newLine();
+		}
+		//	Beta Functionality
+		if(form.isBetaFunctionality()) {
+			textConverter.addNote(getFeature(MWindow.COLUMNNAME_IsBetaFunctionality));
+		}
+		return true;
+	}
+	
+	@Override
+	public boolean addIndex(AbstractTextConverter indexConverter, PO source) {
+		form = (MForm) source;
+		((IIndex) indexConverter).addIndex(form.getName(), getDocumentName().toLowerCase(), getFolderName(), 0);
+		return true;
+	}
+
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter) {
+		return false;
+	}
+
+	@Override
+	public String getFolderName() {
+		return FOLDER_NAME;
+	}
+
+	@Override
+	public String getDocumentName() {
+		if(form != null) {
+			return getValidValue(SUB_FOLDER_NAME + "-" + form.getName());
+		}
+		//	
+		return "";
+	}
+
+}

--- a/base/src/org/spin/util/docs/FunctionalDocsForMenu.java
+++ b/base/src/org/spin/util/docs/FunctionalDocsForMenu.java
@@ -1,0 +1,142 @@
+/*************************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
+package org.spin.util.docs;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.compiere.model.MMenu;
+import org.compiere.model.MProcess;
+import org.compiere.model.MRefList;
+import org.compiere.model.MTree;
+import org.compiere.model.MWindow;
+import org.compiere.model.PO;
+import org.compiere.util.DB;
+import org.compiere.util.Util;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * Documentation generator for Menu entity
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public class FunctionalDocsForMenu extends AbstractDocumentationSource {
+
+	public FunctionalDocsForMenu() {
+		//	 Constructor
+	}
+
+	/**	Document	*/
+	private MMenu menu;
+	/**	Sub-Folder Name	*/
+	public static final String SUB_FOLDER_NAME = "menu";
+	/**	Folder Name	*/
+	public static final String FOLDER_NAME = "functional-guide" + File.separator + SUB_FOLDER_NAME;
+	
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter, PO source) {
+		menu = (MMenu) source;
+		//	Add link from internal reference
+		textConverter.addHeaderIndexName((getFolderName() + "/" + getDocumentName()).toLowerCase());
+		//	Add Name
+		textConverter.addSection(menu.getName());
+		textConverter.newLine();
+		//	Description
+		if(!Util.isEmpty(menu.getDescription())) {
+			textConverter.addText(menu.getDescription());
+			textConverter.newLine();
+		}
+		List<MMenu> menuList = new ArrayList<MMenu>();
+		int currentMenuId = menu.getAD_Menu_ID();
+		int parentId = 0;
+		int treeId = MTree.getDefaultTreeIdFromTableName(menu.getAD_Client_ID(), "AD_Menu_ID");
+		//	Add current
+		menuList.add(menu);
+		do {
+			parentId = DB.getSQLValue(menu.get_TrxName(), "SELECT Parent_ID "
+					+ "FROM AD_TreeNodeMM "
+					+ "WHERE AD_Tree_ID = ? AND Node_ID = ?", treeId, currentMenuId);
+			if(parentId > 0) {
+				currentMenuId = parentId;
+				menuList.add(MMenu.getFromId(menu.getCtx(), currentMenuId));
+			}
+		} while(parentId > 0);
+		//	Write Path
+		textConverter.addSubSection("Menu Path");
+		for(int index = menuList.size() -1, level = 0; index >= 0; index--, level++) {
+			MMenu menuItem = menuList.get(index);
+			textConverter.addQuote(menuItem.getName(), level);
+		}
+		//	
+		textConverter.newLine();
+		//	Window Type
+		textConverter.addSubSubSection("Menu Type");
+		textConverter.addBold(MRefList.getListName(source.getCtx(), MMenu.ACTION_AD_Reference_ID, menu.getAction()));
+		textConverter.newLine();
+		//	Sales Transaction
+		if(menu.isSOTrx()) {
+			textConverter.addNote(getFeature(MWindow.COLUMNNAME_IsSOTrx));
+		}
+		textConverter.newLine();
+		String internalReference = null;
+		String validName = null;
+		String showName = null;
+		if(menu.getAction().equals(MMenu.ACTION_Process)) {
+			MProcess process = MProcess.get(menu.getCtx(), menu.getAD_Process_ID());
+			validName = getValidValue(process.getValue());
+			showName = process.getName();
+			internalReference = FunctionalDocsForProcess.FOLDER_NAME + File.separator + FunctionalDocsForProcess.SUB_FOLDER_NAME + "-" + validName;
+		} else if(menu.getAction().equals(MMenu.ACTION_Window)) {
+			MWindow window = (MWindow) menu.getAD_Window();
+			validName = getValidValue(window.getName());
+			showName = window.getName();
+			internalReference = FunctionalDocsForWindow.FOLDER_NAME + File.separator + FunctionalDocsForWindow.SUB_FOLDER_NAME + "-" + validName;
+		}
+		//	Validate null
+		if(!Util.isEmpty(internalReference)) {
+			textConverter.addSeeAlso(showName, internalReference.toLowerCase());
+		}
+		return true;
+	}
+
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter) {
+		return false;
+	}
+	
+	@Override
+	public boolean addIndex(AbstractTextConverter indexConverter, PO source) {
+		menu = (MMenu) source;
+		((IIndex) indexConverter).addIndex(menu.getName(), getDocumentName().toLowerCase(), getFolderName(), 0);
+		return true;
+	}
+
+	@Override
+	public String getFolderName() {
+		return FOLDER_NAME;
+	}
+
+	@Override
+	public String getDocumentName() {
+		if(menu != null) {
+			return getValidValue(SUB_FOLDER_NAME + "-" + menu.getName());
+		}
+		//	
+		return null;
+	}
+
+}

--- a/base/src/org/spin/util/docs/FunctionalDocsForMenu.java
+++ b/base/src/org/spin/util/docs/FunctionalDocsForMenu.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.adempiere.model.MBrowse;
+import org.compiere.model.MForm;
 import org.compiere.model.MMenu;
 import org.compiere.model.MProcess;
 import org.compiere.model.MRefList;
@@ -99,12 +101,22 @@ public class FunctionalDocsForMenu extends AbstractDocumentationSource {
 			MProcess process = MProcess.get(menu.getCtx(), menu.getAD_Process_ID());
 			validName = getValidValue(process.getValue());
 			showName = process.getName();
-			internalReference = FunctionalDocsForProcess.FOLDER_NAME + File.separator + FunctionalDocsForProcess.SUB_FOLDER_NAME + "-" + validName;
+			internalReference = ".." + File.separator + ".." + File.separator + FunctionalDocsForProcess.FOLDER_NAME + File.separator + FunctionalDocsForProcess.SUB_FOLDER_NAME + "-" + validName;
 		} else if(menu.getAction().equals(MMenu.ACTION_Window)) {
 			MWindow window = (MWindow) menu.getAD_Window();
 			validName = getValidValue(window.getName());
 			showName = window.getName();
-			internalReference = FunctionalDocsForWindow.FOLDER_NAME + File.separator + FunctionalDocsForWindow.SUB_FOLDER_NAME + "-" + validName;
+			internalReference = ".." + File.separator + ".." + File.separator + FunctionalDocsForWindow.FOLDER_NAME + File.separator + FunctionalDocsForWindow.SUB_FOLDER_NAME + "-" + validName;
+		} else if(menu.getAction().equals(MMenu.ACTION_SmartBrowse)) {
+			MBrowse browse = (MBrowse) menu.getAD_Browse();
+			validName = getValidValue(browse.getName());
+			showName = browse.getName();
+			internalReference = ".." + File.separator + ".." + File.separator + FunctionalDocsForSmartBrowse.FOLDER_NAME + File.separator + FunctionalDocsForSmartBrowse.SUB_FOLDER_NAME + "-" + validName;
+		} else if(menu.getAction().equals(MMenu.ACTION_Form)) {
+			MForm form = (MForm) menu.getAD_Form();
+			validName = getValidValue(form.getName());
+			showName = form.getName();
+			internalReference = ".." + File.separator + ".." + File.separator + FunctionalDocsForForm.FOLDER_NAME + File.separator + FunctionalDocsForForm.SUB_FOLDER_NAME + "-" + validName;
 		}
 		//	Validate null
 		if(!Util.isEmpty(internalReference)) {

--- a/base/src/org/spin/util/docs/FunctionalDocsForProcess.java
+++ b/base/src/org/spin/util/docs/FunctionalDocsForProcess.java
@@ -1,0 +1,182 @@
+/*************************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
+package org.spin.util.docs;
+
+import java.io.File;
+
+import org.adempiere.model.MBrowse;
+import org.compiere.model.MForm;
+import org.compiere.model.MProcess;
+import org.compiere.model.MProcessPara;
+import org.compiere.model.PO;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+import org.compiere.wf.MWorkflow;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * Documentation generator for Process entity
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public class FunctionalDocsForProcess extends AbstractDocumentationSource {
+
+	public FunctionalDocsForProcess() {
+		//	 Constructor
+	}
+
+	/**	Document	*/
+	private MProcess process;
+	/**	Sub-Folder Name	*/
+	public static final String SUB_FOLDER_NAME = "process";
+	/**	Folder Name	*/
+	public static final String FOLDER_NAME = "functional-guide" + File.separator + SUB_FOLDER_NAME;
+	
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter, PO source) {
+		process = (MProcess) source;
+		//	Add link from internal reference
+		textConverter.addHeaderIndexName((getFolderName() + "/" + getDocumentName()).toLowerCase());
+		//	Add Name
+		textConverter.addSection(process.getName());
+		textConverter.newLine();
+		//	Description
+		if(!Util.isEmpty(process.getDescription())) {
+			textConverter.addText(process.getDescription());
+			textConverter.newLine();
+		}
+		//	Help
+		if(!Util.isEmpty(process.getHelp())) {
+			textConverter.addSubSection("Help");
+			textConverter.addText(process.getHelp());
+			textConverter.newLine();
+		}
+		//	Beta Functionality
+		if(process.isBetaFunctionality()) {
+			textConverter.addNote(getFeature(MProcess.COLUMNNAME_IsBetaFunctionality));
+		}
+		//	Workflow
+		if(process.getAD_Workflow_ID() != 0) {
+			MWorkflow workflow = MWorkflow.get(source.getCtx(), process.getAD_Workflow_ID());
+			textConverter.addSubSubSection("Workflow");
+			textConverter.addBold(workflow.getName());
+			textConverter.newLine();
+			textConverter.addText(" ");
+			textConverter.addItalic(workflow.getDescription());
+			textConverter.newLine();
+		}
+		//	Special Form
+		if(process.getAD_Form_ID() != 0) {
+			MForm form = (MForm) process.getAD_Form();
+			textConverter.addSubSubSection("Special Form");
+			textConverter.addBold(form.getName());
+			textConverter.newLine();
+			textConverter.addText(" ");
+			textConverter.addItalic(form.getDescription());
+			textConverter.newLine();
+		}
+		//	Smart Browse
+		if(process.getAD_Browse_ID() != 0) {
+			MBrowse smartBrowse = MBrowse.get(source.getCtx(), process.getAD_Browse_ID());
+			textConverter.addSubSubSection("Smart Browse");
+			textConverter.addBold(smartBrowse.getName());
+			textConverter.newLine();
+			textConverter.addText(" ");
+			textConverter.addItalic(smartBrowse.getDescription());
+			textConverter.newLine();
+		}
+		//	Get Parameters
+		MProcessPara parameters[] = process.getParameters();
+		if(parameters != null
+				&& parameters.length > 0) {
+			textConverter.addSubSection("Parameters");
+			//	
+			for(MProcessPara parameter : parameters) {
+				//	Name
+				textConverter.addSubSubSection(parameter.getName());
+				//	Description
+				if(!Util.isEmpty(parameter.getDescription())) {
+					textConverter.addBold("Description");
+					textConverter.newLine();
+					textConverter.addText(" ");
+					textConverter.addItalic(parameter.getDescription());
+					textConverter.newLine();
+				}
+				//	Help
+				if(!Util.isEmpty(parameter.getHelp())) {
+					textConverter.addBold("Help");
+					textConverter.newLine();
+					textConverter.addText(" ");
+					textConverter.addItalic(parameter.getHelp());
+					textConverter.newLine();
+				}
+				StringBuffer note = new StringBuffer();
+				//	Mandatory
+				if(parameter.isMandatory()) {
+					note.append(getFeature(MProcessPara.COLUMNNAME_IsMandatory));
+				}
+				//	Range
+				if(parameter.isRange()) {
+					if(note.length() > 0) {
+						note.append(Env.NL);
+					}
+					//	
+					note.append(getFeature(MProcessPara.COLUMNNAME_IsRange));
+				}
+				//	Is Info Only
+				if(parameter.isInfoOnly()) {
+					if(note.length() > 0) {
+						note.append(Env.NL);
+					}
+					//	
+					note.append(getFeature(MProcessPara.COLUMNNAME_IsInfoOnly));
+				}
+				//	Add as note
+				if(note.length() > 0) {
+					textConverter.addNote(note.toString());
+				}
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public boolean addIndex(AbstractTextConverter indexConverter, PO source) {
+		process = (MProcess) source;
+		((IIndex) indexConverter).addIndex(process.getName(), getDocumentName().toLowerCase(), getFolderName(), 0);
+		return true;
+	}
+	
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter) {
+		return false;
+	}
+
+	@Override
+	public String getFolderName() {
+		return FOLDER_NAME;
+	}
+
+	@Override
+	public String getDocumentName() {
+		if(process != null) {
+			return getValidValue(SUB_FOLDER_NAME + "-" + process.getValue());
+		}
+		//	
+		return null;
+	}
+
+}

--- a/base/src/org/spin/util/docs/FunctionalDocsForSmartBrowse.java
+++ b/base/src/org/spin/util/docs/FunctionalDocsForSmartBrowse.java
@@ -1,0 +1,196 @@
+/*************************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
+package org.spin.util.docs;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.adempiere.model.MBrowse;
+import org.adempiere.model.MBrowseField;
+import org.compiere.model.MProcess;
+import org.compiere.model.PO;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * Documentation generator for Smart Browse entity
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public class FunctionalDocsForSmartBrowse extends AbstractDocumentationSource {
+
+	public FunctionalDocsForSmartBrowse() {
+		//	 Constructor
+	}
+
+	/**	Document	*/
+	private MBrowse smartBrowse;
+	/**	Sub-Folder Name	*/
+	public static final String SUB_FOLDER_NAME = "smart-browse";
+	/**	Folder Name	*/
+	public static final String FOLDER_NAME = "functional-guide" + File.separator + SUB_FOLDER_NAME;
+	
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter, PO source) {
+		smartBrowse = (MBrowse) source;
+		//	Add link from internal reference
+		textConverter.addHeaderIndexName((getFolderName() + "/" + getDocumentName()).toLowerCase());
+		//	Add Name
+		textConverter.addSection(smartBrowse.getName());
+		textConverter.newLine();
+		//	Description
+		if(!Util.isEmpty(smartBrowse.getDescription())) {
+			textConverter.addText(smartBrowse.getDescription());
+			textConverter.newLine();
+		}
+		//	Help
+		if(!Util.isEmpty(smartBrowse.getHelp())) {
+			textConverter.addSubSection("Help");
+			textConverter.addText(smartBrowse.getHelp());
+			textConverter.newLine();
+		}
+		//	Beta Functionality
+		if(smartBrowse.isBetaFunctionality()) {
+			textConverter.addNote(getFeature(MProcess.COLUMNNAME_IsBetaFunctionality));
+		}
+		//	window
+		if(smartBrowse.getAD_Window_ID() != 0) {
+			String internalReference = FunctionalDocsForWindow.FOLDER_NAME + File.separator + FunctionalDocsForWindow.SUB_FOLDER_NAME + "-" + getValidValue(smartBrowse.getAD_Window().getName());
+			textConverter.addSeeAlso(getValidValue(internalReference).toLowerCase());
+			textConverter.newLine();
+		}
+		//	Process
+		if(smartBrowse.getAD_Process_ID() != 0) {
+			String internalReference = FunctionalDocsForProcess.FOLDER_NAME + File.separator + FunctionalDocsForProcess.SUB_FOLDER_NAME + "-" + getValidValue(smartBrowse.getAD_Process().getValue());
+			textConverter.addSeeAlso(internalReference.toLowerCase());
+			textConverter.newLine();
+		}
+		StringBuffer note = new StringBuffer();
+		//	Updateable
+		if(smartBrowse.isUpdateable()) {
+			note.append(getFeature(MBrowse.COLUMNNAME_IsUpdateable));
+		}
+		//	Deleteable
+		if(smartBrowse.isDeleteable()) {
+			if(note.length() > 0) {
+				note.append(Env.NL);
+			}
+			//	
+			note.append(getFeature(MBrowse.COLUMNNAME_IsDeleteable));
+		}
+		//	Is Selected by default
+		if(smartBrowse.isSelectedByDefault()) {
+			if(note.length() > 0) {
+				note.append(Env.NL);
+			}
+			//	
+			note.append(getFeature(MBrowse.COLUMNNAME_IsSelectedByDefault));
+		}
+		//	Collapsible
+		if(smartBrowse.isCollapsibleByDefault()) {
+			if(note.length() > 0) {
+				note.append(Env.NL);
+			}
+			//	
+			note.append(getFeature(MBrowse.COLUMNNAME_IsCollapsibleByDefault));
+		}
+		//	Execute Query by default
+		if(smartBrowse.isExecutedQueryByDefault()) {
+			if(note.length() > 0) {
+				note.append(Env.NL);
+			}
+			//	
+			note.append(getFeature(MBrowse.COLUMNNAME_IsExecutedQueryByDefault));
+		}
+		//	Execute Query by default
+		if(smartBrowse.isShowTotal()) {
+			if(note.length() > 0) {
+				note.append(Env.NL);
+			}
+			//	
+			note.append(getFeature(MBrowse.COLUMNNAME_IsShowTotal));
+		}
+		//	Add as note
+		if(note.length() > 0) {
+			textConverter.addNote(note.toString());
+		}
+		
+		//	Get Parameters
+		List<MBrowseField> browseField = smartBrowse.getFields();
+		if(browseField != null
+				&& browseField.size() > 0) {
+			textConverter.addSubSection("Fields");
+			//	
+			TableTextConverter fieldTable = new TableTextConverter();
+			ArrayList<String> row = new ArrayList<>();
+			row.add("Name");
+			row.add("Description");
+			row.add("Displayed");
+			row.add("Query Criteria");
+			row.add("Order By");
+			row.add("Read Only");
+			row.add("Mandatory");
+			fieldTable.addRow(row);
+			for(MBrowseField field : browseField) {
+				if(!field.isDisplayed()
+						&& !field.isQueryCriteria()) {
+					continue;
+				}
+				row = new ArrayList<>();
+				row.add(field.getName());
+				row.add(field.getDescription());
+				row.add(field.isDisplayed()? "Yes": "No");
+				row.add(field.isQueryCriteria()? "Yes": "No");
+				row.add(field.isOrderBy()? "Yes": "No");
+				row.add(field.isReadOnly()? "Yes": "No");
+				row.add(field.isMandatory()? "Yes": "No");
+				fieldTable.addRow(row);
+			}
+			//	Add table
+			textConverter.addTable(fieldTable);
+		}
+		return true;
+	}
+	
+	@Override
+	public boolean addIndex(AbstractTextConverter indexConverter, PO source) {
+		smartBrowse = (MBrowse) source;
+		((IIndex) indexConverter).addIndex(smartBrowse.getName(), getDocumentName().toLowerCase(), getFolderName(), 0);
+		return true;
+	}
+
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter) {
+		return false;
+	}
+
+	@Override
+	public String getFolderName() {
+		return FOLDER_NAME;
+	}
+
+	@Override
+	public String getDocumentName() {
+		if(smartBrowse != null) {
+			return getValidValue(SUB_FOLDER_NAME + "-" + smartBrowse.getValue());
+		}
+		//	
+		return null;
+	}
+
+}

--- a/base/src/org/spin/util/docs/FunctionalDocsForSmartBrowse.java
+++ b/base/src/org/spin/util/docs/FunctionalDocsForSmartBrowse.java
@@ -70,14 +70,16 @@ public class FunctionalDocsForSmartBrowse extends AbstractDocumentationSource {
 		}
 		//	window
 		if(smartBrowse.getAD_Window_ID() != 0) {
-			String internalReference = FunctionalDocsForWindow.FOLDER_NAME + File.separator + FunctionalDocsForWindow.SUB_FOLDER_NAME + "-" + getValidValue(smartBrowse.getAD_Window().getName());
-			textConverter.addSeeAlso(getValidValue(internalReference).toLowerCase());
+			String name = smartBrowse.getAD_Window().getName();
+			String internalReference = ".." + File.separator + ".." + File.separator + FunctionalDocsForWindow.FOLDER_NAME + File.separator + FunctionalDocsForWindow.SUB_FOLDER_NAME + "-" + getValidValue(name);
+			textConverter.addSeeAlso(name, internalReference.toLowerCase());
 			textConverter.newLine();
 		}
 		//	Process
 		if(smartBrowse.getAD_Process_ID() != 0) {
-			String internalReference = FunctionalDocsForProcess.FOLDER_NAME + File.separator + FunctionalDocsForProcess.SUB_FOLDER_NAME + "-" + getValidValue(smartBrowse.getAD_Process().getValue());
-			textConverter.addSeeAlso(internalReference.toLowerCase());
+			MProcess process = (MProcess) smartBrowse.getAD_Process();
+			String internalReference = ".." + File.separator + ".." + File.separator + FunctionalDocsForProcess.FOLDER_NAME + File.separator + FunctionalDocsForProcess.SUB_FOLDER_NAME + "-" + getValidValue(process.getValue());
+			textConverter.addSeeAlso(process.getName(), internalReference.toLowerCase());
 			textConverter.newLine();
 		}
 		StringBuffer note = new StringBuffer();

--- a/base/src/org/spin/util/docs/FunctionalDocsForWindow.java
+++ b/base/src/org/spin/util/docs/FunctionalDocsForWindow.java
@@ -1,0 +1,267 @@
+/*************************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
+package org.spin.util.docs;
+
+import java.io.File;
+import java.util.ArrayList;
+
+import org.compiere.model.MField;
+import org.compiere.model.MRefList;
+import org.compiere.model.MTab;
+import org.compiere.model.MWindow;
+import org.compiere.model.PO;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * Documentation generator for Window entity
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public class FunctionalDocsForWindow extends AbstractDocumentationSource {
+
+	public FunctionalDocsForWindow() {
+		//	 Constructor
+	}
+
+	/**	Document	*/
+	private MWindow window;
+	/**	Sub-Folder Name	*/
+	public static final String SUB_FOLDER_NAME = "window";
+	/**	Folder Name	*/
+	public static final String FOLDER_NAME = "functional-guide" + File.separator + SUB_FOLDER_NAME;
+	
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter, PO source) {
+		window = (MWindow) source;
+		//	Add link from internal reference
+		textConverter.addHeaderIndexName((getFolderName() + "/" + getDocumentName()).toLowerCase());
+		//	Add Name
+		textConverter.addSection(window.getName());
+		textConverter.newLine();
+		//	Description
+		if(!Util.isEmpty(window.getDescription())) {
+			textConverter.addText(window.getDescription());
+			textConverter.newLine();
+		}
+		//	Help
+		if(!Util.isEmpty(window.getHelp())) {
+			textConverter.addSubSection("Help");
+			textConverter.addText(window.getHelp());
+			textConverter.newLine();
+		}
+		//	Beta Functionality
+		if(window.isBetaFunctionality()) {
+			textConverter.addNote(getFeature(MWindow.COLUMNNAME_IsBetaFunctionality));
+		}
+		//	Window Type
+		textConverter.addSubSubSection("Window Type");
+		textConverter.addBold(MRefList.getListName(source.getCtx(), MWindow.WINDOWTYPE_AD_Reference_ID, window.getWindowType()));
+		textConverter.newLine();
+		//	Sales Transaction
+		if(window.isSOTrx()) {
+			textConverter.addNote(getFeature(MWindow.COLUMNNAME_IsSOTrx));
+		}
+		textConverter.newLine();
+		//	
+		MTab tabs[] = window.getTabs(false, source.get_TrxName());
+		//	Get Parameters
+		if(tabs != null
+				&& tabs.length > 0) {
+			textConverter.addSubSection("Tabs");
+			//	
+			for(MTab tab : tabs) {
+				TableTextConverter table = new TableTextConverter();
+				ArrayList<String> row = new ArrayList<String>();
+				row.add("Attribute");
+				row.add("Value");
+				row.add("Description");
+				table.addRow(row);
+				//	Name
+				textConverter.addSubSubSection(tab.getName());
+				//	Description
+				if(!Util.isEmpty(tab.getDescription())) {
+					textConverter.addBold("Description");
+					textConverter.newLine();
+					textConverter.addText(" ");
+					textConverter.addItalic(tab.getDescription());
+					textConverter.newLine();
+				}
+				//	Help
+				if(!Util.isEmpty(tab.getHelp())) {
+					textConverter.addBold("Help");
+					textConverter.newLine();
+					textConverter.addText(" ");
+					textConverter.addItalic(tab.getHelp());
+					textConverter.newLine();
+				}
+				StringBuffer note = new StringBuffer();
+				//	Single Row
+				if(tab.isSingleRow()) {
+					note.append(getFeature(MTab.COLUMNNAME_IsSingleRow));
+				}
+				//	Advanced Tab
+				if(tab.isAdvancedTab()) {
+					if(note.length() > 0) {
+						note.append(Env.NL);
+					}
+					//	
+					note.append(getFeature(MTab.COLUMNNAME_IsAdvancedTab));
+				}
+				//	Tree
+				if(tab.isHasTree()) {
+					if(note.length() > 0) {
+						note.append(Env.NL);
+					}
+					//	
+					note.append(getFeature("IsHasTree"));
+				}
+				//	Info
+				if(tab.isInfoTab()) {
+					if(note.length() > 0) {
+						note.append(Env.NL);
+					}
+					//	
+					note.append(getFeature(MTab.COLUMNNAME_IsInfoTab));
+				}
+				//	Sort Tab
+				if(tab.isSortTab()) {
+					if(note.length() > 0) {
+						note.append(Env.NL);
+					}
+					//	
+					note.append(getFeature(MTab.COLUMNNAME_IsSortTab));
+				}
+				//	Translation Tab
+				if(tab.isTranslationTab()) {
+					if(note.length() > 0) {
+						note.append(Env.NL);
+					}
+					//	
+					note.append(getFeature(MTab.COLUMNNAME_IsTranslationTab));
+				}
+				//	Read Only Tab
+				if(tab.isReadOnly()) {
+					if(note.length() > 0) {
+						note.append(Env.NL);
+					}
+					//	
+					note.append(getFeature(MTab.COLUMNNAME_IsReadOnly));
+				}
+				//	Insert Record Tab
+				if(tab.isInsertRecord()) {
+					if(note.length() > 0) {
+						note.append(Env.NL);
+					}
+					//	
+					note.append(getFeature(MTab.COLUMNNAME_IsInsertRecord));
+				}
+				//	Add as note
+				if(note.length() > 0) {
+					textConverter.addNote(note.toString());
+				}
+				//	For Fields
+				MField fields[] = tab.getFields(false, source.get_TrxName());
+				if(fields != null
+						&& fields.length > 0) {
+					textConverter.addSubSection("Fields");
+					//	
+					for(MField field : fields) {
+						if(!field.isDisplayed()) {
+							continue;
+						}
+						//	Name
+						textConverter.addSubSubSection(field.getName());
+						//	Description
+						if(!Util.isEmpty(field.getDescription())) {
+							textConverter.addBold("Description");
+							textConverter.newLine();
+							textConverter.addText(" ");
+							textConverter.addItalic(field.getDescription());
+							textConverter.newLine();
+						}
+						//	Help
+						if(!Util.isEmpty(field.getHelp())) {
+							textConverter.addBold("Help");
+							textConverter.newLine();
+							textConverter.addText(" ");
+							textConverter.addItalic(field.getHelp());
+							textConverter.newLine();
+						}
+						note = new StringBuffer();
+						//	Read Only
+						if(field.isDisplayedGrid()) {
+							note.append(getFeature(MField.COLUMNNAME_IsDisplayedGrid));
+						}
+						//	Read Only
+						if(field.isReadOnly()) {
+							if(note.length() > 0) {
+								note.append(Env.NL);
+							}
+							//	
+							note.append(getFeature(MField.COLUMNNAME_IsReadOnly));
+						}
+						//	Allows Copy
+						if(field.isAllowCopy()) {
+							if(note.length() > 0) {
+								note.append(Env.NL);
+							}
+							//	
+							note.append(getFeature(MField.COLUMNNAME_IsAllowCopy));
+						}
+						//	Encrypted
+						if(field.isEncrypted()) {
+							if(note.length() > 0) {
+								note.append(Env.NL);
+							}
+							//	
+							note.append(getFeature(MField.COLUMNNAME_IsEncrypted));
+						}
+					}
+				}
+			}
+		}
+		return true;
+	}
+	
+	@Override
+	public boolean addIndex(AbstractTextConverter indexConverter, PO source) {
+		window = (MWindow) source;
+		((IIndex) indexConverter).addIndex(window.getName(), getDocumentName().toLowerCase(), getFolderName(), 0);
+		return true;
+	}
+
+	@Override
+	public boolean createDocumentation(AbstractTextConverter textConverter) {
+		return false;
+	}
+
+	@Override
+	public String getFolderName() {
+		return FOLDER_NAME;
+	}
+
+	@Override
+	public String getDocumentName() {
+		if(window != null) {
+			return getValidValue(SUB_FOLDER_NAME + "-" + window.getName());
+		}
+		//	
+		return "";
+	}
+
+}

--- a/base/src/org/spin/util/docs/IIndex.java
+++ b/base/src/org/spin/util/docs/IIndex.java
@@ -1,0 +1,52 @@
+/*************************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
+package org.spin.util.docs;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * Abstract class for Text converter
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public interface IIndex {
+	
+	/**
+	 * Add Group to Index
+	 * @param title
+	 * @param name
+	 * @param margin
+	 */
+	public void addGroup(String title, String name, int margin);
+	
+	/**
+	 * Add a tree for file
+	 * @param maxdepth
+	 * @param isnumbered
+	 * @return
+	 */
+	public void addTreeDefinition(int maxdepth, boolean isnumbered);
+	
+	/**
+	 * Add Index value
+	 * Used for File as index
+	 * @param title
+	 * @param name
+	 * @param folder
+	 * @param margin
+	 * @return
+	 */
+	public void addIndex(String title, String name, String folder, int margin);
+}

--- a/base/src/org/spin/util/docs/MarkdownConverter.java
+++ b/base/src/org/spin/util/docs/MarkdownConverter.java
@@ -1,0 +1,762 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.									  *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.spin.util.docs;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.compiere.util.CLogger;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * Markdown converter, it can be used for export a simple String to reStructuredText format
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public class MarkdownConverter extends AbstractTextConverter implements IIndex {
+
+	/**
+	 * Standard constructor
+	 */
+	public MarkdownConverter() {
+		super();
+		//	
+		formattedText = new StringBuffer();
+		translatedText = new StringBuffer();
+	}
+	
+	/**	Formatted text	*/
+	private StringBuffer formattedText;
+	/**	Translated text	*/
+	private StringBuffer translatedText;
+	/**	Previous level	*/
+	private int previouslevel = -1;
+	/**	Logging								*/
+	private CLogger	log = CLogger.getCLogger(getClass());
+	/**	Main index added	*/
+	private MarkdownConverter mainIndex;
+	
+	@Override
+	public AbstractTextConverter addText(String text) {
+		formattedText.append(formatText(text));
+		log.fine("addText=" + text);
+		return this;
+	}
+	
+	/**
+	 * Format Text
+	 * @param text
+	 * @return
+	 */
+	private String formatText(String text) {
+		return text.replaceAll("(?i)<p */?>", "")
+				.replaceAll("(?i)<br */?>\\n", "\n")
+				.replaceAll("(?i)<br */?>", "* ")
+				.replaceAll("(?i)<b */?>", "\\\\ **")
+				.replaceAll("(?i)</b */?>", "**\\\\ ");
+	}
+	
+	@Override
+	public AbstractTextConverter addBold(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addBold=" + text);
+		//	Format
+		addText(formatBold(text));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addItalic(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addItalic=" + text);
+		//	Format
+		addText(formatItalic(text));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addStrikethrough(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("Strikethrough=" + text);
+		//	Format
+		addText(formatStrikethrough(text));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addCode(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addCode=" + text);
+		newLine();
+		//	Format
+		addText(formatCode(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addQuote(String text, int level) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addQuote=" + text);
+		newLine();
+		//	Format
+		addText(formatQuote(text, false, level));
+		return this;
+	}
+	
+	
+	@Override
+	public AbstractTextConverter addQuote(String text) {
+		return addQuote(text, 0);
+	}
+	
+	
+	@Override
+	public AbstractTextConverter addQuoteNumeric(String text, int level) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addQuoteNumeric=" + text);
+		newLine();
+		//	Format
+		addText(formatQuote(text, true, level));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addQuoteNumeric(String text) {
+		return addQuoteNumeric(text, 0);
+	}
+	
+	@Override
+	public AbstractTextConverter addSection(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addSection=" + text);
+		//	Format
+		newLine();
+		addText(formatSection(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addSubSection(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addSubSection=" + text);
+		//	Format
+		newLine();
+		addText(formatSubSection(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addSubSubSection(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addSubSubSection=" + text);
+		//	Format
+		newLine();
+		addText(formatSubSubSection(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addParagraph(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addParagraph=" + text);
+		//	Format
+		newLine();
+		addText(formatParagraphs(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addPart(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addPart=" + text);
+		//	Format
+		newLine();
+		addText(formatPart(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addChapter(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addChapter=" + text);
+		//	Format
+		newLine();
+		addText(formatChapter(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addExternalLink(String text, String link) {
+		if(Util.isEmpty(text)
+				|| Util.isEmpty(link)) {
+			return this;
+		}
+		log.fine("addExternalLink=" + text);
+		addText(formatExternalLink(text, link));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addSeeAlso(String internalLink) {
+		return addSeeAlso(null, internalLink);
+	}
+	
+	@Override
+	public AbstractTextConverter addSeeAlso(String name, String internalLink) {
+		if(Util.isEmpty(internalLink)) {
+			return this;
+		}
+		log.fine("addSeeAlso=" + internalLink);
+		formattedText.append(formatSeeAlso(name, internalLink));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addHeaderIndexName(String indexName) {
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addComment(String comment) {
+		if(Util.isEmpty(comment)) {
+			return this;
+		}
+		log.fine("addComment=" + comment);
+		addText(formatComment(comment));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addNote(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		addText(formatNote(text));
+		return this;
+	}
+
+	@Override
+	public AbstractTextConverter addTable(TableTextConverter table) {
+		log.fine("addTable=" + table);
+		//	
+		if(table.getRows().size() != 0) {
+			List<String> firstRow = table.getRow(0);
+			if(firstRow.size() != 0) {
+				String columnSeparator = " | ";
+				int[] maxSizes = new int[firstRow.size()];
+				newLine();
+				boolean isFirst = true;
+				StringBuffer headerLine = new StringBuffer();
+				for(List<String> row : table.getRows()) {
+					newLine();
+					StringBuffer text = new StringBuffer();
+					for(int columnIndex = 0; columnIndex < maxSizes.length; columnIndex++) {
+						String columnText = "";
+						if(columnIndex < row.size()) {
+							maxSizes[columnIndex] = table.getMaxColumnSize(columnIndex);
+							columnText = row.get(columnIndex);
+							if(Util.isEmpty(columnText)) {
+								columnText = "";
+							}
+						}
+						//	Validate 0
+						int size = maxSizes[columnIndex];
+						if(size > 0) {
+							if(isNumeric(columnText)) {
+								columnText = String.format("%1$" + size + "s", columnText);
+							} else {
+								columnText = String.format("%1$-" + size + "s", columnText);
+							}
+						}
+						if(text.length() > 0) {
+							text.append(columnSeparator);
+						}
+						text.append(columnText);
+						//	
+						if(isFirst) {
+							//	Separator for new column
+							if(headerLine.length() > 0) {
+								headerLine.append(columnSeparator);
+							}
+							headerLine.append(getParalelChar(columnText, "-"));
+						}
+					}
+					//	For first
+					if(isFirst) {
+						newLine();
+						addText(text.toString());
+						newLine();
+						addText(headerLine.toString());
+						isFirst = false;
+					} else {
+						addText(text.toString());
+					}
+				}
+				//	last for table
+				newLine();
+			}
+		}
+		return this;
+	}
+	
+	/**
+	 * Format text as bold
+	 * @param text
+	 * @return
+	 */
+	private String formatBold(String text) {
+		StringBuffer formattedValue = new StringBuffer();
+		//	**phrase**
+		formattedValue.append("**").append(text.trim()).append("**");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format as Italic
+	 * @param text
+	 * @return
+	 */
+	private String formatItalic(String text) {
+		StringBuffer formattedValue = new StringBuffer();
+		//	*phrase* 
+		formattedValue.append("*").append(text.trim()).append("*");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format as Strikethrough
+	 * @param text
+	 * @return
+	 */
+	private String formatStrikethrough(String text) {
+		StringBuffer formattedValue = new StringBuffer();
+		//	~~phrase~~ 
+		formattedValue.append("~~").append(text.trim()).append("~~");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format as Code
+	 * @param text
+	 * @return
+	 */
+	private String formatCode(String text) {
+		StringBuffer formattedValue = new StringBuffer();
+		//```
+		//code
+		//```
+		formattedValue.append("```").append(Env.NL).append(text.trim()).append(Env.NL).append("```");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format as Quote
+	 * @param text
+	 * @return
+	 */
+	private String formatQuote(String text, boolean isNumeric, int level) {
+		//	Add Space
+		if(previouslevel != level) {
+			newLine();
+		}
+		previouslevel = level;
+		StringBuffer formattedValue = new StringBuffer();
+		//	
+		String leftSpace = "";
+		if(level > 0) {
+			leftSpace = String.format("%1$" + level + "s", ""); 
+		}
+		String type = "-";
+		if(isNumeric) {
+			type = "1.";
+		}
+		formattedValue.append(leftSpace).append(type).append(" ").append(text);
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format as Quote
+	 * @param text
+	 * @return
+	 */
+	private String formatIndex(String text, int level) {
+		//	Add Space
+		if(previouslevel != level) {
+			newLine();
+		}
+		previouslevel = level;
+		StringBuffer formattedValue = new StringBuffer();
+		//	
+		String leftSpace = "";
+		if(level > 0) {
+			leftSpace = String.format("%1$" + level + "s", "");
+		}
+		String type = "-";
+		formattedValue.append(leftSpace).append(type).append(" ").append(text);
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Header
+	 * @param text
+	 * @param charValue
+	 * @return
+	 */
+	private String formatHeader(String text, String charValue) {
+		StringBuffer formattedValue = new StringBuffer(text.trim());
+		formattedValue.append(Env.NL);
+		formattedValue.append(charValue).append(" ").append(text.trim());
+		formattedValue.append(Env.NL);
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Link
+	 * @param text
+	 * @param link
+	 * @return
+	 */
+	private String formatExternalLink(String text, String link) {
+		//	.. _distributed scaling: http://en.wikipedia.org/wiki/CAP_theorem
+		StringBuffer formattedValue = new StringBuffer();
+		//	
+		formattedValue.append("[").append(text.trim()).append("]").append("(").append(link).append(")");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Section
+	 * @param text
+	 * @return
+	 */
+	private String formatSection(String text) {
+		return formatHeader(text, "#");
+	}
+	
+	/**
+	 * Format Subsection
+	 * @param text
+	 * @return
+	 */
+	private String formatSubSection(String text) {
+		return formatHeader(text, "##");
+	}
+	
+	/**
+	 * Format Subsubsection
+	 * @param text
+	 * @return
+	 */
+	private String formatSubSubSection(String text) {
+		return formatHeader(text, "###");
+	}
+	
+	/**
+	 * Format paragraphs
+	 * @param text
+	 * @return
+	 */
+	private String formatParagraphs(String text) {
+		return formatHeader(text, "");
+	}
+	
+	/**
+	 * Format Parts
+	 * @param text
+	 * @return
+	 */
+	private String formatPart(String text) {
+		return formatHeader(text, "#");
+	}
+	
+	/**
+	 * Formnat Chapters
+	 * @param text
+	 * @return
+	 */
+	private String formatChapter(String text) {
+		return formatHeader(text, "*");
+	}
+	
+	/**
+	 * Get under character
+	 * @param text
+	 * @param underValue
+	 * @return
+	 */
+	private String getParalelChar(String text, String underValue) {
+		return String.format("%1$" + text.length() + "s", "").replace(" ", underValue); 
+	}
+	
+	/**
+	 * Format note
+	 * @param text
+	 * @return
+	 */
+	private String formatNote(String text) {
+		//	.. _distributed scaling: http://en.wikipedia.org/wiki/CAP_theorem
+		StringBuffer formattedValue = new StringBuffer(Env.NL);
+		//	
+		formattedValue.append("```")
+			.append(Env.NL)
+			.append(text.trim())
+			.append(Env.NL)
+			.append("```");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * See Also
+	 * @param internalLink
+	 * @return
+	 */
+	private String formatSeeAlso(String name, String internalLink) {
+		//	.. seealso::
+		    //	:ref:`vdufun`
+		StringBuffer formattedValue = new StringBuffer(Env.NL);
+		//	
+		if(Util.isEmpty(name)) {
+			name = internalLink;
+		}
+		formattedValue.append(formatExternalLink(name, internalLink.trim() + "." + getExtension()));
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Comment
+	 * @param internalLink
+	 * @return
+	 */
+	private String formatComment(String comment) {
+		//	.. _api/db/security:
+		StringBuffer formattedValue = new StringBuffer(Env.NL);
+		//	
+		formattedValue.append(".. ")
+			.append(comment.replaceAll("\\n", "\n.."))
+			.append(Env.NL);
+		return formattedValue.toString();
+	}
+	
+	@Override
+	public AbstractTextConverter newLine() {
+		addText(Env.NL);
+		return this;
+	}
+	
+	@Override
+	public String toString() {
+		log.fine("toString=" + formattedText.toString());
+		return formattedText.toString();
+	}
+	
+	public static void main(String[] args) {
+		MarkdownConverter formatter = new MarkdownConverter();
+		formatter.addSection("Section");
+		formatter.addSubSection("SubSection");
+		formatter.addSubSubSection("SubSubSection");
+		formatter.addChapter("Chapter");
+		formatter.addPart("Part");
+		formatter.addBold("Hi everybody");
+		formatter.newLine();
+		formatter.newLine();
+		formatter.addBold("Hi");
+		formatter.newLine();
+		formatter.addItalic("Hello");
+		formatter.newLine();
+		formatter.addStrikethrough("Hello");
+		formatter.newLine();
+		formatter.addText("Hi all");
+		formatter.newLine();
+		formatter.addQuote("Items");
+		formatter.addQuote("Item 1", 1);
+		formatter.addQuote("Item 2", 1);
+		formatter.addQuote("Item 2.1", 2);
+		formatter.addQuote("Item 2.2", 2);
+		formatter.addQuote("Item 2.3", 2);
+		formatter.addQuote("Item 3", 1);
+		formatter.addQuoteNumeric("Other");
+		formatter.addQuoteNumeric("Description 1", 1);
+		formatter.addQuoteNumeric("Description 2", 2);
+		formatter.addQuoteNumeric("Description 2.1", 3);
+		formatter.addQuoteNumeric("Description 2.2", 3);
+		formatter.addQuoteNumeric("Description 2.3", 3);
+		formatter.addQuoteNumeric("Description 3", 2);
+		formatter.addText("This is a collection of key documentation gathered from the ADempiere wiki and the collective experience of the "
+				+ "ADempiere Development Community. The aim of this collection is to provide a searchable and usable source of project documentation that will "
+				+ "improve on the data contained in the wiki while enhancing the readers experience. ");
+		formatter.addExternalLink("ADempiere Test", "http://demo.erpya.com:8888");
+		formatter.addText(" si no le interesa revise tambien ");
+		formatter.addExternalLink("ADempiere Test 1 ", "http://demo.erpya.com:8888/webui/");
+		formatter.addCode("String a = \"Epale\";");
+		TableTextConverter table = new TableTextConverter();
+		ArrayList<String> row = new ArrayList<>();
+		row.add("Value");
+		row.add("Name");
+		row.add("Description");
+		table.addRow(row);
+		row = new ArrayList<>();
+		row.add("Test");
+		row.add("Test Process");
+		row.add("A Test Process");
+		table.addRow(row);
+		row = new ArrayList<>();
+		row.add("Production");
+		row.add("Production Process");
+		row.add("A Production Process");
+		table.addRow(row);
+		row = new ArrayList<>();
+		row.add("Report");
+		row.add("Test Report");
+		row.add("A Test Report");
+		table.addRow(row);
+		//	
+		formatter.addTable(table);
+		//	Get it gfor a file
+		System.out.println(formatter.toString());
+	}
+
+	@Override
+	public void clear() {
+		formattedText = new StringBuffer();
+		previouslevel = -1;
+	}
+
+	@Override
+	public String getExtension() {
+		return "md";
+	}
+	
+	@Override
+	public String getIndexFileName() {
+		return "index.md";
+	}
+	
+	@Override
+	public String getMainIndexFileName() {
+		return "mkdocs.yml";
+	}
+
+	@Override
+	public AbstractTextConverter addText(String text, int margin) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		//	Add Margin
+		String leftSpace = "";
+		if(margin > 0) {
+			leftSpace = String.format("%1$" + margin + "s", "");
+		}
+		addText(leftSpace + text);
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter getMainIndex() {
+		return mainIndex;
+	}
+	
+	/**
+	 * Add link to main index
+	 * @param title
+	 * @param name
+	 * @param folder
+	 * @param margin
+	 */
+	private void addToMainIndex(String title, String name, String folder, int margin) {
+		if(mainIndex == null) {
+			mainIndex = new MarkdownConverter();
+			mainIndex.addText("site_name: ERPCyA - Documentation");
+			mainIndex.newLine();
+			mainIndex.newLine();
+			mainIndex.addText("nav:");
+			mainIndex.newLine();
+			mainIndex.newLine();
+		}
+		//	
+		String fileName = "";
+		if(margin == -1) {
+			margin = 1;
+		}
+		if(!Util.isEmpty(folder)) {
+			fileName = folder + File.separator + name.trim() + "." + getExtension();
+		}
+		for (char value : fileName.toCharArray())  { 
+            // checking character in string 
+            if (value == File.separatorChar) {
+            	margin++;
+            } 
+        }
+		mainIndex.newLine();
+		mainIndex.addText(formatIndex(title + ": " + (Util.isEmpty(fileName)? "":"'" + fileName + "'") , margin*4));
+	}
+
+	@Override
+	public AbstractTextConverter addTranslationText(String text) {
+		translatedText.append(text);
+		return this;
+	}
+
+	@Override
+	public void addIndex(String title, String name, String folder, int margin) {
+		addToMainIndex(title, name, folder, -1);
+		addText(formatIndex(formatExternalLink(title, name.trim() + "." + getExtension()), margin));
+	}
+
+	@Override
+	public void addGroup(String title, String name, int margin) {
+		addToMainIndex(title, null, null, margin);
+	}
+
+	@Override
+	public void addTreeDefinition(int maxdepth, boolean isnumbered) {
+		newLine();
+	}
+}

--- a/base/src/org/spin/util/docs/ReStructuredTextConverter.java
+++ b/base/src/org/spin/util/docs/ReStructuredTextConverter.java
@@ -1,0 +1,733 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.									  *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.spin.util.docs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.compiere.util.CLogger;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * reStructuredText converter, it can be used for export a simple String to reStructuredText format
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public class ReStructuredTextConverter extends AbstractTextConverter implements IIndex {
+
+	/**
+	 * Standard constructor
+	 */
+	public ReStructuredTextConverter() {
+		super();
+		//	
+		formattedText = new StringBuffer();
+		translatedText = new StringBuffer();
+		urlSource = new StringBuffer();
+	}
+	
+	/**	Formatted text	*/
+	private StringBuffer formattedText;
+	/**	Translated text	*/
+	private StringBuffer translatedText;
+	/**	Previous level	*/
+	private int previouslevel = -1;
+	/**	Url source	*/
+	private StringBuffer urlSource;
+	/**	Logging								*/
+	private CLogger	log = CLogger.getCLogger(getClass());
+	
+	@Override
+	public AbstractTextConverter addText(String text) {
+		formattedText.append(formatText(text));
+		log.fine("addText=" + text);
+		return this;
+	}
+	
+	/**
+	 * Format Text
+	 * @param text
+	 * @return
+	 */
+	private String formatText(String text) {
+		return text.replaceAll("(?i)<p */?>", "")
+				.replaceAll("(?i)<br */?>\\n", "\n")
+				.replaceAll("(?i)<br */?>", "* ")
+				.replaceAll("(?i)<b */?>", "\\\\ **")
+				.replaceAll("(?i)</b */?>", "**\\\\ ");
+	}
+	
+	@Override
+	public AbstractTextConverter addBold(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addBold=" + text);
+		//	Format
+		addText(formatBold(text));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addItalic(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addItalic=" + text);
+		//	Format
+		addText(formatItalic(text));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addCode(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addCode=" + text);
+		newLine();
+		newLine();
+		//	Format
+		addText(formatCode(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addQuote(String text, int level) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addQuote=" + text);
+		newLine();
+		//	Format
+		addText(formatQuote(text, false, level));
+		return this;
+	}
+	
+	
+	@Override
+	public AbstractTextConverter addQuote(String text) {
+		return addQuote(text, 0);
+	}
+	
+	
+	@Override
+	public AbstractTextConverter addQuoteNumeric(String text, int level) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addQuoteNumeric=" + text);
+		newLine();
+		//	Format
+		addText(formatQuote(text, true, level));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addQuoteNumeric(String text) {
+		return addQuoteNumeric(text, 0);
+	}
+	
+	@Override
+	public AbstractTextConverter addSection(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addSection=" + text);
+		//	Format
+		newLine();
+		addText(formatSection(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addSubSection(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addSubSection=" + text);
+		//	Format
+		newLine();
+		addText(formatSubSection(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addSubSubSection(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addSubSubSection=" + text);
+		//	Format
+		newLine();
+		addText(formatSubSubSection(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addParagraph(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addParagraph=" + text);
+		//	Format
+		newLine();
+		addText(formatParagraphs(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addPart(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addPart=" + text);
+		//	Format
+		newLine();
+		addText(formatPart(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addChapter(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		log.fine("addChapter=" + text);
+		//	Format
+		newLine();
+		addText(formatChapter(text));
+		newLine();
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addExternalLink(String text, String link) {
+		if(Util.isEmpty(text)
+				|| Util.isEmpty(link)) {
+			return this;
+		}
+		log.fine("addExternalLink=" + text);
+		addText(formatExternalLinkText(text));
+		urlSource.append(formatExternalLink(text, link));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addSeeAlso(String internalLink) {
+		return addSeeAlso(null, internalLink);
+	}
+	
+	@Override
+	public AbstractTextConverter addSeeAlso(String name, String internalLink) {
+		if(Util.isEmpty(internalLink)) {
+			return this;
+		}
+		log.fine("addSeeAlso=" + internalLink);
+		formattedText.append(formatSeeAlso(internalLink));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addHeaderIndexName(String indexName) {
+		if(Util.isEmpty(indexName)) {
+			return this;
+		}
+		log.fine("addSeeAlso=" + indexName);
+		addText(formatHeaderIndexName(indexName));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addComment(String comment) {
+		if(Util.isEmpty(comment)) {
+			return this;
+		}
+		log.fine("addComment=" + comment);
+		addText(formatComment(comment));
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addNote(String text) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		addText(formatNote(text));
+		return this;
+	}
+
+	@Override
+	public AbstractTextConverter addTable(TableTextConverter table) {
+		log.fine("addTable=" + table);
+		//	
+		if(table.getRows().size() != 0) {
+			List<String> firstRow = table.getRow(0);
+			if(firstRow.size() != 0) {
+				String columnSeparator = "  ";
+				int[] maxSizes = new int[firstRow.size()];
+				newLine();
+				boolean isFirst = true;
+				StringBuffer headerLine = new StringBuffer();
+				for(List<String> row : table.getRows()) {
+					newLine();
+					StringBuffer text = new StringBuffer();
+					for(int columnIndex = 0; columnIndex < maxSizes.length; columnIndex++) {
+						String columnText = "";
+						if(columnIndex < row.size()) {
+							maxSizes[columnIndex] = table.getMaxColumnSize(columnIndex);
+							columnText = row.get(columnIndex);
+							if(Util.isEmpty(columnText)) {
+								columnText = "";
+							}
+						}
+						//	Validate 0
+						int size = maxSizes[columnIndex];
+						if(size > 0) {
+							if(isNumeric(columnText)) {
+								columnText = String.format("%1$" + size + "s", columnText);
+							} else {
+								columnText = String.format("%1$-" + size + "s", columnText);
+							}
+						}
+						if(text.length() > 0) {
+							text.append(columnSeparator);
+						}
+						text.append(columnText);
+						//	
+						if(isFirst) {
+							//	Separator for new column
+							if(headerLine.length() > 0) {
+								headerLine.append(columnSeparator);
+							}
+							headerLine.append(getParalelChar(columnText, "="));
+						}
+					}
+					//	For first
+					if(isFirst) {
+						addText(headerLine.toString());
+						newLine();
+						addText(text.toString());
+						newLine();
+						addText(headerLine.toString());
+						isFirst = false;
+					} else {
+						addText(text.toString());
+					}
+				}
+				//	last for table
+				newLine();
+				addText(headerLine.toString());
+				newLine();
+			}
+		}
+		return this;
+	}
+	
+	/**
+	 * Format text as bold
+	 * @param text
+	 * @return
+	 */
+	private String formatBold(String text) {
+		StringBuffer formattedValue = new StringBuffer();
+		//	\ **phrase**\ 
+		formattedValue.append("\\ **").append(text.trim()).append("**\\ ");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format as Italic
+	 * @param text
+	 * @return
+	 */
+	private String formatItalic(String text) {
+		StringBuffer formattedValue = new StringBuffer();
+		//	\ *phrase*\ 
+		formattedValue.append("\\ *").append(text.trim()).append("*\\ ");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format as Code
+	 * @param text
+	 * @return
+	 */
+	private String formatCode(String text) {
+		StringBuffer formattedValue = new StringBuffer();
+		//	``code``
+		formattedValue.append("``").append(text.trim()).append("``");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format as Quote
+	 * @param text
+	 * @return
+	 */
+	private String formatQuote(String text, boolean isNumeric, int level) {
+		//	Add Space
+		if(previouslevel != level) {
+			newLine();
+		}
+		previouslevel = level;
+		StringBuffer formattedValue = new StringBuffer();
+		//	
+		String leftSpace = "";
+		if(level > 0) {
+			leftSpace = String.format("%1$" + level + "s", ""); 
+		}
+		String type = "*";
+		if(isNumeric) {
+			type = "#.";
+		}
+		formattedValue.append(leftSpace).append(type).append(" ").append(text);
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Header
+	 * @param text
+	 * @param underValue
+	 * @return
+	 */
+	private String formatHeader(String text, String underValue) {
+		StringBuffer formattedValue = new StringBuffer(text.trim());
+		formattedValue.append(Env.NL);
+		formattedValue.append(getParalelChar(text.trim(), underValue));
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Main header
+	 * @param text
+	 * @param underValue
+	 * @return
+	 */
+	private String formatDoubleHeader(String text, String underValue) {
+		text = text.trim();
+		StringBuffer formattedValue = new StringBuffer();
+		formattedValue.append(getParalelChar(text, underValue));
+		formattedValue.append(Env.NL);
+		formattedValue.append(text);
+		formattedValue.append(Env.NL);
+		formattedValue.append(getParalelChar(text, underValue));
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format External Link Text
+	 * @param text
+	 * @return
+	 */
+	private String formatExternalLinkText(String text) {
+		StringBuffer formattedValue = new StringBuffer();
+		formattedValue.append("`").append(text.trim()).append("`_");
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Link
+	 * @param text
+	 * @param link
+	 * @return
+	 */
+	private String formatExternalLink(String text, String link) {
+		//	.. _distributed scaling: http://en.wikipedia.org/wiki/CAP_theorem
+		StringBuffer formattedValue = new StringBuffer(Env.NL);
+		//	
+		formattedValue.append(".. _").append(text.trim()).append(": ").append(link);
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Section
+	 * @param text
+	 * @return
+	 */
+	private String formatSection(String text) {
+		return formatDoubleHeader(text, "=");
+	}
+	
+	/**
+	 * Format Subsection
+	 * @param text
+	 * @return
+	 */
+	private String formatSubSection(String text) {
+		return formatHeader(text, "=");
+	}
+	
+	/**
+	 * Format Subsubsection
+	 * @param text
+	 * @return
+	 */
+	private String formatSubSubSection(String text) {
+		return formatHeader(text, "-");
+	}
+	
+	/**
+	 * Format paragraphs
+	 * @param text
+	 * @return
+	 */
+	private String formatParagraphs(String text) {
+		return formatHeader(text, "\"");
+	}
+	
+	/**
+	 * Format Parts
+	 * @param text
+	 * @return
+	 */
+	private String formatPart(String text) {
+		return formatHeader(text, "#");
+	}
+	
+	/**
+	 * Formnat Chapters
+	 * @param text
+	 * @return
+	 */
+	private String formatChapter(String text) {
+		return formatHeader(text, "*");
+	}
+	
+	/**
+	 * Get under character
+	 * @param text
+	 * @param underValue
+	 * @return
+	 */
+	private String getParalelChar(String text, String underValue) {
+		return String.format("%1$" + text.length() + "s", "").replace(" ", underValue); 
+	}
+	
+	/**
+	 * Format note
+	 * @param text
+	 * @return
+	 */
+	private String formatNote(String text) {
+		//	.. _distributed scaling: http://en.wikipedia.org/wiki/CAP_theorem
+		StringBuffer formattedValue = new StringBuffer(Env.NL);
+		//	
+		formattedValue.append(".. note::")
+			.append(Env.NL)
+			.append("    ").append(text.trim())
+			.append(Env.NL);
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * See Also
+	 * @param internalLink
+	 * @return
+	 */
+	private String formatSeeAlso(String internalLink) {
+		//	.. seealso::
+		    //	:ref:`vdufun`
+		StringBuffer formattedValue = new StringBuffer(Env.NL);
+		//	
+		formattedValue.append(".. seealso::")
+			.append(Env.NL)
+			.append("    :ref:`").append(internalLink).append("`")
+			.append(Env.NL);
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Header link
+	 * @param indexName
+	 * @return
+	 */
+	private String formatHeaderIndexName(String indexName) {
+		//	.. _api/db/security:
+		StringBuffer formattedValue = new StringBuffer(Env.NL);
+		//	
+		formattedValue.append(".. _")
+			.append(indexName).append(":")
+			.append(Env.NL);
+		return formattedValue.toString();
+	}
+	
+	/**
+	 * Format Comment
+	 * @param internalLink
+	 * @return
+	 */
+	private String formatComment(String comment) {
+		//	.. _api/db/security:
+		StringBuffer formattedValue = new StringBuffer(Env.NL);
+		//	
+		formattedValue.append(".. ")
+			.append(comment.replaceAll("\\n", "\n.."))
+			.append(Env.NL);
+		return formattedValue.toString();
+	}
+	
+	@Override
+	public AbstractTextConverter newLine() {
+		addText(Env.NL);
+		return this;
+	}
+	
+	@Override
+	public String toString() {
+		if(urlSource.length() > 0) {
+			formattedText.append(Env.NL);
+			formattedText.append(urlSource);
+			urlSource = new StringBuffer();
+		}
+		log.fine("toString=" + formattedText.toString());
+		return formattedText.toString();
+	}
+	
+	public static void main(String[] args) {
+		ReStructuredTextConverter formatter = new ReStructuredTextConverter();
+		formatter.addSection("Section");
+		formatter.addSubSection("SubSection");
+		formatter.addSubSubSection("SubSubSection");
+		formatter.addChapter("Chapter");
+		formatter.addPart("Part");
+		formatter.addBold("Hi everybody");
+		formatter.newLine();
+		formatter.newLine();
+		formatter.addBold("Hi");
+		formatter.addItalic("Hello");
+		formatter.addText("Hi all");
+		formatter.addQuote("Items");
+		formatter.addQuote("Item 1", 1);
+		formatter.addQuote("Item 2", 1);
+		formatter.addQuote("Item 2.1", 2);
+		formatter.addQuote("Item 2.2", 2);
+		formatter.addQuote("Item 2.3", 2);
+		formatter.addQuote("Item 3", 1);
+		formatter.addQuoteNumeric("Other");
+		formatter.addQuoteNumeric("Description 1", 1);
+		formatter.addQuoteNumeric("Description 2", 2);
+		formatter.addQuoteNumeric("Description 2.1", 3);
+		formatter.addQuoteNumeric("Description 2.2", 3);
+		formatter.addQuoteNumeric("Description 2.3", 3);
+		formatter.addQuoteNumeric("Description 3", 2);
+		formatter.addText("This is a collection of key documentation gathered from the ADempiere wiki and the collective experience of the "
+				+ "ADempiere Development Community. The aim of this collection is to provide a searchable and usable source of project documentation that will "
+				+ "improve on the data contained in the wiki while enhancing the readers experience. ");
+		formatter.addExternalLink("ADempiere Test", "http://demo.erpya.com:8888");
+		formatter.addText(" si no le interesa revise tambien ");
+		formatter.addExternalLink("ADempiere Test 1 ", "http://demo.erpya.com:8888/webui/");
+		formatter.addCode("String a = \"Epale\";");
+		TableTextConverter table = new TableTextConverter();
+		ArrayList<String> row = new ArrayList<>();
+		row.add("Value");
+		row.add("Name");
+		row.add("Description");
+		table.addRow(row);
+		row = new ArrayList<>();
+		row.add("Test");
+		row.add("Test Process");
+		row.add("A Test Process");
+		table.addRow(row);
+		row = new ArrayList<>();
+		row.add("Production");
+		row.add("Production Process");
+		row.add("A Production Process");
+		table.addRow(row);
+		row = new ArrayList<>();
+		row.add("Report");
+		row.add("Test Report");
+		row.add("A Test Report");
+		table.addRow(row);
+		//	
+		formatter.addTable(table);
+		//	Get it gfor a file
+		System.out.println(formatter.toString());
+	}
+
+	@Override
+	public void clear() {
+		formattedText = new StringBuffer();
+		urlSource = new StringBuffer();
+		previouslevel = -1;
+	}
+
+	@Override
+	public String getExtension() {
+		return "rst";
+	}
+	
+	@Override
+	public String getIndexFileName() {
+		return "index.rst";
+	}
+
+	@Override
+	public AbstractTextConverter addText(String text, int margin) {
+		if(Util.isEmpty(text)) {
+			return this;
+		}
+		//	Add Margin
+		String leftSpace = "";
+		if(margin > 0) {
+			leftSpace = String.format("%1$" + margin + "s", "");
+		}
+		addText(leftSpace + text);
+		return this;
+	}
+
+	@Override
+	public void addTreeDefinition(int maxdepth, boolean isnumbered) {
+		formattedText.append(".. toctree::");
+		newLine();
+		addText(":maxdepth: " + maxdepth, 4);
+		newLine();
+		if(isnumbered) {
+			addText(":numbered:", 4);
+		}
+		newLine();
+	}
+
+	@Override
+	public AbstractTextConverter addTranslationText(String text) {
+		translatedText.append(text);
+		return this;
+	}
+	
+	@Override
+	public AbstractTextConverter addStrikethrough(String text) {
+		return addText(text);
+	}
+
+	@Override
+	public void addIndex(String title, String name, String folder, int margin) {
+		addText(name, margin);
+	}
+
+	@Override
+	public void addGroup(String title, String name, int margin) {
+		
+	}
+}

--- a/base/src/org/spin/util/docs/TableTextConverter.java
+++ b/base/src/org/spin/util/docs/TableTextConverter.java
@@ -1,0 +1,108 @@
+/*************************************************************************************
+ * Product: Spin-Suite (Mobile Suite)                       		                 *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
+package org.spin.util.docs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.compiere.util.Util;
+
+/**
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ * Table object for text converter
+ * @see: https://github.com/adempiere/adempiere/issues/1934
+ * For formst reference use: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+ */
+public class TableTextConverter {
+
+	/**
+	 * Header Column Names
+	 */
+	public TableTextConverter() {
+		rows = new ArrayList<>();
+	}
+	
+	/**
+	 * Constructor with column names
+	 * @param columnNames
+	 */
+	public TableTextConverter(List<String> columnNames) {
+		this();
+		if(columnNames != null
+				&& columnNames.size() > 0) {
+			addRow(columnNames);
+		}
+	}
+	
+	/**	Rows	*/
+	private List<List<String>> rows;
+	
+	/**
+	 * Add Row
+	 * @param row
+	 */
+	public void addRow(List<String> row) {
+		rows.add(row);
+	}
+	
+	/**
+	 * Get Row
+	 * @param index
+	 * @return
+	 */
+	public List<String> getRow(int index) {
+		if(index >= rows.size()) {
+			return null;
+		}
+		//	Default
+		return rows.get(index);
+	}
+	
+	/**
+	 * Get all rows
+	 * @return
+	 */
+	public List<List<String>> getRows() {
+		return rows;
+	}
+	
+	/**
+	 * Get Max Column Size
+	 * @param columnIndex
+	 * @return
+	 */
+	public int getMaxColumnSize(int columnIndex) {
+		if(rows.size() == 0) {
+			return -1;
+		}
+		int maxSize = 0;
+		//	
+		for(List<String> row : rows) {
+			if(columnIndex >= row.size()) {
+				continue;
+			}
+			String columnText = row.get(columnIndex);
+			if(!Util.isEmpty(columnText)) {
+				if(columnText.length() > maxSize) {
+					maxSize = columnText.length();
+				}
+			}
+		}
+		//	
+		return maxSize;
+	}
+	
+}

--- a/migration/391lts-392lts/04420_1934_Process_Generate_Docs.xml
+++ b/migration/391lts-392lts/04420_1934_Process_Generate_Docs.xml
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Generate docs from Application Dictionary #1934" ReleaseNo="3.9.1" SeqNo="4420">
+    <Comments>See: https://github.com/adempiere/adempiere/issues/1934</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="284" Action="I" Record_ID="54128" Table="AD_Process">
+        <Data AD_Column_ID="2813" Column="ProcedureName" isNewNull="true"/>
+        <Data AD_Column_ID="63488" Column="AD_Browse_ID" isNewNull="true"/>
+        <Data AD_Column_ID="4374" Column="AD_ReportView_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6485" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="50182" Column="JasperReport" isNewNull="true"/>
+        <Data AD_Column_ID="2805" Column="Created">2018-08-28 23:59:39.342</Data>
+        <Data AD_Column_ID="2807" Column="Updated">2018-08-28 23:59:39.342</Data>
+        <Data AD_Column_ID="2804" Column="IsActive">true</Data>
+        <Data AD_Column_ID="50181" Column="ShowHelp">Y</Data>
+        <Data AD_Column_ID="2809" Column="Name">Generate Documentation from Menu</Data>
+        <Data AD_Column_ID="2810" Column="Description">Generate Documentation from Option Menu</Data>
+        <Data AD_Column_ID="4656" Column="Classname">org.spin.process.GenerateDocsFromMenu</Data>
+        <Data AD_Column_ID="2811" Column="Help">It process allows create docs in supported formats for external documentation handler</Data>
+        <Data AD_Column_ID="4214" Column="IsDirectPrint">false</Data>
+        <Data AD_Column_ID="4023" Column="Value">GenerateDocsFromMenu</Data>
+        <Data AD_Column_ID="11563" Column="WorkflowValue" isNewNull="true"/>
+        <Data AD_Column_ID="56515" Column="AD_Form_ID" isNewNull="true"/>
+        <Data AD_Column_ID="5790" Column="AccessLevel">4</Data>
+        <Data AD_Column_ID="12458" Column="IsBetaFunctionality">false</Data>
+        <Data AD_Column_ID="3371" Column="IsReport">false</Data>
+        <Data AD_Column_ID="14084" Column="IsServerProcess">false</Data>
+        <Data AD_Column_ID="78843" Column="GenerateClass">N</Data>
+        <Data AD_Column_ID="57920" Column="CopyFromProcess">N</Data>
+        <Data AD_Column_ID="7752" Column="AD_PrintFormat_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2808" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2806" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2801" Column="AD_Process_ID">54128</Data>
+        <Data AD_Column_ID="2802" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2803" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="11834" Column="AD_Workflow_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6653" Column="Statistic_Seconds">0</Data>
+        <Data AD_Column_ID="6652" Column="Statistic_Count">0</Data>
+        <Data AD_Column_ID="84383" Column="UUID">4223ed80-3098-11e9-8dc8-27f25de3fde8</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="287" Action="I" Record_ID="0" Table="AD_Process_Trl">
+        <Data AD_Column_ID="2854" Column="Help">It process allows create docs in supported formats for external documentation handler</Data>
+        <Data AD_Column_ID="2850" Column="Updated">2018-08-28 23:59:44.693</Data>
+        <Data AD_Column_ID="2847" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2848" Column="Created">2018-08-28 23:59:44.693</Data>
+        <Data AD_Column_ID="2852" Column="Name">Generate Documentation from Menu</Data>
+        <Data AD_Column_ID="2853" Column="Description">Generate Documentation from Option Menu</Data>
+        <Data AD_Column_ID="2855" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2849" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2851" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2846" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2845" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2844" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="2843" Column="AD_Process_ID">54128</Data>
+        <Data AD_Column_ID="84387" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="287" Action="U" Record_ID="0" Table="AD_Process_Trl">
+        <Data AD_Column_ID="2852" Column="Name" oldValue="Generate Documentation from Menu">Generar Documentación desde Menú</Data>
+        <Data AD_Column_ID="2853" Column="Description" oldValue="Generate Documentation from Option Menu">Generar Documentación desde Menú de Opciones</Data>
+        <Data AD_Column_ID="2844" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="2843" Column="AD_Process_ID" oldValue="54128">54128</Data>
+        <Data AD_Column_ID="2854" Column="Help" oldValue="It process allows create docs in supported formats for external documentation handler">Permite crear documentación en Formatos soportados para manejadores externos de documentos, reStructuredText or MarkDown</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="284" Action="U" Record_ID="54128" Table="AD_Process">
+        <Data AD_Column_ID="2811" Column="Help" oldValue="It process allows create docs in supported formats for external documentation handler">It process allows create docs in supported formats for external documentation handler, reStructuredText or MarkDown</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="287" Action="U" Record_ID="0" Table="AD_Process_Trl">
+        <Data AD_Column_ID="2854" Column="Help" oldValue="Permite crear documentación en Formatos soportados para manejadores externos de documentos, reStructuredText or MarkDown">Permite crear documentación en Formatos soportados para manejadores externos de documentos, reStructuredText o MarkDown</Data>
+        <Data AD_Column_ID="2844" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="2843" Column="AD_Process_ID" oldValue="54128">54128</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="102" Action="I" Record_ID="54061" Table="AD_Reference">
+        <Data AD_Column_ID="556" Column="Updated">2018-08-29 00:05:45.072</Data>
+        <Data AD_Column_ID="553" Column="IsActive">true</Data>
+        <Data AD_Column_ID="554" Column="Created">2018-08-29 00:05:45.072</Data>
+        <Data AD_Column_ID="54355" Column="IsOrderByValue">false</Data>
+        <Data AD_Column_ID="1180" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="130" Column="Name">ExportFormat List</Data>
+        <Data AD_Column_ID="131" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="139" Column="ValidationType">L</Data>
+        <Data AD_Column_ID="132" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="555" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="557" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="129" Column="AD_Reference_ID">54061</Data>
+        <Data AD_Column_ID="6486" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="363" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="364" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="84393" Column="UUID">431166fa-3098-11e9-8dcd-63e1650d7d8c</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="126" Action="I" Record_ID="54061" Table="AD_Reference_Trl">
+        <Data AD_Column_ID="282" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="666" Column="IsActive">true</Data>
+        <Data AD_Column_ID="667" Column="Created">2018-08-29 00:05:46.086</Data>
+        <Data AD_Column_ID="669" Column="Updated">2018-08-29 00:05:46.086</Data>
+        <Data AD_Column_ID="283" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="280" Column="Name">ExportFormat List</Data>
+        <Data AD_Column_ID="281" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="670" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="668" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="1203" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="1202" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="278" Column="AD_Reference_ID">54061</Data>
+        <Data AD_Column_ID="279" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84394" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="276" Action="I" Record_ID="60430" Table="AD_Element">
+        <Data AD_Column_ID="4299" Column="PrintName">Export Format</Data>
+        <Data AD_Column_ID="2600" Column="Updated">2018-08-29 00:06:06.21</Data>
+        <Data AD_Column_ID="2598" Column="Created">2018-08-29 00:06:06.21</Data>
+        <Data AD_Column_ID="2597" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2605" Column="Help">The Export Format is a drop down list box for selecting the format type (text, tab delimited, XML, etc) of the file to be imported</Data>
+        <Data AD_Column_ID="2603" Column="Name">Export Format</Data>
+        <Data AD_Column_ID="2604" Column="Description">Export Format of the data</Data>
+        <Data AD_Column_ID="2602" Column="ColumnName">ExportFormat</Data>
+        <Data AD_Column_ID="6286" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="6283" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="6284" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="6285" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="58589" Column="FieldLength">255</Data>
+        <Data AD_Column_ID="58588" Column="AD_Reference_ID">17</Data>
+        <Data AD_Column_ID="2601" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2599" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2594" Column="AD_Element_ID">60430</Data>
+        <Data AD_Column_ID="6484" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="2596" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2595" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58590" Column="AD_Reference_Value_ID">54061</Data>
+        <Data AD_Column_ID="84316" Column="UUID">43675a38-3098-11e9-8dd0-7b7946fc0e9e</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="90" StepType="AD">
+      <PO AD_Table_ID="277" Action="I" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="6449" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="2641" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2642" Column="Created">2018-08-29 00:06:07.657</Data>
+        <Data AD_Column_ID="2644" Column="Updated">2018-08-29 00:06:07.657</Data>
+        <Data AD_Column_ID="2646" Column="Name">Export Format</Data>
+        <Data AD_Column_ID="6450" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="2647" Column="Description">Export Format of the data</Data>
+        <Data AD_Column_ID="2649" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="4300" Column="PrintName">Export Format</Data>
+        <Data AD_Column_ID="2648" Column="Help">The Export Format is a drop down list box for selecting the format type (text, tab delimited, XML, etc) of the file to be imported</Data>
+        <Data AD_Column_ID="6451" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="6448" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="2645" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2643" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2640" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2639" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2638" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID">60430</Data>
+        <Data AD_Column_ID="84317" Column="UUID">43675a38-3098-11e9-8dd0-7b7946fc0e9e</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="100" StepType="AD">
+      <PO AD_Table_ID="276" Action="U" Record_ID="60430" Table="AD_Element">
+        <Data AD_Column_ID="2605" Column="Help" oldValue="The Export Format is a drop down list box for selecting the format type (text, tab delimited, XML, etc) of the file to be imported">The Export Format is used for determine if document format is for a specific documentation, they can be reStructuredText or MarkDown</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="110" StepType="AD">
+      <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2646" Column="Name" oldValue="Export Format">Formato de Exportación</Data>
+        <Data AD_Column_ID="2647" Column="Description" oldValue="Export Format of the data">Formato de Exportación de Documentación</Data>
+        <Data AD_Column_ID="4300" Column="PrintName" oldValue="Export Format">Formato de Exportación</Data>
+        <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="60430">60430</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="120" StepType="AD">
+      <PO AD_Table_ID="276" Action="U" Record_ID="60430" Table="AD_Element">
+        <Data AD_Column_ID="2604" Column="Description" oldValue="Export Format of the data">Export Format of the Documentation</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="130" StepType="AD">
+      <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="60430">60430</Data>
+        <Data AD_Column_ID="2648" Column="Help" oldValue="The Export Format is a drop down list box for selecting the format type (text, tab delimited, XML, etc) of the file to be imported">El Formatoi de Exportación es usado para determinar el formato en el quje será exportada la documentación, ellos pueden ser reStructuredText o MarkDown</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="140" StepType="AD">
+      <PO AD_Table_ID="276" Action="U" Record_ID="60430" Table="AD_Element">
+        <Data AD_Column_ID="2605" Column="Help" oldValue="The Export Format is used for determine if document format is for a specific documentation, they can be reStructuredText or MarkDown">The Export Format is used for determine if format is for a specific documentation, they can be reStructuredText or MarkDown</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="150" StepType="AD">
+      <PO AD_Table_ID="276" Action="U" Record_ID="60430" Table="AD_Element">
+        <Data AD_Column_ID="2602" Column="ColumnName" oldValue="ExportFormat">DocsExportFormat</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="160" StepType="AD">
+      <PO AD_Table_ID="102" Action="U" Record_ID="54061" Table="AD_Reference">
+        <Data AD_Column_ID="130" Column="Name" oldValue="ExportFormat List">DocsExportFormat List</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="170" StepType="AD">
+      <PO AD_Table_ID="285" Action="I" Record_ID="56564" Table="AD_Process_Para">
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="2817" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2820" Column="Updated">2018-08-29 00:10:22.114</Data>
+        <Data AD_Column_ID="2818" Column="Created">2018-08-29 00:10:22.114</Data>
+        <Data AD_Column_ID="4017" Column="ColumnName">DocsExportFormat</Data>
+        <Data AD_Column_ID="2823" Column="Description">Export Format of the Documentation</Data>
+        <Data AD_Column_ID="2824" Column="Help">The Export Format is used for determine if format is for a specific documentation, they can be reStructuredText or MarkDown</Data>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="2830" Column="IsRange">false</Data>
+        <Data AD_Column_ID="2822" Column="Name">Export Format</Data>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="3739" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="3738" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="81287" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="2821" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2819" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID">56564</Data>
+        <Data AD_Column_ID="7728" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3737" Column="FieldLength">255</Data>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID">54128</Data>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID">17</Data>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID">54061</Data>
+        <Data AD_Column_ID="2826" Column="SeqNo">10</Data>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID">60430</Data>
+        <Data AD_Column_ID="84385" Column="UUID">44a9ead2-3098-11e9-8dd8-27a60ac98fe0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="180" StepType="AD">
+      <PO AD_Table_ID="286" Action="I" Record_ID="56564" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="2841" Column="Description">Export Format of the Documentation</Data>
+        <Data AD_Column_ID="2838" Column="Updated">2018-08-29 00:10:22.943</Data>
+        <Data AD_Column_ID="2836" Column="Created">2018-08-29 00:10:22.943</Data>
+        <Data AD_Column_ID="2835" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3743" Column="Help">The Export Format is used for determine if format is for a specific documentation, they can be reStructuredText or MarkDown</Data>
+        <Data AD_Column_ID="2842" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2840" Column="Name">Export Format</Data>
+        <Data AD_Column_ID="2837" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID">56564</Data>
+        <Data AD_Column_ID="2832" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84386" Column="UUID">44a9ead2-3098-11e9-8dd8-27a60ac98fe0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="190" StepType="AD">
+      <PO AD_Table_ID="285" Action="I" Record_ID="56565" Table="AD_Process_Para">
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="2817" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2820" Column="Updated">2018-08-29 00:10:43.161</Data>
+        <Data AD_Column_ID="2818" Column="Created">2018-08-29 00:10:43.161</Data>
+        <Data AD_Column_ID="4017" Column="ColumnName">File_Directory</Data>
+        <Data AD_Column_ID="2823" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="2824" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="2830" Column="IsRange">false</Data>
+        <Data AD_Column_ID="2822" Column="Name">File_Directory</Data>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="3739" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="3738" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="81287" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="2821" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2819" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID">56565</Data>
+        <Data AD_Column_ID="7728" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3737" Column="FieldLength">255</Data>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID">54128</Data>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID">14</Data>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2826" Column="SeqNo">20</Data>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID">50022</Data>
+        <Data AD_Column_ID="84385" Column="UUID">44fe92b2-3098-11e9-8ddb-ef09acab339e</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="200" StepType="AD">
+      <PO AD_Table_ID="286" Action="I" Record_ID="56565" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="2841" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="2838" Column="Updated">2018-08-29 00:10:44.794</Data>
+        <Data AD_Column_ID="2836" Column="Created">2018-08-29 00:10:44.794</Data>
+        <Data AD_Column_ID="2835" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3743" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="2842" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2840" Column="Name">File_Directory</Data>
+        <Data AD_Column_ID="2837" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID">56565</Data>
+        <Data AD_Column_ID="2832" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84386" Column="UUID">44fe92b2-3098-11e9-8ddb-ef09acab339e</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="210" StepType="AD">
+      <PO AD_Table_ID="104" Action="I" Record_ID="55186" Table="AD_Ref_List">
+        <Data AD_Column_ID="564" Column="Created">2018-08-29 00:11:46.089</Data>
+        <Data AD_Column_ID="566" Column="Updated">2018-08-29 00:11:46.089</Data>
+        <Data AD_Column_ID="563" Column="IsActive">true</Data>
+        <Data AD_Column_ID="200" Column="Value">org.spin.util.ReStructuredTextConverter</Data>
+        <Data AD_Column_ID="150" Column="Description">reStructuredText Format</Data>
+        <Data AD_Column_ID="152" Column="ValidFrom" isNewNull="true"/>
+        <Data AD_Column_ID="149" Column="Name">reStructuredText</Data>
+        <Data AD_Column_ID="153" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="565" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="567" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="7712" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="148" Column="AD_Ref_List_ID">55186</Data>
+        <Data AD_Column_ID="372" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="371" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="151" Column="AD_Reference_ID">54061</Data>
+        <Data AD_Column_ID="84390" Column="UUID">45525b5e-3098-11e9-8dde-c70f44e97a15</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="220" StepType="AD">
+      <PO AD_Table_ID="136" Action="I" Record_ID="55186" Table="AD_Ref_List_Trl">
+        <Data AD_Column_ID="707" Column="Created">2018-08-29 00:11:47.885</Data>
+        <Data AD_Column_ID="706" Column="IsActive">true</Data>
+        <Data AD_Column_ID="709" Column="Updated">2018-08-29 00:11:47.885</Data>
+        <Data AD_Column_ID="339" Column="Description">reStructuredText Format</Data>
+        <Data AD_Column_ID="338" Column="Name">reStructuredText</Data>
+        <Data AD_Column_ID="340" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="710" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="708" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="1216" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="1215" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="336" Column="AD_Ref_List_ID">55186</Data>
+        <Data AD_Column_ID="337" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84391" Column="UUID">45525b5e-3098-11e9-8dde-c70f44e97a15</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="230" StepType="AD">
+      <PO AD_Table_ID="116" Action="I" Record_ID="54354" Table="AD_Menu">
+        <Data AD_Column_ID="4426" Column="IsSOTrx">false</Data>
+        <Data AD_Column_ID="6651" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="598" Column="IsActive">true</Data>
+        <Data AD_Column_ID="599" Column="Created">2018-08-29 00:14:18.954</Data>
+        <Data AD_Column_ID="601" Column="Updated">2018-08-29 00:14:18.954</Data>
+        <Data AD_Column_ID="229" Column="Name">Generate Documentation from Menu</Data>
+        <Data AD_Column_ID="1169" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="230" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="232" Column="Action">R</Data>
+        <Data AD_Column_ID="59134" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="6297" Column="AD_Workbench_ID" isNewNull="true"/>
+        <Data AD_Column_ID="4621" Column="AD_Form_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3375" Column="AD_Process_ID">54128</Data>
+        <Data AD_Column_ID="602" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="600" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="228" Column="AD_Menu_ID">54354</Data>
+        <Data AD_Column_ID="7721" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="399" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="400" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="234" Column="AD_Workflow_ID" isNewNull="true"/>
+        <Data AD_Column_ID="233" Column="AD_Window_ID" isNewNull="true"/>
+        <Data AD_Column_ID="235" Column="AD_Task_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57960" Column="AD_Browse_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84344" Column="UUID">45a4cf38-3098-11e9-8de1-dfa97a796192</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="240" StepType="AD">
+      <PO AD_Table_ID="120" Action="I" Record_ID="54354" Table="AD_Menu_Trl">
+        <Data AD_Column_ID="637" Column="Created">2018-08-29 00:14:20.934</Data>
+        <Data AD_Column_ID="636" Column="IsActive">true</Data>
+        <Data AD_Column_ID="639" Column="Updated">2018-08-29 00:14:20.934</Data>
+        <Data AD_Column_ID="247" Column="Name">Generate Documentation from Menu</Data>
+        <Data AD_Column_ID="248" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="249" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="638" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="640" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1194" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1195" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="245" Column="AD_Menu_ID">54354</Data>
+        <Data AD_Column_ID="246" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84345" Column="UUID">45a4cf38-3098-11e9-8de1-dfa97a796192</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="250" StepType="AD">
+      <PO AD_Table_ID="452" Action="I" Record_ID="54354" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6153" Column="Updated">2018-08-29 00:14:21.154</Data>
+        <Data AD_Column_ID="6150" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6151" Column="Created">2018-08-29 00:14:21.154</Data>
+        <Data AD_Column_ID="6157" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6154" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6152" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="6161" Column="Node_ID">54354</Data>
+        <Data AD_Column_ID="6155" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6162" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="6149" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID">10</Data>
+        <Data AD_Column_ID="84442" Column="UUID">45a4cf38-3098-11e9-8de1-dfa97a796192</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="260" StepType="AD">
+      <PO AD_Table_ID="116" Action="U" Record_ID="54354" Table="AD_Menu">
+        <Data AD_Column_ID="232" Column="Action" oldValue="R">P</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="270" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="54354" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="999">0</Data>
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="54354">54354</Data>
+        <Data AD_Column_ID="6155" Column="Parent_ID" oldValue="0">159</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="280" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="114" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="0">1</Data>
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="114">114</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="290" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="108" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="1">2</Data>
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="108">108</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="300" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="115" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="2">3</Data>
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="115">115</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="310" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="53225" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="3">4</Data>
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="53225">53225</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="320" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="53226" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="4">5</Data>
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="53226">53226</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="330" StepType="AD">
+      <PO AD_Table_ID="53660" Action="I" Record_ID="116" Table="AD_Table_Process">
+        <Data AD_Column_ID="69648" Column="AD_Table_ID">116</Data>
+        <Data AD_Column_ID="69641" Column="IsActive">true</Data>
+        <Data AD_Column_ID="69642" Column="Created">2018-08-29 00:24:40.105</Data>
+        <Data AD_Column_ID="69643" Column="Updated">2018-08-29 00:24:40.105</Data>
+        <Data AD_Column_ID="69647" Column="AD_Process_ID">54128</Data>
+        <Data AD_Column_ID="69645" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="69644" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="69649" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="69640" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="69639" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="84427" Column="UUID">478d3146-3098-11e9-8dea-3bec02b13f89</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="340" StepType="AD">
+      <PO AD_Table_ID="285" Action="U" Record_ID="56565" Table="AD_Process_Para">
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID" oldValue="14">38</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="350" StepType="AD">
+      <PO AD_Table_ID="104" Action="U" Record_ID="55186" Table="AD_Ref_List">
+        <Data AD_Column_ID="200" Column="Value" oldValue="org.spin.util.ReStructuredTextConverter">org.spin.util.docs.ReStructuredTextConverter</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="360" StepType="AD">
+      <PO AD_Table_ID="104" Action="I" Record_ID="55307" Table="AD_Ref_List">
+        <Data AD_Column_ID="563" Column="IsActive">true</Data>
+        <Data AD_Column_ID="564" Column="Created">2019-02-15 17:47:57.978</Data>
+        <Data AD_Column_ID="566" Column="Updated">2019-02-15 17:47:57.978</Data>
+        <Data AD_Column_ID="200" Column="Value">org.spin.util.docs.MarkdownConverter</Data>
+        <Data AD_Column_ID="7712" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="151" Column="AD_Reference_ID">54061</Data>
+        <Data AD_Column_ID="150" Column="Description">Markdown Format</Data>
+        <Data AD_Column_ID="152" Column="ValidFrom" isNewNull="true"/>
+        <Data AD_Column_ID="149" Column="Name">Markdown</Data>
+        <Data AD_Column_ID="153" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="148" Column="AD_Ref_List_ID">55307</Data>
+        <Data AD_Column_ID="372" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="371" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="565" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="567" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84390" Column="UUID">900f87fc-316f-11e9-880a-c39a4a451b1b</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="370" StepType="AD">
+      <PO AD_Table_ID="136" Action="I" Record_ID="55307" Table="AD_Ref_List_Trl">
+        <Data AD_Column_ID="707" Column="Created">2019-02-15 17:48:03.971</Data>
+        <Data AD_Column_ID="709" Column="Updated">2019-02-15 17:48:03.971</Data>
+        <Data AD_Column_ID="706" Column="IsActive">true</Data>
+        <Data AD_Column_ID="338" Column="Name">Markdown</Data>
+        <Data AD_Column_ID="340" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="339" Column="Description">Markdown Format</Data>
+        <Data AD_Column_ID="1216" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="1215" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="710" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="708" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="336" Column="AD_Ref_List_ID">55307</Data>
+        <Data AD_Column_ID="337" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84391" Column="UUID">900f87fc-316f-11e9-880a-c39a4a451b1b</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/migration/391lts-392lts/04420_1934_Process_Generate_Docs.xml
+++ b/migration/391lts-392lts/04420_1934_Process_Generate_Docs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Generate docs from Application Dictionary #1934" ReleaseNo="3.9.1" SeqNo="4420">
+  <Migration EntityType="D" Name="Generate docs from Application Dictionary #1934" ReleaseNo="3.9.2" SeqNo="4420">
     <Comments>See: https://github.com/adempiere/adempiere/issues/1934</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="284" Action="I" Record_ID="54128" Table="AD_Process">
@@ -59,11 +59,11 @@
     </Step>
     <Step SeqNo="30" StepType="AD">
       <PO AD_Table_ID="287" Action="U" Record_ID="0" Table="AD_Process_Trl">
-        <Data AD_Column_ID="2852" Column="Name" oldValue="Generate Documentation from Menu">Generar Documentación desde Menú</Data>
-        <Data AD_Column_ID="2853" Column="Description" oldValue="Generate Documentation from Option Menu">Generar Documentación desde Menú de Opciones</Data>
         <Data AD_Column_ID="2844" Column="AD_Language" oldValue="es_MX">es_MX</Data>
         <Data AD_Column_ID="2843" Column="AD_Process_ID" oldValue="54128">54128</Data>
         <Data AD_Column_ID="2854" Column="Help" oldValue="It process allows create docs in supported formats for external documentation handler">Permite crear documentación en Formatos soportados para manejadores externos de documentos, reStructuredText or MarkDown</Data>
+        <Data AD_Column_ID="2852" Column="Name" oldValue="Generate Documentation from Menu">Generar Documentación desde Menú</Data>
+        <Data AD_Column_ID="2853" Column="Description" oldValue="Generate Documentation from Option Menu">Generar Documentación desde Menú de Opciones</Data>
       </PO>
     </Step>
     <Step SeqNo="40" StepType="AD">
@@ -435,8 +435,8 @@
     <Step SeqNo="290" StepType="AD">
       <PO AD_Table_ID="452" Action="U" Record_ID="108" Table="AD_TreeNodeMM">
         <Data AD_Column_ID="6157" Column="SeqNo" oldValue="1">2</Data>
-        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="108">108</Data>
         <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="108">108</Data>
       </PO>
     </Step>
     <Step SeqNo="300" StepType="AD">
@@ -520,6 +520,35 @@
         <Data AD_Column_ID="336" Column="AD_Ref_List_ID">55307</Data>
         <Data AD_Column_ID="337" Column="AD_Language">es_MX</Data>
         <Data AD_Column_ID="84391" Column="UUID">900f87fc-316f-11e9-880a-c39a4a451b1b</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="380" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="54423" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="54423">54423</Data>
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="16">17</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="390" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="54354" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="54354">54354</Data>
+        <Data AD_Column_ID="6155" Column="Parent_ID" oldValue="159">155</Data>
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="0">18</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="400" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="53920" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="53920">53920</Data>
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="17">19</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="410" StepType="AD">
+      <PO AD_Table_ID="452" Action="U" Record_ID="383" Table="AD_TreeNodeMM">
+        <Data AD_Column_ID="6161" Column="Node_ID" oldValue="383">383</Data>
+        <Data AD_Column_ID="6157" Column="SeqNo" oldValue="18">20</Data>
+        <Data AD_Column_ID="6160" Column="AD_Tree_ID" oldValue="10">10</Data>
       </PO>
     </Step>
   </Migration>


### PR DESCRIPTION
Hi guys, this pull request allows generate documentation from ADempiere Application Dictionary, the documentation can be generated for:

- [Markdown](https://en.wikipedia.org/wiki/Markdown)
- [reStructuredText](http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)

The result for it documentation can be some like here: [https://adempiere.github.io/](https://adempiere.github.io/) 
See this video for know what is step by step
![current ogv](https://user-images.githubusercontent.com/2333092/52888462-1d4a5200-3152-11e9-944c-d1b8d607c8f0.gif)


Fixex: #1934 