### PR TITLE
Add conversion for bank statement helper method

### DIFF
--- a/base/src/org/compiere/model/MBankStatement.java
+++ b/base/src/org/compiere/model/MBankStatement.java
@@ -76,14 +76,14 @@ public class MBankStatement extends X_C_BankStatement implements DocAction
 				.first();
 		if (bankStatement == null || bankStatement.get_ID() <= 0)
 		{
-			bankStatement =  new MBankStatement(payment.getCtx() , 0 , payment.get_TrxName());
+			bankStatement = new MBankStatement(payment.getCtx() , 0 , payment.get_TrxName());
 			bankStatement.setC_BankAccount_ID(payment.getC_BankAccount_ID());
 			bankStatement.setStatementDate(payment.getDateAcct());
 			if(payment.getDescription() != null) {
 				bankStatement.setName(payment.getDescription());
 			} else {
 				SimpleDateFormat format = DisplayType.getDateFormat(DisplayType.Date);
-				bankStatement.setName(Msg.getMsg(payment.getCtx(), "@Generate@: ") + format.format(payment.getDateAcct()));
+				bankStatement.setName(Msg.parseTranslation(payment.getCtx(), "@Generate@: ") + format.format(payment.getDateAcct()));
 			}
 			bankStatement.saveEx();
 		}

--- a/base/src/org/compiere/model/MBankStatementLine.java
+++ b/base/src/org/compiere/model/MBankStatementLine.java
@@ -42,9 +42,10 @@ import org.compiere.util.Msg;
  * 			<li>BF [ 1896885 ] BS Line: don't update header if after save/delete fails
  * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
  *  	<li> FR [ 1699 ] Add support view for Bank Statement
+ *  	<li> FR [ 1699 ] Add conversion for bank statement helper method #2403
  *  	@see https://github.com/adempiere/adempiere/issues/1699
  * @author Víctor Pérez Juárez Email: victor.perez@e-evolution.com, http://www.e-evolution.com , http://github.com/e-Evolution+
- * 		<li> FR [ 1699 ] Add conversion for bank statement helper method #2403
+ * 		<li> FR [ 1699 ] Add functional programming #2403
  *      <a href="https://github.com/adempiere/adempiere/pull/2403">
  */
  public class MBankStatementLine extends X_C_BankStatementLine
@@ -196,7 +197,7 @@ import org.compiere.util.Msg;
             Optional<BigDecimal> maybeCurrencyRate = Optional.ofNullable(MConversionRate.getRate (payment.getC_Currency_ID(),
                     bankAccount.getC_Currency_ID(), conversionDate, payment.getC_ConversionType_ID(), payment.getAD_Client_ID(),
                     payment.getAD_Org_ID()));
-			maybeCurrencyRate.ifPresent(currentRate -> paymentAmount.multiply(currencyRate)
+			maybeCurrencyRate.ifPresent(currencyRate -> paymentAmount.multiply(currencyRate)
 					.setScale(currency.getStdPrecision(), BigDecimal.ROUND_HALF_UP));
         }
         setC_Payment_ID (payment.getC_Payment_ID());

--- a/base/src/org/compiere/process/StatementCreateFrom.java
+++ b/base/src/org/compiere/process/StatementCreateFrom.java
@@ -62,7 +62,7 @@ public class StatementCreateFrom extends StatementCreateFromAbstract {
 			Timestamp dateTransaction 	= getSelectionAsTimestamp(key, "P_DateTrx");  			//  1-DateTrx
 			int paymentId 	= getSelectionAsInt(key, "P_C_Payment_ID");				//	2-Payment
 			int currencyId 	= getSelectionAsInt(key, "P_C_Currency_ID");			//  3-Currency
-			BigDecimal transactionAmount 	= getSelectionAsBigDecimal(key, "P_ConvertedAmount");	//  5- Converted Amount
+			BigDecimal transactionAmount = getSelectionAsBigDecimal(key, "P_ConvertedAmount");	//  5- Converted Amount
 			//	Log
 			log.fine("Line Date=" + dateTransaction + ", Payment=" + paymentId + ", Currency=" + currencyId + ", Amt=" + transactionAmount);
 			MBankStatementLine bankStatementLine = new MBankStatementLine (bankStatement);


### PR DESCRIPTION
This pull request add conversion from payment to bank statement, currently exists the follow method:

<pre>
MBankStatement.addPayment(paymentCash);
</pre>

**Bank Account Detail**:
 - Currency: USD

**Current Behavior:**
- Payment:
 - Payment Amount: 100
 - Payment Currency: EUR
- Bank statement:
 - Trx Amount: 100
 - Currency: USD (This is bad)

**After change:**
- Payment:
 - Payment Amount: 100
 - Payment Currency: EUR
- Bank statement:
 - Trx Amount: 124.90
 - Currency: USD


The previous method add automatically a payment to current bank statement, the problem is that if payment is created with other currency, it is not converted for bank statement.

Best regard