### PR TITLE
#2373 Add shortcut key Shift+F2 to copy record in webui.

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/component/CWindowToolbar.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/component/CWindowToolbar.java
@@ -57,6 +57,8 @@ import org.zkoss.zul.Space;
  * 		@see FR [ 990 ] Sort Tab is not MVC</a>
  * 		<a href="https://github.com/adempiere/adempiere/issues/999">
  * 		@see FR [ 999 ] Add ZK Support for Process Action</a>
+ * @author Michael McKay, mckayERP@gmail.com
+ * 		<li><a href="https://github.com/adempiere/adempiere/issues/2373">#2373</a> Add copy record shortcut key Shift+F2
  */
 public class CWindowToolbar extends FToolbar implements EventListener
 {
@@ -104,6 +106,7 @@ public class CWindowToolbar extends FToolbar implements EventListener
     private Map<Integer, ToolBarButton> keyMap = new HashMap<Integer, ToolBarButton>();
     private Map<Integer, ToolBarButton> altKeyMap = new HashMap<Integer, ToolBarButton>();
     private Map<Integer, ToolBarButton> ctrlKeyMap = new HashMap<Integer, ToolBarButton>();
+    private Map<Integer, ToolBarButton> shiftKeyMap = new HashMap<Integer, ToolBarButton>();
 
 	private boolean embedded;
 
@@ -330,6 +333,8 @@ public class CWindowToolbar extends FToolbar implements EventListener
 		ctrlKeyMap.put(VK_S, btnSave);
 		ctrlKeyMap.put(VK_D, btnDelete);
 		ctrlKeyMap.put(VK_F, btnFind);
+		
+		shiftKeyMap.put(KeyEvent.F2, btnCopy);
 	}
 
 	protected void addSeparator()
@@ -598,6 +603,7 @@ public class CWindowToolbar extends FToolbar implements EventListener
 
 	private void onCtrlKeyEvent(KeyEvent keyEvent) {
 		ToolBarButton btn = null;
+		// <Alt>
 		if (keyEvent.isAltKey() && !keyEvent.isCtrlKey() && !keyEvent.isShiftKey())
 		{
 			if (keyEvent.getKeyCode() == VK_X)
@@ -614,18 +620,26 @@ public class CWindowToolbar extends FToolbar implements EventListener
 			{
 				btn = altKeyMap.get(keyEvent.getKeyCode());
 			}
-		}else if (!keyEvent.isAltKey() && keyEvent.isCtrlKey() && !keyEvent.isShiftKey())
+		}
+		// <Ctrl>
+		else if (!keyEvent.isAltKey() && keyEvent.isCtrlKey() && !keyEvent.isShiftKey())
 		{
 			btn = ctrlKeyMap.get(keyEvent.getKeyCode());
 		}
-		else if (!keyEvent.isAltKey() && keyEvent.isCtrlKey() && !keyEvent.isShiftKey())
-			btn = ctrlKeyMap.get(keyEvent.getKeyCode());
+		// <Shift>
+		else if (!keyEvent.isAltKey() && !keyEvent.isCtrlKey() && keyEvent.isShiftKey())
+		{
+			btn = shiftKeyMap.get(keyEvent.getKeyCode());
+		}
+		// Normal eg <F2>
 		else if (!keyEvent.isAltKey() && !keyEvent.isCtrlKey() && !keyEvent.isShiftKey())
+		{
 			btn = keyMap.get(keyEvent.getKeyCode());
-		else if (!keyEvent.isAltKey() && keyEvent.isCtrlKey() && !keyEvent.isShiftKey())
-			btn = ctrlKeyMap.get(keyEvent.getKeyCode());
-		else if (!keyEvent.isAltKey() && !keyEvent.isCtrlKey() && !keyEvent.isShiftKey())
-			btn = keyMap.get(keyEvent.getKeyCode());
+		}
+//		else if (!keyEvent.isAltKey() && keyEvent.isCtrlKey() && !keyEvent.isShiftKey())
+//			btn = ctrlKeyMap.get(keyEvent.getKeyCode());
+//		else if (!keyEvent.isAltKey() && !keyEvent.isCtrlKey() && !keyEvent.isShiftKey())
+//			btn = keyMap.get(keyEvent.getKeyCode());
 
 
 		sendButtonClickEvent(keyEvent, btn);

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/panel/ADWindowPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/panel/ADWindowPanel.java
@@ -73,7 +73,9 @@ import org.zkoss.zul.Vbox;
  *		@see https://github.com/adempiere/adempiere/issues/265
  *		<a href="https://github.com/adempiere/adempiere/issues/588">
  * 		@see FR [ 588 ] Webui status bar is located on up</a>
- * @date Feb 25, 2007
+  * @author Michael McKay, mckayERP@gmail.com
+ * 		<li><a href="https://github.com/adempiere/adempiere/issues/2373">#2373</a> Add copy record shortcut key Shift+F2
+* @date Feb 25, 2007
  * @version $Revision: 0.10 $
  */
 public class ADWindowPanel extends AbstractADWindowPanel
@@ -196,7 +198,7 @@ public class ADWindowPanel extends AbstractADWindowPanel
         		keyListener.detach();
         	keyListener = new Keylistener();
         	statusBar.appendChild(keyListener);
-        	keyListener.setCtrlKeys("#f1#f2#f3#f4#f5#f6#f7#f8#f9#f10#f11#f12^f^i^n^s^d@#left@#right@#up@#down@#pgup@#pgdn@p^p@z@x#enter");
+        	keyListener.setCtrlKeys("#f1#f2$#f2#f3#f4#f5#f6#f7#f8#f9#f10#f11#f12^f^i^n^s^d@#left@#right@#up@#down@#pgup@#pgdn@p^p@z@x#enter");
         	keyListener.addEventListener(Events.ON_CTRL_KEY, toolbar);
         	keyListener.addEventListener(Events.ON_CTRL_KEY, this);
         	keyListener.setAutoBlur(false);


### PR DESCRIPTION
Fixes #2373.

Adds Shift+F2 as a shortcut key for copy record in the webui.  This is the same key used in the Java Client.

See https://adempiere.gitbook.io/docs/v/develop/introduction/getting-started/opening-and-using-windows/shortcut-keys