### PR TITLE
#2383 Override the getPopupMenu method() in webui date / time editor.

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
@@ -37,7 +37,9 @@ import org.zkoss.zk.ui.event.Events;
  * @version $Revision: 0.10 $
  *
  * @author	Michael McKay
- * 				<li>release/380 - add old value comparison to support lookup/info windows
+ * 		<li>release/380 - add old value comparison to support lookup/info windows
+ * 		<li><a href="https://github.com/adempiere/adempiere/issues/2383">#2383</a> Override the getPopupMenu method.
+ * 
  * @author Yamel Senih, ysenih@erpcya.com, ERPCyA http://www.erpcya.com
  *		<li> FR [ 146 ] Remove unnecessary class, add support for info to specific column
  *		@see https://github.com/adempiere/adempiere/issues/146
@@ -248,6 +250,15 @@ public class WDateEditor extends WEditor implements ContextMenuListener
 				return true;
 			else
 				return false;
+	}
+
+	// #2383
+	/**
+	 *  Get the pop up menu for this editor
+	 */
+    public WEditorPopupMenu getPopupMenu()
+	{
+	   	return popupMenu;
 	}
 
 }

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
@@ -31,6 +31,8 @@ import org.zkoss.zk.ui.event.Events;
  * @author Yamel Senih, ysenih@erpcya.com, ERPCyA http://www.erpcya.com
  *		<li> FR [ 146 ] Remove unnecessary class, add support for info to specific column
  *		@see https://github.com/adempiere/adempiere/issues/146
+ * @author Michael McKay, mckayERP@gmail.com
+ * 		<li><a href="https://github.com/adempiere/adempiere/issues/2383">#2383</a> Override the getPopupMenu method.
  */
 public class WDatetimeEditor extends WEditor implements ContextMenuListener
 {
@@ -208,4 +210,14 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
 			WRecordInfo.start(gridField);
 		}
 	}
+	
+	// #2383
+	/**
+	 *  Get the pop up menu for this editor
+	 */
+    public WEditorPopupMenu getPopupMenu()
+	{
+	   	return popupMenu;
+	}
+
 }

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WTimeEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WTimeEditor.java
@@ -33,6 +33,8 @@ import org.zkoss.zul.Timebox;
  * @author Yamel Senih, ysenih@erpcya.com, ERPCyA http://www.erpcya.com
  *		<li> FR [ 146 ] Remove unnecessary class, add support for info to specific column
  *		@see https://github.com/adempiere/adempiere/issues/146
+ * @author Michael McKay, mckayERP@gmail.com
+ * 		<li><a href="https://github.com/adempiere/adempiere/issues/2383">#2383</a> Override the getPopupMenu method.
  */
 public class WTimeEditor extends WEditor implements ContextMenuListener
 {
@@ -204,4 +206,14 @@ public class WTimeEditor extends WEditor implements ContextMenuListener
 			WRecordInfo.start(gridField);
 		}
 	}
+	
+	// #2383
+	/**
+	 *  Get the pop up menu for this editor
+	 */
+    public WEditorPopupMenu getPopupMenu()
+	{
+	   	return popupMenu;
+	}
+
 }


### PR DESCRIPTION
Fixes #2383.

Overrides the getPopupMenu() method which returns null by default.
