### PR TITLE
Fix/#2347 w payment query error

### DIFF
--- a/base/src/org/adempiere/controller/PaymentFormController.java
+++ b/base/src/org/adempiere/controller/PaymentFormController.java
@@ -1,0 +1,1140 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.adempiere.controller;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.adempiere.controller.ed.CPaymentEditor;
+import org.compiere.model.GridTab;
+import org.compiere.model.MBankAccount;
+import org.compiere.model.MConversionRate;
+import org.compiere.model.MInvoice;
+import org.compiere.model.MOrder;
+import org.compiere.model.MPayment;
+import org.compiere.model.MPaymentValidate;
+import org.compiere.model.MRole;
+import org.compiere.model.X_C_Bank;
+import org.compiere.model.X_C_Invoice;
+import org.compiere.model.X_C_Order;
+import org.compiere.process.DocAction;
+import org.compiere.util.CLogger;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+import org.compiere.util.KeyNamePair;
+import org.compiere.util.Msg;
+import org.compiere.util.Trx;
+import org.compiere.util.TrxRunnable;
+import org.compiere.util.ValueNamePair;
+
+/**
+ * A controller for the VPayment and WPayment dialogs.  These are 
+ * helper functions that allow the user to take payments from customers
+ * in place of opening the Payment window.
+ * <p>
+ * The controller attempts to identify the orders, invoices and payments 
+ * involved but only as they relate to the calling document. The initial 
+ * payment amount will be the open amount of all related invoices less 
+ * any unallocated payments OR the difference between the Grand Total 
+ * and all payments.  Payments can be taken in succession as partial 
+ * payments or as a single payment or over-payment. Users should be 
+ * cautioned to avoid taking payments using this method if the payment
+ * amount is less than or equal to zero.
+ * <p>
+ * Cash payments are accepted as payment to a "Cash" bank account or cash
+ * journal.
+ * <p>
+ * Payments are completed and allocated if a single invoice is identified
+ * or can be found. If multiple invoices exist, the payment will have to be
+ * allocated manually.
+ * <p>
+ * Online processes can be defined but these are only functioning for the
+ * credit cards.  Payment processors have to be in place for this to
+ * work.  Direct Deposit and Direct Debit do not have online processes 
+ * enabled
+ * 
+ * 
+ * @author Michael McKay, mckayERP@gmail.com
+ * 		<br>Copied largely from previous work in VPayment and WPayment.
+ * 		<br>Changed the logic to allow multiple payments
+ *
+ */
+public class PaymentFormController {
+	
+	public static final String MSG_PaymentCreateConfirmation = "PaymentFormController: PaymentCreateConfirmation";
+	public static final String MSG_PaymentError = "PaymentError";
+	public static final String MSG_PaymentCreated = "PaymentCreated";
+	public static final String MSG_PaymentProcessed = "PaymentProcessed";
+	public static final String MSG_CashJournal = "PaymentFormController: CashJournal";
+	public static final String MSG_CashJournalTip = "PaymentFormController: CashJournalTip";
+	private static final String MSG_PaymentNotCreated = "PaymentFormController: PaymentNotCreated";
+	private static final String MSG_PaymentNotCompletedAfterProcessApproval = "PaymentFormController: PaymentNotCompletedAfterProcessApproval";
+	private static final String MSG_PaymentNotProcessed = "PaymentFormController: PaymentNotProcessed";
+	private static final String MSG_NoBusinessPartnerFound = "PaymentFormController: NoBusinessPartnerFound";
+	private static final String MSG_DocumentReverserdOrVoided = "PaymentFormController: DocumentReversedOrVoided";
+	private static final String Msg_NoCashJournalSelected = "PaymentFormController: NoCashJournalSelected";
+	private static final String MSG_NoCreditCardTypeSelected = "PaymentFormController: NoCreditCardTypeSelected";
+	private static final String MSG_NoBPBankAccountSelected = "PaymentFormController: NoBPBankAccountSelected";
+	private static final String MSG_ZeroPaymentAmount = "PaymentFormController: ZeroPaymentAmount";
+
+	/**	Logger			*/
+	private static CLogger log = CLogger.getCLogger(PaymentFormController.class);
+
+	
+	/**	Window						*/
+	private int                 windowNo = 0;
+	/**	Tab							*/
+	private GridTab        		gridTab;
+	/** Is SOTrx					*/
+	private boolean				isSOTrx = true;
+	/** Doc Status					*/
+	private String              docStatus = null;
+	/** Only change the payment rule - don't accept payments */
+	private boolean 			onlyChangePaymentRule;
+	/** Invoice Currency              */
+	private int	 				c_currency_id = 0;
+	/** Client							*/
+	private int                 ad_client_id = 0;
+	/** Organization					*/
+	private int                 ad_org_id = 0;
+	/** Business Partner				*/
+	private int                 c_bpartner_id = 0;
+	/** Amount of payment				*/
+	private BigDecimal			paymentAmount = Env.ZERO;
+	/** Start Payment Rule          */
+	private String				paymentRule = "";
+	/** Start Payment Term          */
+	private int					c_paymentTerm_id = 0;
+	/** Start Acct Date             */
+	private Timestamp			dateAcct = null;
+	/** Placeholder payment. Used to find the list of available credit cards */
+	private MPayment            payment = null;
+	/** Start CreditCard            */
+	private String              ccType = "";
+	/** Start Bank Account			*/
+	private int					c_bankAccount_id = 0;
+	/** Starting CashBook              */
+	private int                 cashBook_id = 0; // refers to c_bankAccount_id where BankType=Cash
+	
+	// Place holders for the user-entered values
+	private String new_paymentRule = "";
+	private Timestamp new_dateAcct = null;
+	private int new_c_paymentTerm_id = 0;
+	private int new_cashBook_id = 0;
+	private String new_ccType = "";
+	private String new_ccNumber = "";
+	private String new_ccExpDate = "";
+	private int new_c_bankAccount_id = 0;
+	private int new_c_bp_bankAccount_id = 0;
+	private BigDecimal new_paymentAmount = Env.ZERO;
+	private String new_checkRoutingNumber = "";
+	private String new_checkAccountNumber = "";
+	private String new_checkNumber = "";
+	private String new_ccName = "";
+
+	/** EMU Currencies				*/
+	private static Hashtable<Integer,KeyNamePair> currencies = null;	
+
+	/** Controller error message	*/
+	private String				errorMsg = "";
+
+	private String onlineInfo = "";
+
+	private HashMap<String, String> paymentRuleValues;
+
+	// Holders for the currently selected values
+	private ValueNamePair selectedPaymentRule;
+	private KeyNamePair selectedPaymentTerm;
+	private ValueNamePair selectedCreditCard;
+	private KeyNamePair selectedBankAccount;
+	private KeyNamePair selectedCashBook;
+	
+	/** The editor calling this controller */
+	private CPaymentEditor editor;
+
+	/** The payment document number generated once the payment is saved */
+	private String paymentDocNumber;
+
+	/** The order this payment will refer to */
+	private int c_order_id;
+
+	/** The invoice this payment will refer to */
+	private int c_invoice_id;
+
+	/** A list of invoices that may be associated with the order */
+	private List<MInvoice> invoices = new ArrayList<MInvoice>();
+	
+	/** A list of payments that may be associated with the order */
+	private List<MPayment> payments = new ArrayList<MPayment>();
+
+
+	/** The total amount open on all the invoices */
+	private BigDecimal invoiceAmountOpen = Env.ZERO;
+
+	/** The grand total on the document */
+	private BigDecimal grandTotal = Env.ZERO;
+
+	/** The total amount paid on the document */
+	private BigDecimal paidAmount = Env.ZERO;
+
+	/** The amount paid that has been allocated */
+	private BigDecimal paidAmountAllocated = Env.ZERO;
+
+	/** The amount paid that remains unallocated */
+	private BigDecimal paidAmountUnallocated = Env.ZERO;
+
+	/** The total amount invoices related to this document */
+	private BigDecimal invoiceAmount = Env.ZERO;
+
+	/** A flag, true if the document is an order */
+	private boolean isOrder = false;
+
+	/** A flag, true if the document is an invoice */
+	private boolean isInvoice = false;
+	private boolean processOnline = false;
+	private String errorInfo;
+	
+
+	/**
+	 * 
+	 */
+	public PaymentFormController(CPaymentEditor editor, int WindowNo, GridTab tab, HashMap<String, String> buttonValues) {
+		
+		this.editor = editor;
+		windowNo = WindowNo;
+		gridTab = tab;
+		paymentRuleValues = buttonValues;
+		
+	}
+	
+	public boolean init() {
+
+		//  Check the restrictions.
+		//  We need a business partner - the payment, if any, will be made to 
+		//  the same business partner.  If the BP can't be identified, its 
+		//  a problem.
+		if (gridTab.getValue("C_BPartner_ID") == null)
+		{
+			errorMsg = MSG_NoBusinessPartnerFound;
+			return false;
+		}
+
+		// Set the dateAcct to today/now
+		dateAcct = getDate();
+		
+		//  DocStatus
+		docStatus = (String)gridTab.getValue("DocStatus");
+		log.config(docStatus);
+		if (docStatus == null)
+			docStatus = "";
+
+		//	Is the Trx Reversed / Voided ?  Don't accept payments referencing it.
+		// SHouldn't be able to click the button but incase
+		if (docStatus.equals("RE") || docStatus.equals("VO"))
+		{
+			
+			errorMsg = MSG_DocumentReverserdOrVoided;
+			return false;
+			
+		}
+		
+		paymentRule = (String)gridTab.getValue("PaymentRule");
+		String payTypes = "KTSDBP";
+		if (!payTypes.contains(paymentRule) || paymentRule == null || paymentRule.isEmpty())
+		{
+		
+			// The payment rule is not allowed or unknown
+			// Don't flag an error - allow the user to correct it
+			paymentRule = X_C_Order.PAYMENTRULE_Check;
+			
+		}
+
+		//  Sales transaction?
+		isSOTrx = "Y".equals(Env.getContext(Env.getCtx(), windowNo, "IsSOTrx"));
+		grandTotal = ((BigDecimal) gridTab.getValue("GrandTotal"));		
+
+		//  Document is not complete - allow a change to the Payment Rule only
+		//  OR a PO  OR the total is zero
+		onlyChangePaymentRule = false;
+		if (!docStatus.equals("CO") && !docStatus.equals("WP") 
+			|| !isSOTrx && gridTab.getTableName().equals("C_Order") 
+			|| grandTotal.compareTo(Env.ZERO) == 0)
+		{
+			
+			onlyChangePaymentRule = true;
+			
+		}
+
+		//	Get Data from Grid
+		ad_client_id = ((Integer)gridTab.getValue("AD_Client_ID")).intValue();
+		ad_org_id = ((Integer)gridTab.getValue("AD_Org_ID")).intValue();
+		c_bpartner_id = ((Integer)gridTab.getValue("C_BPartner_ID")).intValue();
+		c_currency_id = ((Integer)gridTab.getValue("C_Currency_ID")).intValue();
+		
+		if (gridTab.getValue("C_PaymentTerm_ID") != null)
+		{
+
+			c_paymentTerm_id = ((Integer)gridTab.getValue("C_PaymentTerm_ID")).intValue();
+			
+		}
+
+		//  Since we are taking a payment, set the dateAcct to the current time
+		dateAcct = new Timestamp(System.currentTimeMillis());
+		
+		if (currencies == null)
+			loadCurrencies();
+
+		//  Try to figure out what is owing based on incomplete info
+		//  We are only looking at this document, not the Business Partner's 
+		//  credit status and balance owing.
+		
+		//  Get Order and optionally Invoice
+		isOrder = gridTab.getTableName().equals(X_C_Order.Table_Name);
+		isInvoice = gridTab.getTableName().equals(X_C_Invoice.Table_Name);
+		
+		//  If this is an order or invoice, try to find the associated invoices and payments
+		//  to determine the amounts yet to pay.
+		if (isOrder)
+		{
+			// One order, many invoices and payments
+			c_order_id = ((Integer)gridTab.getValue("C_Order_ID")).intValue();
+			
+			// Invoices
+			c_invoice_id = 0;
+			for (MInvoice inv : MInvoice.getOfOrder(Env.getCtx(), c_order_id, null))
+			{
+				if (!inv.isPaid())
+					invoices.add(inv);
+				// Adjust for credit memos
+				invoiceAmountOpen = invoiceAmountOpen.add(inv.getOpenAmt(true, null));
+				invoiceAmount = invoiceAmount.add(inv.getGrandTotal(true));
+			}
+			if (invoices.size() == 1)
+				c_invoice_id = invoices.get(0).getC_Invoice_ID();
+			
+		}
+		else if (isInvoice)
+		{
+			//  One invoice, one or no orders and possibly many payments
+			//  The only connection between unallocated payments and the invoice
+			//  is the order, otherwise, there is no way of knowing without
+			//  involving the entire business partner account activity.  In the 
+			//  payment dialog, we are just focused on this one document.
+			c_invoice_id =  ((Integer)gridTab.getValue("C_Invoice_ID")).intValue();
+			MInvoice invoice = new MInvoice(Env.getCtx(), c_invoice_id, null);
+			invoices.add(invoice);
+			invoiceAmount = invoice.getGrandTotal(true);
+			invoiceAmountOpen = invoice.getOpenAmt(true, null);
+			
+			c_order_id = invoice.getC_Order_ID();
+			
+		}
+
+		payments = new ArrayList<MPayment>();
+		paidAmount = Env.ZERO;
+		paidAmountAllocated = Env.ZERO;
+		paidAmountUnallocated = Env.ZERO;
+
+		if (c_order_id > 0)
+		{
+			// Payments
+			for (MPayment pmt : MPayment.getOfOrder(Env.getCtx(), c_order_id, null))
+			{
+				payments.add(pmt);
+				paidAmount = paidAmount.add(pmt.getPayAmt());
+				if (pmt.isAllocated())
+					paidAmountAllocated = paidAmountAllocated.add(pmt.getPayAmt());
+				else
+					paidAmountUnallocated = paidAmountUnallocated.add(pmt.getPayAmt());
+			}				
+		}
+
+		// Order with no invoice - prepayment
+		if (c_order_id > 0 && invoiceAmount.equals(Env.ZERO))
+		{
+
+			paymentAmount = grandTotal.subtract(paidAmount);
+			
+		}
+		else // No order or a non-zero invoice amount.
+		{
+			paymentAmount = invoiceAmountOpen.subtract(paidAmountUnallocated);			
+		}
+				
+		//  Create a dummy payment which is required to determine the payment processor
+		//  and possible credit card types available.
+		payment = new MPayment(Env.getCtx(), 0, null);
+		payment.setAmount(c_currency_id, paymentAmount);
+
+		return true;
+	}
+
+	/**
+	 * @return the errorMsg or empty string
+	 */
+	public String getErrorMsg() {
+		if (errorMsg == null || errorMsg.isEmpty())
+			return "";
+		
+		String message = Msg.translate(Env.getCtx(), errorMsg);
+		if (errorInfo != null && !errorInfo.isEmpty())
+			message += " " + errorInfo;
+		
+		return message;
+	}
+
+	/**
+	 *	Fill Currencies with EMU currencies
+	 */
+	private void loadCurrencies()
+	{
+		
+		currencies = new Hashtable<Integer,KeyNamePair>(12);	//	Currenly only 10+1
+		String SQL = "SELECT C_Currency_ID, ISO_Code FROM C_Currency "
+			+ "WHERE (IsEMUMember='Y' AND EMUEntryDate<SysDate) OR IsEuro='Y' "
+			+ "ORDER BY 2";
+		try
+		{
+			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
+			ResultSet rs = pstmt.executeQuery();
+			while (rs.next())
+			{
+				int id = rs.getInt(1);
+				String name = rs.getString(2);
+				currencies.put(new Integer(id), new KeyNamePair(id, name));
+			}
+			rs.close();
+			pstmt.close();
+		}
+		catch (SQLException e)
+		{
+			log.log(Level.SEVERE, SQL, e);
+		}
+	}	//	loadCurrencies
+
+	public boolean isEMUCurrency() {
+		
+		if (currencies == null)
+			loadCurrencies();
+		
+		//	Is the currency an EMU currency?
+		Integer C_Currency_ID = new Integer(c_currency_id);
+		return currencies.containsKey(C_Currency_ID);
+	}
+
+	public Hashtable<Integer, KeyNamePair> getCurrencies() {
+		
+		if (currencies == null)
+			loadCurrencies();
+
+		return currencies;
+	}
+
+	public KeyNamePair getCurrentCurrency() {
+		
+		if (currencies != null)
+			return currencies.get(c_currency_id);
+		
+		return null;
+	}
+
+	public ArrayList<ValueNamePair> getPaymentRules() {
+		
+		ArrayList<ValueNamePair> rules = new ArrayList<ValueNamePair>();
+		Object[] a = paymentRuleValues.keySet().toArray();
+		selectedPaymentRule = null;
+		
+		for (int i = 0; i < a.length; i++)
+		{			
+			String PaymentRule = (String)a[i];		//	used for Panel selection
+			if (X_C_Order.PAYMENTRULE_DirectDebit.equals(PaymentRule)			//	SO
+				&& !isSOTrx)
+				continue;
+			else if (X_C_Order.PAYMENTRULE_DirectDeposit.equals(PaymentRule)	//	PO 
+				&& isSOTrx)
+				continue;
+			
+			else if (X_C_Order.PAYMENTRULE_Mixed.equals(PaymentRule)) // Mixed is not implemented
+				continue;
+                                                
+			ValueNamePair pp = new ValueNamePair(PaymentRule, (String)paymentRuleValues.get(a[i]));
+			rules.add(pp);
+			if (PaymentRule.toString().equals(paymentRule))	//	to select
+				selectedPaymentRule = pp;
+		}
+		
+		return rules;
+
+	}
+
+	/**
+	 * @return the selectedPaymentRule
+	 */
+	public ValueNamePair getSelectedPaymentRule() {
+		return selectedPaymentRule;
+	}
+
+	public String whichPanel(ValueNamePair pp) {
+		String s = pp.getValue().toLowerCase();
+		if (X_C_Order.PAYMENTRULE_DirectDebit.equalsIgnoreCase(s))
+			s = X_C_Order.PAYMENTRULE_DirectDeposit.toLowerCase();
+		s += "Panel";
+		return s;
+	}
+	
+	/**
+	 * Get the list of available payment terms
+	 * @return
+	 */
+	public ArrayList<KeyNamePair> getPaymentTerms() {
+
+		ArrayList<KeyNamePair> paymentTerms = new ArrayList<KeyNamePair>();
+		
+		selectedPaymentTerm = null;
+		
+		// 	Load Payment Terms
+		String SQL = MRole.getDefault().addAccessSQL(
+			"SELECT C_PaymentTerm_ID, Name FROM C_PaymentTerm WHERE IsActive='Y' ORDER BY Name",
+			"C_PaymentTerm", MRole.SQL_NOTQUALIFIED, MRole.SQL_RO);
+		try
+		{
+			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
+			ResultSet rs = pstmt.executeQuery();
+			while (rs.next())
+			{
+				int key = rs.getInt(1);
+				String name = rs.getString(2);
+				KeyNamePair pp = new KeyNamePair(key, name);
+				paymentTerms.add(pp);
+				if (key == c_paymentTerm_id)
+					selectedPaymentTerm = pp;
+			}
+			rs.close();
+			pstmt.close();
+		}
+		catch (SQLException ept)
+		{
+			log.log(Level.SEVERE, SQL, ept);
+		}
+
+		return paymentTerms;
+	}
+
+	/**
+	 * @return the selectedPaymentTerm
+	 */
+	public KeyNamePair getSelectedPaymentTerm() {
+		return selectedPaymentTerm;
+	}
+	
+	/**
+	 * Get the list of business partner accounts
+	 * @return a list of accounts
+	 */
+	public ArrayList<KeyNamePair> getBPAccounts() {
+		
+		ArrayList<KeyNamePair> accounts = new ArrayList<KeyNamePair>();
+		
+		// 	Load Accounts
+		String SQL = "SELECT a.C_BP_BankAccount_ID, NVL(b.Name, ' ')||'_'||NVL(a.AccountNo, ' ') AS Acct "
+			+ "FROM C_BP_BankAccount a"
+			+ " LEFT OUTER JOIN C_Bank b ON (a.C_Bank_ID=b.C_Bank_ID) "
+			+ "WHERE a.C_BPartner_ID=?"
+			+ "AND a.IsActive='Y' AND a.IsACH='Y'";
+		try
+		{
+			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
+			pstmt.setInt(1, c_bpartner_id);
+			ResultSet rs = pstmt.executeQuery();
+			while (rs.next())
+			{
+				int key = rs.getInt(1);
+				String name = rs.getString(2);
+				KeyNamePair pp = new KeyNamePair(key, name);
+				accounts.add(pp);
+			}
+			rs.close();
+			pstmt.close();
+		}
+		catch (SQLException eac)
+		{
+			log.log(Level.SEVERE, SQL, eac);
+		}
+
+		return accounts;
+	}
+	
+	/** 
+	 * Get the list of available credit cards.
+	 * @return a list of credit cards.
+	 */
+	public ArrayList<ValueNamePair> getCreditCards() {
+		
+		ArrayList<ValueNamePair> cards = new ArrayList<ValueNamePair>();
+
+		if (payment == null)
+			return cards;
+		
+		selectedCreditCard = null;
+		//	Load Credit Cards
+		ValueNamePair[] ccs = payment.getCreditCards();
+		for (int i = 0; i < ccs.length; i++)
+		{
+			cards.add(ccs[i]);
+			if (ccs[i].getValue().equals(ccType))
+				selectedCreditCard = ccs[i];
+		}
+
+		return cards;
+		
+	}
+
+	/**
+	 * @return the selecteCreditCard
+	 */
+	public ValueNamePair getSelecteCreditCard() {
+		return selectedCreditCard;
+	}
+
+	/**
+	 * Get a list of bank accounts
+	 * @return a list of bank accounts
+	 */
+	public ArrayList<KeyNamePair> getBankAccounts() {
+		return getBankAccounts(false);
+	}
+	
+	/**
+	 * Get a set of bank accounts or cash journals
+	 * @param cashJournal - set to true for cash journals, false for bank accounts
+	 * @return a List of bank accounts that represent regular bank accounts or cash journals.
+	 */
+	private ArrayList<KeyNamePair> getBankAccounts(boolean cashJournal) {
+
+		ArrayList<KeyNamePair> accounts = new ArrayList<KeyNamePair>();
+		
+		String bankType = X_C_Bank.BANKTYPE_Bank;
+		if (cashJournal)
+		{
+			
+			bankType = X_C_Bank.BANKTYPE_CashJournal;
+		}
+		
+		//  Load Bank Accounts
+		String SQL = MRole.getDefault().addAccessSQL(
+			"SELECT C_BankAccount_ID, ba.accountno, IsDefault "
+			+ "FROM C_BankAccount ba"
+			+ " INNER JOIN C_Bank b ON (ba.C_Bank_ID=b.C_Bank_ID) "
+			+ "WHERE b.IsActive='Y'"
+			+ " AND b.BankType=?",
+			"ba", MRole.SQL_FULLYQUALIFIED, MRole.SQL_RO);
+		selectedBankAccount = null;
+		try
+		{
+			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
+			pstmt.setString(1, bankType);
+			ResultSet rs = pstmt.executeQuery();
+			while (rs.next())
+			{
+				int key = rs.getInt(1);
+				String name = rs.getString(2);
+				KeyNamePair pp = new KeyNamePair(key, name);
+				accounts.add(pp);
+				if (cashJournal)
+				{
+					
+					if (key == c_bankAccount_id)
+						selectedCashBook = pp;
+					if (selectedCashBook == null && rs.getString(3).equals("Y"))    //  Default
+						selectedCashBook = pp;
+
+				}
+				else
+				{
+					
+					if (key == c_bankAccount_id)
+						selectedBankAccount = pp;
+					if (selectedBankAccount == null && rs.getString(3).equals("Y"))    //  Default
+						selectedBankAccount = pp;
+					
+				}
+			}
+			rs.close();
+			pstmt.close();
+		}
+		catch (SQLException ept)
+		{
+			log.log(Level.SEVERE, SQL, ept);
+		}
+		
+		return accounts;
+	}
+
+	/**
+	 * @return the selectedBankAccount
+	 */
+	public KeyNamePair getSelectedBankAccount() {
+		return selectedBankAccount;
+	}
+	
+	/**
+	 * Get the cash books or cash journals
+	 * @return
+	 */
+	public ArrayList<KeyNamePair> getCashBooks() {
+		
+		return getBankAccounts(true);
+		
+	}
+
+	/**
+	 * @return the selectedCashBook
+	 */
+	public KeyNamePair getSelectedCashBook() {
+		return selectedCashBook;
+	}
+
+	/**
+	 * Convert the current payment amount to a different currency
+	 * @param currencyTo_id - the currency target
+	 * @return the converted amount.
+	 */
+	public BigDecimal getConvertedAmount(int currencyTo_id) {
+
+		return MConversionRate.convert(Env.getCtx(),
+				paymentAmount, c_currency_id, currencyTo_id, ad_client_id, ad_org_id);
+	}
+
+	/**
+	 * Use the changes to the fields to create a new payment and complete it. 
+	 * @return
+	 */
+	public boolean saveChanges() {
+				
+		errorMsg = "";
+		errorInfo = "";
+
+		if (!checkMandatory()) // Also updates all values
+			return false;
+		
+		// BF [ 1920179 ] perform the save in a trx's context.
+		final boolean[] success = new boolean[] { false };
+		final TrxRunnable r = new TrxRunnable() {
+
+			public void run(String trxName) {
+				success[0] = saveChangesInTrx(trxName);
+			}
+		};
+		try {
+			Trx.run(r);
+		} catch (Throwable e) {
+			success[0] = false;
+			errorMsg = e.getLocalizedMessage();
+		}
+		if (payment != null)
+			payment.set_TrxName(null);
+		return success[0];
+	}
+	
+	/**************************************************************************
+	 *	Save Changes
+	 *	@return true, if window can exit
+	 */
+	private boolean saveChangesInTrx(final String trxName)
+	{
+		
+		String new_paymentRule = editor.getPaymentRule();
+		log.info("Payment Rule: " + new_paymentRule);
+
+		String payTypes = "KTSDBP";
+		if (!payTypes.contains(new_paymentRule) || new_paymentRule == null || new_paymentRule.isEmpty())
+		{
+			
+			throw new IllegalArgumentException("Payment Rule is null, empty or not recognized.");
+			
+		}
+
+		/**********************
+		 *	Save Values to mTab
+		 */
+		log.config("Saving changes");
+
+		//  Payment Rule
+		if (!new_paymentRule.equals(paymentRule))
+			gridTab.setValue("PaymentRule", new_paymentRule);
+		if (onlyChangePaymentRule)
+		{
+			return true;
+		}		
+		
+		// On Credit - update the payment term
+		if (new_paymentRule.equals(MOrder.PAYMENTRULE_OnCredit))
+		{
+			if (!new_paymentRule.equals(paymentRule))
+				gridTab.setValue("PaymentRule", new_paymentRule);
+			if (new_c_paymentTerm_id != c_paymentTerm_id)
+				gridTab.setValue("C_PaymentTerm_ID", new_c_paymentTerm_id);
+			return true;
+		}
+		
+		//  Create a payment
+		BigDecimal payAmount = new_paymentAmount;
+			
+		
+		// Check the date
+		if (new_dateAcct == null)
+			new_dateAcct = dateAcct;
+
+		if (isInvoice)
+		{
+			MInvoice invoice = invoices.get(0);
+			if (invoice.isCreditMemo())
+				payAmount = payAmount.negate();
+		}
+	
+		// Info
+		log.config("C_Order_ID=" + c_order_id + ", C_Invoice_ID=" + c_invoice_id + ", Amt=" + payAmount);		
+		
+		/***********************
+		 *  Create Payments
+		 */
+
+		log.fine("Creating new Payment - " + new_paymentRule);
+
+		//  Set Amount
+		payment = new MPayment(Env.getCtx(), 0, trxName);
+		
+		payment.setC_BPartner_ID(c_bpartner_id);
+		payment.setC_Invoice_ID(c_invoice_id);
+		payment.setC_Order_ID(c_order_id);
+		payment.setDateTrx(new_dateAcct);
+		payment.setDateAcct(new_dateAcct);
+		payment.setAmount(c_currency_id, payAmount);
+
+		if (new_paymentRule.equals(MOrder.PAYMENTRULE_CreditCard))
+		{
+			payment.setCreditCard(MPayment.TRXTYPE_Sales, new_ccType,
+				new_ccNumber, "", new_ccExpDate);
+			payment.setA_Name(new_ccName);
+		}
+		else if (new_paymentRule.equals(MOrder.PAYMENTRULE_DirectDeposit)
+			|| new_paymentRule.equals(MOrder.PAYMENTRULE_DirectDebit))
+		{
+			MBankAccount bpBankAccount = new MBankAccount(Env.getCtx(), new_c_bp_bankAccount_id, null);
+			payment.setBankACH(new_c_bp_bankAccount_id, isSOTrx, new_paymentRule, 
+				bpBankAccount.getBank().getRoutingNo(), bpBankAccount.getAccountNo());
+		}
+		else if (new_paymentRule.equals(MOrder.PAYMENTRULE_Check))
+		{
+			payment.setBankCheck(new_c_bankAccount_id, isSOTrx, new_checkRoutingNumber,
+				new_checkAccountNumber, new_checkNumber);
+		}
+		else if (new_paymentRule.equals(MOrder.PAYMENTRULE_Cash))
+		{
+			// Get changes to cash amount
+			payment.setBankCash(new_cashBook_id, isSOTrx, MPayment.TENDERTYPE_Cash);
+		}
+		
+		if (!payment.save()) {
+			log.warning("Unable to save draft payment! Payment deleted.");
+			errorMsg = MSG_PaymentNotCreated;
+			errorInfo = payment.getErrorMessage();
+			payment.deleteEx(true);
+			payment = null;
+			return false;
+		}
+		
+		boolean approved = false;
+		if (processOnline )
+		{
+			log.config("Processing payment on-line");
+			approved = payment.processOnline();
+			onlineInfo = payment.getR_RespMsg() + " (" + payment.getR_AuthCode()
+				+ ") ID=" + payment.getR_PnRef();
+			processOnline = false;
+			
+			if (!approved)
+			{
+				log.warning("Unable to save process payment online! Payment (deleted): " + payment.toString());
+				errorMsg = MSG_PaymentNotProcessed;
+				errorInfo = payment.getErrorMessage();
+				payment.delete(true);
+				payment = null;
+				return false;
+			}
+		}
+
+		boolean ok = payment.processIt(DocAction.ACTION_Complete);
+		
+		if (!ok)
+		{
+			if (approved) 
+			{ 
+				//  This is a problem that will need human intervention
+				//  The payment was processed through an online processor
+				//  and approved, but the payment could not be completed.
+				//  Save the payment, as it has a record of the online 
+				//  process and let the user figure out what when wrong.
+				errorMsg = MSG_PaymentNotCompletedAfterProcessApproval;
+				payment.saveEx();
+				log.severe("Payment approved online but not completed! Payment exists: " + payment.toString() );
+			}
+			else
+			{
+				//  No online process but something went wrong.  Delete the payment.
+				//  Check the logs or any exceptions for info.
+				log.warning("Unable to complete payment! Payment (deleted): " + payment.toString());
+				errorMsg = MSG_PaymentNotCreated;
+				errorInfo = payment.getErrorMessage();
+				payment.delete(true);
+				payment = null;
+			}
+			return false;
+		}
+
+		payment.saveEx();
+		paymentDocNumber = payment.getDocumentNo();
+		log.config("Payment completed: " + payment.toString());
+				
+		//	Set Payment
+		gridTab.setValue("C_Payment_ID", new Integer(payment.getC_Payment_ID()));
+		
+		if (errorMsg.isEmpty())
+			return true;
+		else
+			return false;
+	}	//	saveChanges
+
+	/**
+	 * @return the paymentDocNumber
+	 */
+	public String getPaymentDocNumber() {
+		return paymentDocNumber;
+	}
+
+	/**
+	 *  Check Mandatory
+	 *  @return true if all mandatory items are OK
+	 */
+	public boolean checkMandatory()
+	{
+		log.config( "");
+
+		//  only Payment Rule
+		if (onlyChangePaymentRule)
+			return true;
+		
+		getValues();
+
+		/***********************
+		 *	Mandatory Data Check
+		 */
+
+		
+		boolean dataOK = true;
+		// paymentAmount
+		editor.setMandatory(CPaymentEditor.FIELD_bAmount, true);
+		editor.setMandatory(CPaymentEditor.FIELD_kAmount, true);
+		editor.setMandatory(CPaymentEditor.FIELD_sAmount, true);
+		editor.setMandatory(CPaymentEditor.FIELD_tAmount, true);
+		if (new_paymentAmount.equals(Env.ZERO))
+		{
+			editor.setError(CPaymentEditor.FIELD_bAmount, true);
+			editor.setError(CPaymentEditor.FIELD_kAmount, true);
+			editor.setError(CPaymentEditor.FIELD_sAmount, true);
+			editor.setError(CPaymentEditor.FIELD_tAmount, true);
+			errorMsg = MSG_ZeroPaymentAmount;
+			dataOK = false;
+		}
+
+		//	B (Cash)		(Currency)
+		if (new_paymentRule.equals(MOrder.PAYMENTRULE_Cash))
+		{
+			editor.setMandatory(CPaymentEditor.FIELD_bCashBook, true);
+			if (new_cashBook_id == 0)
+			{
+				editor.setError(CPaymentEditor.FIELD_bCashBook, true);
+				errorMsg = Msg_NoCashJournalSelected;
+				dataOK = false;
+			}
+			else
+				editor.setError(CPaymentEditor.FIELD_bCashBook, false);
+		}
+
+		//	K (CreditCard)  Type, Number, Exp, Approval
+		else if (new_paymentRule.equals(MOrder.PAYMENTRULE_CreditCard))
+		{
+			editor.setMandatory(CPaymentEditor.FIELD_kType, true);
+			if (new_ccType.isEmpty())
+			{
+				errorMsg = MSG_NoCreditCardTypeSelected;
+				editor.setError(CPaymentEditor.FIELD_kType, true);
+				dataOK = false;
+			}
+			// Validation of the credit card number is moved to the payment processor.
+			// Different payment processors can have different validation rules.
+		}
+
+		//	T (Transfer)	BPartner_Bank
+		else if (new_paymentRule.equals(X_C_Order.PAYMENTRULE_DirectDeposit)
+			|| new_paymentRule.equals(X_C_Order.PAYMENTRULE_DirectDebit))
+		{
+			editor.setMandatory(CPaymentEditor.FIELD_tAccount, true);
+			if (new_c_bp_bankAccount_id == 0)
+			{
+				errorMsg = MSG_NoBPBankAccountSelected;
+				editor.setError(CPaymentEditor.FIELD_tAccount, true); 
+				dataOK = false;
+			}
+		}	//	Direct
+		//      P (PaymentTerm) PaymentTerm 	 
+        else if (new_paymentRule.equals(X_C_Order.PAYMENTRULE_OnCredit))
+        {
+            // ok
+        	editor.setMandatory(CPaymentEditor.FIELD_pTerm, true);
+        }
+		//	S (Check)		(Currency) CheckNo, Routing
+		else if (new_paymentRule.equals(MOrder.PAYMENTRULE_Check))
+		{
+			editor.setMandatory(CPaymentEditor.FIELD_sBankAccount, true);
+			editor.setMandatory(CPaymentEditor.FIELD_sRouting, true);
+			editor.setMandatory(CPaymentEditor.FIELD_sAccountNumber, true);
+			editor.setMandatory(CPaymentEditor.FIELD_sCheckNumber, true);
+			if (new_c_bankAccount_id == 0)
+			{
+				editor.setError(CPaymentEditor.FIELD_sBankAccount, true);
+				errorMsg = "PaymentNoProcessor";
+				dataOK = false;
+			}
+
+			errorMsg = MPaymentValidate.validateRoutingNo(new_checkRoutingNumber);
+			if (!errorMsg.isEmpty())
+			{
+				editor.setError(CPaymentEditor.FIELD_sRouting, true);
+				dataOK = false;
+			}
+			errorMsg = MPaymentValidate.validateAccountNo(new_checkAccountNumber);
+			if (!errorMsg.isEmpty())
+			{
+				editor.setError(CPaymentEditor.FIELD_sAccountNumber, true);
+				dataOK = false;
+			}
+			errorMsg = MPaymentValidate.validateCheckNo(new_checkNumber);
+			if (!errorMsg.isEmpty())
+			{
+				editor.setError(CPaymentEditor.FIELD_sCheckNumber, true);
+				dataOK = false;
+			}
+		}
+		else
+		{
+			log.log(Level.SEVERE, "Unknown PaymentRule " + new_paymentRule);
+			errorMsg = "Unknown PaymentRule " + new_paymentRule;
+			return false;
+		}
+
+		//
+		log.config("OK=" + dataOK);
+		return dataOK;
+	}   //  checkMandatory
+
+	/**
+	 * Process the payment online.  The results of the online payment
+	 * can be read in {@link #getOnlineInfo()}.
+	 * @return true if successful, false if there was an error.
+	 */
+	public boolean processOnline() {
+		
+		processOnline = true;
+		
+		return saveChanges();
+		
+	}
+
+	/**
+	 * @return the onlineInfo
+	 */
+	public String getOnlineInfo() {
+		return onlineInfo;
+	}
+
+	private void getValues() {
+		
+		//	New Values
+		new_dateAcct = dateAcct; 
+		new_c_paymentTerm_id = c_paymentTerm_id;
+		new_cashBook_id = cashBook_id;
+		new_ccType = ccType;
+		new_ccName = "";
+		new_ccNumber = "";
+		new_ccExpDate = "";
+		new_c_bankAccount_id = 0;
+		new_c_bp_bankAccount_id = 0;
+		new_paymentAmount = Env.ZERO;
+		new_checkRoutingNumber = "";
+		new_checkAccountNumber = "";
+		new_checkNumber = "";
+
+		new_dateAcct = editor.getDateAcct(new_paymentRule); 
+		new_paymentRule = editor.getPaymentRule();
+		new_c_bankAccount_id = editor.getBankAccount(new_paymentRule);
+		new_cashBook_id = editor.getCashBook(new_paymentRule);
+		new_dateAcct = editor.getDateAcct(new_paymentRule);
+		new_paymentAmount = editor.getPaymentAmount(new_paymentRule);
+		new_ccType = editor.getCreditCardType(new_paymentRule);
+		new_ccName = editor.getCreditCardName(new_paymentRule);
+		new_ccNumber = editor.getCreditCardNumber(new_paymentRule);
+		new_ccExpDate = editor.getCreditCardExpiry(new_paymentRule);
+		new_c_bp_bankAccount_id = editor.getBPBankAccount(new_paymentRule);
+		new_c_paymentTerm_id = editor.getPaymentTerm(new_paymentRule);
+		new_checkAccountNumber = editor.getCheckAccountNumber(new_paymentRule);
+		new_checkRoutingNumber = editor.getCheckRoutingNumber(new_paymentRule);
+		new_checkNumber = editor.getCheckNumber(new_paymentRule);
+
+	}
+
+	/**
+	 *  Get the current date/time
+	 * @return the current date/time
+	 */
+	public Timestamp getDate() {
+		return new Timestamp(System.currentTimeMillis());
+	}
+
+	/**
+	 * @return the paymentAmount
+	 */
+	public BigDecimal getPaymentAmount() {
+		return paymentAmount;
+	}
+
+	/**
+	 * 
+	 * @return true if only the payment rule can change
+	 */
+	public boolean isOnlyChangePaymentRule() {
+		return onlyChangePaymentRule;
+	}
+
+}

--- a/base/src/org/adempiere/controller/ed/CAbstractEditorController.java
+++ b/base/src/org/adempiere/controller/ed/CAbstractEditorController.java
@@ -1,0 +1,421 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.adempiere.controller.ed;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.GridField;
+import org.compiere.model.GridTab;
+import org.compiere.model.Lookup;
+import org.compiere.model.MQuery;
+import org.compiere.swing.CEditor;
+
+/**
+ * An abstract controller of view editors for specific fields.  The controller manages the
+ * interactions with the model in a consistent way across all view types.
+ * 
+ * @author Michael McKay, mckayERP
+ *
+ */
+public abstract class CAbstractEditorController implements CEditorController {
+
+	/** The GridTab where the editor resides */
+	protected GridTab gridTab;
+	
+	/** The GridField associated with the editor */
+	protected GridField gridField;
+	
+	/** The window number used for this editor */
+	protected int windowNo;
+	
+	/** The lookup for this field */
+	protected Lookup lookup;
+
+	/** Flag for read only state */
+	protected boolean readOnly = false;
+
+	/** Flag for updateable state */
+	protected boolean isUpdateable = true;
+
+	/** Flag for the mandatory state */
+	protected boolean mandatory = false;
+
+	/**	Data Value				*/
+	private Object value = new Object();
+
+	/** Record of the value for comparison at a point in the future */
+	protected Object oldValue = 0;
+	
+	/**	Calling Window Info				*/
+	protected int ad_column_id = 0;
+	
+	/** Column Name	*/
+	protected String	columnName;
+
+	protected CEditor editor;
+
+	protected boolean isButtonEnabled = false;
+
+	protected boolean isDisplayEnabled = false;
+	
+	MQuery zoomQuery = null;
+	String zoomKeyTableName;
+	String zoomKeyColumnName;
+	int zoomAD_Window_ID;
+
+	/** The last display value.  The text displayed can change without the underlying
+	 *  value changing so this variable provides a means to test if a change has occurred.
+	 */
+	protected String lastDisplay;
+	
+	/**
+	 * Standard constructor where the editor is not bound to a tab or model field
+	 */
+	public CAbstractEditorController() {
+		gridTab = null;
+		setGridField(null);
+		setLookup(null);
+		windowNo = 0;
+	}
+
+	/**
+	 * Standard constructor where the editor is in a tab but the model field has not 
+	 * been identified yet.
+	 * @param tab - the model GridTab controlling the field
+	 * @param windowNo - the window number for this editor
+	 */
+	public CAbstractEditorController(CEditor editor, GridTab tab, boolean mandatory, boolean isReadOnly,
+			boolean isUpdateable, int windowNo, Lookup lookup) {
+		gridTab = tab;
+		gridField = null;  // set directly rather than using the setter function.
+		this.editor = editor;
+		this.setMandatory(mandatory);
+		this.setReadOnly(isReadOnly);
+		this.setUpdateable(isUpdateable);
+		this.windowNo = windowNo;
+		this.setLookup(lookup); 
+
+	}
+
+	/**
+	 * Standard constructor where the editor is in a tab but the model field has not 
+	 * been identified yet.
+	 * @param editor - the generic editor representing this field
+	 * @param tab - the model GridTab controlling the field
+	 * @param field - the model GridField for this editor
+	 */
+	public CAbstractEditorController(CEditor editor, GridTab tab, GridField field) {
+		this(tab,field);
+		this.editor = editor;
+	}
+
+	/**
+	 * Private constructor where the editor is in a tab but the model field has not 
+	 * been identified yet.  The editor has to be defined by the public constructors
+	 * @param tab - the model GridTab controlling the field
+	 * @param field - the model GridField for this editor
+	 * @param windowNo - the window number for this editor 
+	 */
+	private CAbstractEditorController(GridTab tab, GridField field) {
+		gridTab = tab;
+		setGridField(field);
+
+		if (gridTab != null) {
+			this.windowNo = gridTab.getWindowNo();
+		}
+		
+		if (gridField != null) {
+			this.setLookup(gridField.getLookup());
+		}
+		
+	}
+	
+	public void init() {
+		
+		set_oldValue();
+		editor.setReadWrite(!readOnly && isUpdateable);
+	}
+	
+	public void dispose() {
+		gridTab = null;
+		gridField = null;
+		lookup.dispose();
+		setLookup(null);
+	}
+
+	/**
+	 * @return the columnName
+	 */
+	public String getColumnName() {
+		return columnName;
+	}
+
+	/**
+	 * @param columnName the columnName to set
+	 */
+	public void setColumnName(String columnName) {
+		this.columnName = columnName;
+	}
+
+	/**
+	 * 	Set GridField
+	 * 	@param field MField
+	 */
+	public void setGridField(GridField field)
+	{
+		gridField = field;
+		
+		if (gridField != null) {
+			columnName = gridField.getColumnName();
+			ad_column_id = gridField.getAD_Column_ID();
+			mandatory = gridField.isMandatory(false);
+			readOnly = gridField.isReadOnly();
+			setLookup(field.getLookup());
+		}
+		else {
+			columnName = "";
+			ad_column_id = 0;
+			mandatory = false;
+			readOnly = false;
+			lookup = null;			
+		}
+	}	//	setField
+	
+	public GridField getGridField() {
+		return gridField;
+	}
+
+	/**
+	 * Get the old value of the field explicitly set in the past
+	 * @return
+	 */
+	public Object get_oldValue() {
+		return oldValue;
+	}
+
+	/**
+	 * Set the old value of the field.  For use in future comparisons.
+	 * The old value must be explicitly set though this call.
+	 */
+	public void set_oldValue() {
+		this.oldValue = getValue();
+	}
+
+	/**
+	 * Has the field changed over time?
+	 * @return true if the old value is different than the current.
+	 */
+	public boolean hasChanged() {
+		// Both or either could be null
+		
+		//Don't think a test of Value is needed as value is not set by the search window
+		if(getValue() != null)
+			if(oldValue != null)
+				return !oldValue.equals(getValue());
+			else
+				return true;
+		else  // getValue() is null
+			if(oldValue != null)
+				return true;
+		return false;
+	}
+	
+	/**
+	 * 	Set Mandatory
+	 * 	@param mandatory mandatory
+	 */
+	public void setMandatory (boolean mandatory)
+	{
+		this.mandatory = mandatory;
+	}	//	setMandatory
+
+	/**
+	 * 	Get Mandatory
+	 *  @return mandatory
+	 */
+	public boolean isMandatory()
+	{
+		return mandatory;
+	}	//	isMandatory
+
+	/**
+	 * @return the readOnly
+	 */
+	public boolean isReadOnly() {
+		return readOnly;
+	}
+
+	/**
+	 * @param readOnly the readOnly to set
+	 */
+	public void setReadOnly(boolean readOnly) {
+		this.readOnly = readOnly;
+	}
+
+	/**
+	 * @return the value
+	 */
+	public Object getValue() {
+		return value;
+	}
+
+	/**
+	 * @param value the value to set
+	 */
+	public void setValue(Object value) {
+		this.value = value;
+	}
+
+	/** 
+	 * Set the editor error flags
+	 */
+	public abstract void setError();
+
+	/**
+	 * @return the lastDisplay
+	 */
+	public String getLastDisplay() {
+		return lastDisplay;
+	}
+
+	/**
+	 * @param lastDisplay the lastDisplay to set
+	 */
+	public void setLastDisplay(String lastDisplay) {
+		this.lastDisplay = lastDisplay;
+	}
+	
+	public void generateZoomQuery() {
+		
+		if (zoomKeyTableName == null || zoomKeyTableName.isEmpty()
+				|| zoomKeyColumnName == null || zoomKeyColumnName.isEmpty())
+			throw new AdempiereException("Can't zoom. Unknown zoom table and key column");
+		
+		zoomQuery = new MQuery();
+		Object value = getValue();
+		if (value == null)
+			value = Integer.valueOf(0);
+
+		zoomQuery.addRestriction(zoomKeyColumnName, MQuery.EQUAL, value);
+		zoomQuery.setZoomColumnName(zoomKeyColumnName);
+		zoomQuery.setZoomTableName(zoomKeyTableName);
+		zoomQuery.setZoomValue(value);
+		zoomQuery.setRecordCount(1);	//	guess
+
+		zoomAD_Window_ID = lookup.getZoom(zoomQuery);
+	}
+
+	/**
+	 * @return the zoomKeyTableName
+	 */
+	protected String getZoomKeyTableName() {
+		return zoomKeyTableName;
+	}
+
+	/**
+	 * @param zoomKeyTableName the zoomKeyTableName to set
+	 */
+	protected void setZoomKeyTableName(String zoomKeyTableName) {
+		this.zoomKeyTableName = zoomKeyTableName;
+	}
+
+	/**
+	 * @return the zoomKeyColumnName
+	 */
+	protected String getZoomKeyColumnName() {
+		return zoomKeyColumnName;
+	}
+
+	/**
+	 * @param zoomKeyColumnName the zoomKeyColumnName to set
+	 */
+	protected void setZoomKeyColumnName(String zoomKeyColumnName) {
+		this.zoomKeyColumnName = zoomKeyColumnName;
+	}
+
+	/**
+	 * @return the zoomAD_Window_ID
+	 */
+	public int getZoomAD_Window_ID() {
+		return zoomAD_Window_ID;
+	}
+
+	/**
+	 * @param zoomAD_Window_ID the zoomAD_Window_ID to set
+	 */
+	protected void setZoomAD_Window_ID(int zoomAD_Window_ID) {
+		this.zoomAD_Window_ID = zoomAD_Window_ID;
+	}
+
+	/**
+	 * @return the zoomQuery
+	 */
+	public MQuery getZoomQuery() {
+		if (zoomQuery == null)
+			throw new AdempiereException("Zoom Query not initialized.");
+		return zoomQuery;
+	}
+
+	/**
+	 * @param zoomQuery the zoomQuery to set
+	 */
+	protected void setZoomQuery(MQuery zoomQuery) {
+		this.zoomQuery = zoomQuery;
+	}
+
+	/**
+	 * @return the windowNo
+	 */
+	public int getWindowNo() {
+		return windowNo;
+	}
+
+	/**
+	 * @param windowNo the windowNo to set
+	 */
+	protected void setWindowNo(int windowNo) {
+		this.windowNo = windowNo;
+	}
+
+	/**
+	 * @return the isUpdateable
+	 */
+	public boolean isUpdateable() {
+		return isUpdateable;
+	}
+
+	/**
+	 * @param isUpdateable the isUpdateable to set
+	 */
+	protected void setUpdateable(boolean isUpdateable) {
+		this.isUpdateable = isUpdateable;
+	}
+
+	/**
+	 * @return the lookup
+	 */
+	public Lookup getLookup() {
+		return lookup;
+	}
+
+
+	/**
+	 * @param lookup the lookup to set
+	 */
+	protected void setLookup(Lookup lookup) {
+		this.lookup = lookup;
+	}
+
+}

--- a/base/src/org/adempiere/controller/ed/CEditorController.java
+++ b/base/src/org/adempiere/controller/ed/CEditorController.java
@@ -1,0 +1,86 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.adempiere.controller.ed;
+
+import org.compiere.model.GridField;
+import org.compiere.model.Lookup;
+import org.compiere.model.MQuery;
+
+/**
+ * An interface for controllers of view editors for specific fields.  The controller manages the
+ * interactions with the model in a consistent way across all view types.
+ * 
+ * @author Michael McKay, mckayERP
+ *
+ */
+public interface CEditorController {
+	
+	/** Dispose of the controller */
+	public void dispose();
+	
+	/**
+	 * @return the columnName
+	 */
+	public String getColumnName();
+
+	/**
+	 * @param columnName the columnName to set
+	 */
+	public void setColumnName(String columnName);
+
+	/**
+	 * 	Set GridField
+	 * 	@param field MField
+	 */
+	public void setGridField(GridField field);
+	
+	public GridField getGridField();
+
+	boolean hasChanged();
+
+	public boolean isMandatory();
+
+	public void setMandatory(boolean mandatory);
+
+	public void setReadOnly(boolean readOnly);
+
+	public boolean isReadOnly();
+
+	public void setValue(Object value);
+
+	public void generateZoomQuery();
+
+	public int getZoomAD_Window_ID();
+
+	public MQuery getZoomQuery();
+
+	public int getWindowNo();
+
+	public void actionText();
+
+	public void actionButton();
+
+	public void enableControls();
+
+	public void setLastDisplay(String display);
+
+	public Lookup getLookup();
+
+	public void set_oldValue();
+
+	public void init();
+
+}

--- a/base/src/org/adempiere/controller/ed/CPaymentEditor.java
+++ b/base/src/org/adempiere/controller/ed/CPaymentEditor.java
@@ -1,0 +1,71 @@
+/**
+ * 
+ */
+package org.adempiere.controller.ed;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+/**
+ * @author Home
+ *
+ */
+public interface CPaymentEditor {
+	
+
+	public final static String FIELD_payment = "paymentCombo";
+	public final static String FIELD_kType = "kTypeCombo";
+	public final static String FIELD_kNumber = "kNumberField";
+	public final static String FIELD_kName = "kNameField";
+	public final static String FIELD_kExp = "kExpField";
+	public final static String FIELD_kApproval = "kApprovalField";
+	public final static String FIELD_kAmount = "kAmountField";
+	public final static String FIELD_tAccount = "tAccountCombo";
+	public final static String FIELD_sCheckNumber = "sCheckNumberField";
+	public final static String FIELD_sAccountNumber = "sAccountNumberField";
+	public final static String FIELD_sRouting = "sRoutingField";
+	public final static String FIELD_sCurrency = "sCurrencyCombo";
+	public final static String FIELD_bCurrency = "bCurrencyCombo";
+	public final static String FIELD_pTerm = "pTermCombo";
+	public final static String FIELD_bAmount = "bAmountField";
+	public final static String FIELD_sAmount = "sAmountField";
+	public final static String FIELD_bDate = "bDateField";
+	public final static String FIELD_sCheck = "sCheckField";
+	public final static String FIELD_sBankAccount = "sBankAccountCombo";
+	public final static String FIELD_bCashBook = "bCashBookCombo";
+	public final static String FIELD_tAmount = "tAmountField";
+
+	
+	public String getPaymentRule();
+	
+	public int getBankAccount(String paymentRule);
+	
+	public int getCashBook(String paymentRule);
+	
+	public Timestamp getDateAcct(String paymentRule);
+	
+	public BigDecimal getPaymentAmount(String paymentRule);
+
+	public String getCreditCardType(String paymentRule);
+	
+	public int getBPBankAccount(String paymentRule);
+	
+	public int getPaymentTerm(String paymentRule);
+
+	public String getCreditCardNumber(String paymentRule);
+
+	public String getCreditCardExpiry(String paymentRule);
+
+	public String getCreditCardName(String paymentRule);
+
+	public String getCheckAccountNumber(String paymentRule);
+
+	public String getCheckRoutingNumber(String paymentRule);
+
+	public String getCheckNumber(String paymentRule);
+	
+	public void setMandatory(String field, boolean mandatory);
+	
+	public void setError(String field, boolean error);
+
+}

--- a/base/src/org/compiere/model/MBankStatement.java
+++ b/base/src/org/compiere/model/MBankStatement.java
@@ -712,37 +712,4 @@ public class MBankStatement extends X_C_BankStatement implements DocAction
 			|| DOCSTATUS_Reversed.equals(ds);
 	}	//	isComplete
 	
-	/**
-	 * 	Get BankStatement (CashJournal) for Bank Account and date
-	 *	@param ctx context
-	 *	@param C_BankAccount_ID cashbook
-	 *	@param dateAcct date
-	 *	@param trxName transaction
-	 *	@return The Bank Statement (Cash Journal)
-	 */
-	public static MBankStatement get (Properties ctx, int C_BankAccount_ID, 
-		Timestamp dateAcct, String trxName)
-	{
-		final String whereClause ="C_BankAccount_ID=?"			//	#1
-				+ " AND TRUNC(StatementDate, 'DD')=?"		//	#2
-				+ " AND Processed='N'";
-		
-		MBankStatement retValue = new Query(ctx, MBankStatement.Table_Name, whereClause, trxName)
-			.setParameters(C_BankAccount_ID, TimeUtil.getDay(dateAcct))
-			.first();
-		
-		if (retValue != null)
-			return retValue;
-		
-		//	None found, make a new one
-		MBankAccount bankAccount = new MBankAccount(ctx, C_BankAccount_ID, trxName);
-		if (bankAccount.get_ID() ==0)
-		{
-			return null;
-		}
-		MBankStatement bankStatment = new MBankStatement (bankAccount);
-		bankStatment.saveEx(trxName);
-		return bankStatment;
-	}	//	get
-
 }	//	MBankStatement

--- a/base/src/org/compiere/model/MBankStatement.java
+++ b/base/src/org/compiere/model/MBankStatement.java
@@ -712,4 +712,37 @@ public class MBankStatement extends X_C_BankStatement implements DocAction
 			|| DOCSTATUS_Reversed.equals(ds);
 	}	//	isComplete
 	
+	/**
+	 * 	Get BankStatement (CashJournal) for Bank Account and date
+	 *	@param ctx context
+	 *	@param C_BankAccount_ID cashbook
+	 *	@param dateAcct date
+	 *	@param trxName transaction
+	 *	@return The Bank Statement (Cash Journal)
+	 */
+	public static MBankStatement get (Properties ctx, int C_BankAccount_ID, 
+		Timestamp dateAcct, String trxName)
+	{
+		final String whereClause ="C_BankAccount_ID=?"			//	#1
+				+ " AND TRUNC(StatementDate, 'DD')=?"		//	#2
+				+ " AND Processed='N'";
+		
+		MBankStatement retValue = new Query(ctx, MBankStatement.Table_Name, whereClause, trxName)
+			.setParameters(C_BankAccount_ID, TimeUtil.getDay(dateAcct))
+			.first();
+		
+		if (retValue != null)
+			return retValue;
+		
+		//	None found, make a new one
+		MBankAccount bankAccount = new MBankAccount(ctx, C_BankAccount_ID, trxName);
+		if (bankAccount.get_ID() ==0)
+		{
+			return null;
+		}
+		MBankStatement bankStatment = new MBankStatement (bankAccount);
+		bankStatment.saveEx(trxName);
+		return bankStatment;
+	}	//	get
+
 }	//	MBankStatement

--- a/base/src/org/compiere/model/MInvoice.java
+++ b/base/src/org/compiere/model/MInvoice.java
@@ -2530,6 +2530,17 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
         }
     }
 
+	public static List<MInvoice> getOfOrder(Properties ctx, int c_order_id, String trxName) {
+		String where =  COLUMNNAME_C_Order_ID+"=?"
+				+ " AND " + COLUMNNAME_DocStatus + " IN ('CO','CL')";
+		List<MInvoice> list = new Query(ctx, Table_Name, where, trxName)
+				.setClient_ID()
+				.setOnlyActiveRecords(true)
+				.setParameters(c_order_id)
+				.list();
+		return list;
+	}
+
 
 
 }	//	MInvoice

--- a/base/src/org/compiere/model/MPayment.java
+++ b/base/src/org/compiere/model/MPayment.java
@@ -1864,8 +1864,6 @@ public final class MPayment extends X_C_Payment
 			processMsg += " @CounterDoc@: @C_Payment_ID@=" + counter.getDocumentNo();
 
 		// @Trifon - CashPayments
-		//if ( getTenderType().equals("X") ) {
-//		if ( isCashTrx() && !MSysConfig.getBooleanValue("CASH_AS_PAYMENT", true , getAD_Client_ID())) {
 		if ( isCashTrx()) {
 			// Create Cash Book entry - check that the bank is a cash bank
 			// The bank account is mandatory
@@ -1877,44 +1875,7 @@ public final class MPayment extends X_C_Payment
 				return DocAction.STATUS_Invalid;
 			}
 			// Find or create a suitable bank statement which is or will become the Cash Journal of this day
-			//MCash cash = MCash.get (getCtx(), getAD_Org_ID(), getDateAcct(), getC_Currency_ID(), get_TrxName());SHW
-//			MBankStatement cashJournal = MBankStatement.get(getCtx(), getC_BankAccount_ID(), getDateAcct(),get_TrxName());
-//			if (cashJournal == null || cashJournal.get_ID() == 0)
-//			{
-//				processMsg = "@NoCashBook@";
-//				return DocAction.STATUS_Invalid;
-//			}
 			MBankStatement.addPayment(this);
-//			MCashLine cl = new MCashLine( cash );
-//			cl.setCashType( X_C_CashLine.CASHTYPE_GeneralReceipts );
-//			cl.setDescription("Generated From Payment #" + getDocumentNo());
-//			cl.setC_Currency_ID( this.getC_Currency_ID() );
-//			cl.setC_Payment_ID( getC_Payment_ID() ); // Set Reference to payment.
-//			StringBuffer info=new StringBuffer();
-//			info.append("Cash journal ( ")
-//				.append(cash.getDocumentNo()).append(" )");				
-//			processMsg = info.toString();
-//			//	Amount
-//			BigDecimal amt = this.getPayAmt();
-/*
-			MDocType dt = MDocType.get(getCtx(), invoice.getC_DocType_ID());			
-			if (MDocType.DOCBASETYPE_APInvoice.equals( dt.getDocBaseType() )
-				|| MDocType.DOCBASETYPE_ARCreditMemo.equals( dt.getDocBaseType() ) 
-			) {
-				amt = amt.negate();
-			}
-*/
-//			cl.setAmount( amt );
-//			//
-//			cl.setDiscountAmt( Env.ZERO );
-//			cl.setWriteOffAmt( Env.ZERO );
-//			cl.setIsGenerated( true );
-//			
-//			if (!cl.save(get_TrxName()))
-//			{
-//				processMsg = "Could not save Cash Journal Line";
-//				return DocAction.STATUS_Invalid;
-//			}
 		}
 		// End Trifon - CashPayments
 		

--- a/base/src/org/compiere/model/MPayment.java
+++ b/base/src/org/compiere/model/MPayment.java
@@ -101,11 +101,22 @@ public final class MPayment extends X_C_Payment
      */
 	public static List<MPayment> getOfOrder(MOrder order)
 	{
-		return new Query(order.getCtx() , MPayment.Table_Name , MOrder.COLUMNNAME_C_Order_ID + "=?", order.get_TrxName())
+		return getOfOrder(order.getCtx(), order.getC_Order_ID(), order.get_TrxName());
+	}
+	
+	/**
+	 * Get payment for order ID
+	 * @param order
+	 * @return payments list
+     */
+	public static List<MPayment> getOfOrder(Properties ctx, int c_order_id, String trxName)
+	{
+		return new Query(ctx , MPayment.Table_Name , MOrder.COLUMNNAME_C_Order_ID + "=?", trxName)
 				.setClient_ID()
-				.setParameters(order.getC_Order_ID())
+				.setParameters(c_order_id)
 				.list();
 	}
+	
 
 	/**
 	 * 	Get Payments Of BPartner
@@ -565,19 +576,20 @@ public final class MPayment extends X_C_Payment
 	protected boolean beforeSave (boolean newRecord)
 	{
 		// @Trifon - CashPayments
-		if ( isCashTrx() && !MSysConfig.getBooleanValue("CASH_AS_PAYMENT", true, getAD_Client_ID())) {
-			// Cash Book Is mandatory
-			if ( getC_CashBook_ID() <= 0 ) {
-				log.saveError("Error", Msg.parseTranslation(getCtx(), "@Mandatory@: @C_CashBook_ID@"));
-				return false;
-			}
-		} else {
+//		if ( isCashTrx() && !MSysConfig.getBooleanValue("CASH_AS_PAYMENT", true, getAD_Client_ID())) {
+//			// Cash Book Is mandatory
+//			if ( getC_CashBook_ID() <= 0 ) {
+//				log.saveError("Error", Msg.parseTranslation(getCtx(), "@Mandatory@: @C_CashBook_ID@"));
+//				return false;
+//			}
+//		} else {
 			// Bank Account Is mandatory
 			if ( getC_BankAccount_ID() <= 0 ) {
-				log.saveError("Error", Msg.parseTranslation(getCtx(), "@Mandatory@: @C_BankAccount_ID@"));
+				m_errorMessage = Msg.parseTranslation(getCtx(), "@Mandatory@: @C_BankAccount_ID@");
+				log.saveError("Error", m_errorMessage);
 				return false;
 			}
-		}
+//		}
 		// end @Trifon - CashPayments
 
 		//	We have a charge
@@ -603,7 +615,8 @@ public final class MPayment extends X_C_Payment
 				;
 			else
 			{
-				log.saveError("Error", Msg.parseTranslation(getCtx(), "@NotFound@: @C_BPartner_ID@"));
+				m_errorMessage = Msg.parseTranslation(getCtx(), "@NotFound@: @C_BPartner_ID@");
+				log.saveError("Error", m_errorMessage);
 				return false;
 			}
 		}
@@ -658,14 +671,16 @@ public final class MPayment extends X_C_Payment
 			if (getC_Invoice_ID() != 0) {
 				MInvoice inv = new MInvoice(getCtx(), getC_Invoice_ID(), get_TrxName());
 				if (inv.getC_BPartner_ID() != getC_BPartner_ID()) {
-					log.saveError("Error", Msg.parseTranslation(getCtx(), "BP different from BP Invoice"));
+					m_errorMessage = Msg.parseTranslation(getCtx(), "BP different from BP Invoice");
+					log.saveError("Error", m_errorMessage);
 					return false;
 				}
 			}
 			if (getC_Order_ID() != 0) {
 				MOrder ord = new MOrder(getCtx(), getC_Order_ID(), get_TrxName());
 				if (ord.getC_BPartner_ID() != getC_BPartner_ID()) {
-					log.saveError("Error", Msg.parseTranslation(getCtx(), "BP different from BP Order"));
+					m_errorMessage = Msg.parseTranslation(getCtx(), "BP different from BP Order");
+					log.saveError("Error", m_errorMessage);
 					return false;
 				}
 			}
@@ -1850,31 +1865,37 @@ public final class MPayment extends X_C_Payment
 
 		// @Trifon - CashPayments
 		//if ( getTenderType().equals("X") ) {
-		if ( isCashTrx() && !MSysConfig.getBooleanValue("CASH_AS_PAYMENT", true , getAD_Client_ID())) {
-			// Create Cash Book entry
-			if ( getC_CashBook_ID() <= 0 ) {
-				log.saveError("Error", Msg.parseTranslation(getCtx(), "@Mandatory@: @C_CashBook_ID@"));
+//		if ( isCashTrx() && !MSysConfig.getBooleanValue("CASH_AS_PAYMENT", true , getAD_Client_ID())) {
+		if ( isCashTrx()) {
+			// Create Cash Book entry - check that the bank is a cash bank
+			// The bank account is mandatory
+			MBankAccount bankAccount = (MBankAccount) getC_BankAccount();
+			if ( !bankAccount.getC_Bank().getBankType().equals(MBank.BANKTYPE_CashJournal) ) {
+				m_errorMessage = Msg.parseTranslation(getCtx(), "@Mandatory@: @C_CashBook_ID@");
+				log.saveError("Error", m_errorMessage);
 				processMsg = "@NoCashBook@";
 				return DocAction.STATUS_Invalid;
 			}
+			// Find or create a suitable bank statement which is or will become the Cash Journal of this day
 			//MCash cash = MCash.get (getCtx(), getAD_Org_ID(), getDateAcct(), getC_Currency_ID(), get_TrxName());SHW
-			MCash cash = MCash.get(getCtx(), getC_CashBook_ID(), getDateAcct(),get_TrxName());
-			if (cash == null || cash.get_ID() == 0)
-			{
-				processMsg = "@NoCashBook@";
-				return DocAction.STATUS_Invalid;
-			}
-			MCashLine cl = new MCashLine( cash );
-			cl.setCashType( X_C_CashLine.CASHTYPE_GeneralReceipts );
-			cl.setDescription("Generated From Payment #" + getDocumentNo());
-			cl.setC_Currency_ID( this.getC_Currency_ID() );
-			cl.setC_Payment_ID( getC_Payment_ID() ); // Set Reference to payment.
-			StringBuffer info=new StringBuffer();
-			info.append("Cash journal ( ")
-				.append(cash.getDocumentNo()).append(" )");				
-			processMsg = info.toString();
-			//	Amount
-			BigDecimal amt = this.getPayAmt();
+//			MBankStatement cashJournal = MBankStatement.get(getCtx(), getC_BankAccount_ID(), getDateAcct(),get_TrxName());
+//			if (cashJournal == null || cashJournal.get_ID() == 0)
+//			{
+//				processMsg = "@NoCashBook@";
+//				return DocAction.STATUS_Invalid;
+//			}
+			MBankStatement.addPayment(this);
+//			MCashLine cl = new MCashLine( cash );
+//			cl.setCashType( X_C_CashLine.CASHTYPE_GeneralReceipts );
+//			cl.setDescription("Generated From Payment #" + getDocumentNo());
+//			cl.setC_Currency_ID( this.getC_Currency_ID() );
+//			cl.setC_Payment_ID( getC_Payment_ID() ); // Set Reference to payment.
+//			StringBuffer info=new StringBuffer();
+//			info.append("Cash journal ( ")
+//				.append(cash.getDocumentNo()).append(" )");				
+//			processMsg = info.toString();
+//			//	Amount
+//			BigDecimal amt = this.getPayAmt();
 /*
 			MDocType dt = MDocType.get(getCtx(), invoice.getC_DocType_ID());			
 			if (MDocType.DOCBASETYPE_APInvoice.equals( dt.getDocBaseType() )
@@ -1883,17 +1904,17 @@ public final class MPayment extends X_C_Payment
 				amt = amt.negate();
 			}
 */
-			cl.setAmount( amt );
-			//
-			cl.setDiscountAmt( Env.ZERO );
-			cl.setWriteOffAmt( Env.ZERO );
-			cl.setIsGenerated( true );
-			
-			if (!cl.save(get_TrxName()))
-			{
-				processMsg = "Could not save Cash Journal Line";
-				return DocAction.STATUS_Invalid;
-			}
+//			cl.setAmount( amt );
+//			//
+//			cl.setDiscountAmt( Env.ZERO );
+//			cl.setWriteOffAmt( Env.ZERO );
+//			cl.setIsGenerated( true );
+//			
+//			if (!cl.save(get_TrxName()))
+//			{
+//				processMsg = "Could not save Cash Journal Line";
+//				return DocAction.STATUS_Invalid;
+//			}
 		}
 		// End Trifon - CashPayments
 		

--- a/base/src/org/compiere/model/MPaymentValidate.java
+++ b/base/src/org/compiere/model/MPaymentValidate.java
@@ -69,6 +69,9 @@ public class MPaymentValidate
 	 */
 	public static int getCreditCardExpMM (String mmyy)
 	{
+		if (mmyy == null || mmyy.isEmpty() || mmyy.length() < 2)
+			return 0;
+		
 		String mmStr = mmyy.substring(0,2);
 		int mm = 0;
 		try
@@ -88,6 +91,9 @@ public class MPaymentValidate
 	 */
 	public static int getCreditCardExpYY (String mmyy)
 	{
+		if (mmyy == null || mmyy.isEmpty() || mmyy.length() < 4)
+			return 0;
+		
 		String yyStr = mmyy.substring(2);
 		int yy = 0;
 		try

--- a/client/src/org/compiere/grid/VPayment.java
+++ b/client/src/org/compiere/grid/VPayment.java
@@ -26,18 +26,14 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.math.BigDecimal;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.logging.Level;
 
 import javax.swing.BorderFactory;
 
-import org.adempiere.plaf.AdempierePLAF;
+import org.adempiere.controller.PaymentFormController;
+import org.adempiere.controller.ed.CPaymentEditor;
 import org.compiere.apps.ADialog;
 import org.compiere.apps.AEnv;
 import org.compiere.apps.ConfirmPanel;
@@ -45,17 +41,6 @@ import org.compiere.grid.ed.VButton;
 import org.compiere.grid.ed.VDate;
 import org.compiere.grid.ed.VNumber;
 import org.compiere.model.GridTab;
-import org.compiere.model.MCash;
-import org.compiere.model.MCashLine;
-import org.compiere.model.MConversionRate;
-import org.compiere.model.MInvoice;
-import org.compiere.model.MOrder;
-import org.compiere.model.MPayment;
-import org.compiere.model.MPaymentValidate;
-import org.compiere.model.MRole;
-import org.compiere.model.MSysConfig;
-import org.compiere.model.X_C_Order;
-import org.compiere.process.DocAction;
 import org.compiere.swing.CButton;
 import org.compiere.swing.CComboBox;
 import org.compiere.swing.CDialog;
@@ -63,39 +48,15 @@ import org.compiere.swing.CLabel;
 import org.compiere.swing.CPanel;
 import org.compiere.swing.CTextField;
 import org.compiere.util.CLogger;
-import org.compiere.util.DB;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.KeyNamePair;
 import org.compiere.util.Msg;
-import org.compiere.util.TimeUtil;
-import org.compiere.util.Trx;
-import org.compiere.util.TrxRunnable;
 import org.compiere.util.ValueNamePair;
 
 /**
  *	Display (and process) Payment Options.
- *  <pre>
- *  Payment Rule
- *  -B- Cash          (Date)          -> Cash Entry
- *  -P- Payment Term  (Term)
- *  -S- Check         (Routing, ..)   -> Payment Entry
- *  -K- CreditCard    (No)            -> Payment Entry
- *  -U- ACH Transfer  (Routing)       -> Payment Entry
- *
- *  When processing:
- *  - If an invoice is a S/K/U, but has no Payment Entry, it is changed to P
- *  - If an invoice is B and has no Cash Entry, it is created
- *  - An invoice is "Open" if it is "P" and no Payment
- *
- *  Entry:
- *  - If not processed, an invoice has no Cash or Payment entry
- *  - The entry is created, during "Online" and when Saving
- *
- *  Changes/Reversals:
- *  - existing Cash Entries are reversed and newly created
- *  - existing Payment Entries are not changed and then "hang there" and need to be allocated
- *  </pre>
+ *  See the Payment Form Controller for details on the operation
  *
  * 	@author 	Jorg Janke
  * 	@version 	$Id: VPayment.java,v 1.2 2006/07/30 00:51:28 jjanke Exp $
@@ -105,14 +66,18 @@ import org.compiere.util.ValueNamePair;
  * 				<li>BF [ 1789949 ] VPayment: is displaying just "CashNotCreated"
  * @author Michael Judd, Akuna Ltd
  * 				<li>FR [ 2803341 ] Deprecate Cash Journal
+ * @author Michael McKay, mckayERP@gmail.com
+ * 		<li><a href=https://github.com/adempiere/adempiere/issues/2347">#2347</a>Reduce duplicated code
  */
 public class VPayment extends CDialog
-	implements ActionListener
+	implements ActionListener, CPaymentEditor
 {
 	/**
 	 * 
 	 */
 	private static final long serialVersionUID = -7931457502030396154L;
+
+	private int windowNo;
 
 	/**
 	 *	Constructor
@@ -124,12 +89,11 @@ public class VPayment extends CDialog
 	public VPayment (int WindowNo, GridTab mTab, VButton button)
 	{
 		super(Env.getWindow(WindowNo), Msg.getMsg(Env.getCtx(), "Payment"), true);
-		m_WindowNo = WindowNo;
-		m_isSOTrx = "Y".equals(Env.getContext(Env.getCtx(), WindowNo, "IsSOTrx"));
-		m_mTab = mTab;
+		windowNo = WindowNo;
+		controller = new PaymentFormController(this, WindowNo, mTab, button.getValues());
+
 		try
 		{
-			bDateField = new VDate("DateAcct", false, false, true, DisplayType.Date, "DateAcct");
 			jbInit();
 			m_initOK = dynInit(button);     //  Null Pointer if order/invoice not saved yet
 		}
@@ -142,48 +106,10 @@ public class VPayment extends CDialog
 		AEnv.positionCenterWindow(Env.getWindow(WindowNo), this);
 	}	//	VPayment
 
-	/**	Window						*/
-	private int                 m_WindowNo = 0;
-	/**	Tab							*/
-	private GridTab         		m_mTab;
+	PaymentFormController 		controller;
 
-	//	Data from Order/Invoice
-	private String              m_DocStatus = null;
-	/** Start Payment Rule          */
-	private String				m_PaymentRule = "";
-	/** Start Payment Term          */
-	private int					m_C_PaymentTerm_ID = 0;
-	/** Start Acct Date             */
-	private Timestamp			m_DateAcct = null;
-	/** Start Payment               */
-	private int					m_C_Payment_ID = 0;
-	private MPayment            m_mPayment = null;
-	private MPayment            m_mPaymentOriginal = null;
-	/** Start CashBook Line         */
-	private int                 m_C_CashLine_ID = 0;
-	private MCashLine			m_cashLine = null;
-	/** Start CreditCard            */
-	private String              m_CCType = "";
-	/** Start Bank Account			*/
-	private int					m_C_BankAccount_ID = 0;
-	/** Start CashBook              */
-	private int                 m_C_CashBook_ID = 0;
-
-	/** Is SOTrx					*/
-	private boolean				m_isSOTrx = true;
-
-	/** Invoice Currency              */
-	private int	 				m_C_Currency_ID = 0;
-	private int                 m_AD_Client_ID = 0;
-	private boolean				m_Cash_As_Payment = true;
-	private int                 m_AD_Org_ID = 0;
-	private int                 m_C_BPartner_ID = 0;
-	private BigDecimal			m_Amount = Env.ZERO;	//	Payment Amount
 	//
 	private boolean 			m_initOK = false;
-	/** Only allow changing Rule        */
-	private boolean             m_onlyRule = false;
-	private static Hashtable<Integer,KeyNamePair> s_Currencies = null;	//	EMU Currencies
 	
 	private boolean				m_needSave = false;
 	/**	Logger			*/
@@ -199,6 +125,12 @@ public class VPayment extends CDialog
 	private CLabel paymentLabel = new CLabel();
 	private CardLayout centerLayout = new CardLayout();
 	private CPanel bPanel = new CPanel();
+	private GridBagLayout bPanelLayout = new GridBagLayout();
+	private VDate bDateField = new VDate("DateAcct", false, false, true, DisplayType.Date, "DateAcct");
+	private CLabel bCurrencyLabel = new CLabel();
+	private CComboBox bCurrencyCombo = new CComboBox();
+	private CLabel bAmountLabel = new CLabel();
+	private VNumber bAmountField = new VNumber();
 	private CPanel kPanel = new CPanel();
 	private GridBagLayout kLayout = new GridBagLayout();
 	private CLabel kTypeLabel = new CLabel();
@@ -216,29 +148,26 @@ public class VPayment extends CDialog
 	private CPanel tPanel = new CPanel();
 	private CLabel tAccountLabel = new CLabel();
 	private CComboBox tAccountCombo = new CComboBox();
+	private CLabel tAmountLabel = new CLabel();
+	private VNumber tAmountField = new VNumber();
 	private CPanel sPanel = new CPanel();
 	private GridBagLayout sPanelLayout = new GridBagLayout();
-	private CLabel sNumberLabel = new CLabel();
-	private CTextField sNumberField = new CTextField();
+	private CLabel sAccountNumberLabel = new CLabel();
+	private CTextField sAccountNumberField = new CTextField();
 	private CLabel sRoutingLabel = new CLabel();
 	private CTextField sRoutingField = new CTextField();
 	private CLabel sCurrencyLabel = new CLabel();
 	private CComboBox sCurrencyCombo = new CComboBox();
-	private CLabel bCurrencyLabel = new CLabel();
-	private CComboBox bCurrencyCombo = new CComboBox();
 	private CPanel pPanel = new CPanel();
 	private CLabel pTermLabel = new CLabel();
 	private CComboBox pTermCombo = new CComboBox();
-	private GridBagLayout bPanelLayout = new GridBagLayout();
-	private CLabel bAmountLabel = new CLabel();
-	private VNumber bAmountField = new VNumber();
 	private CLabel sAmountLabel = new CLabel();
 	private VNumber sAmountField = new VNumber();
-	private VDate bDateField;
+
 	private CLabel bDateLabel = new CLabel();
 	private ConfirmPanel confirmPanel = new ConfirmPanel(true);
-	private CTextField sCheckField = new CTextField();
-	private CLabel sCheckLabel = new CLabel();
+	private CTextField sCheckNumberField = new CTextField();
+	private CLabel sCheckNumberLabel = new CLabel();
 	private CButton kOnline = new CButton();
 	private CButton sOnline = new CButton();
 	private CComboBox sBankAccountCombo = new CComboBox();
@@ -249,11 +178,7 @@ public class VPayment extends CDialog
 	private GridBagLayout tPanelLayout = new GridBagLayout();
 	private CButton tOnline = new CButton();
 	private CLabel kStatus = new CLabel();
-	private CTextField tRoutingField = new CTextField();
-	private CTextField tNumberField = new CTextField();
 	private CLabel tStatus = new CLabel();
-	private CLabel tRoutingText = new CLabel();
-	private CLabel tNumberText = new CLabel();
 	private CLabel sStatus = new CLabel();
 
 	/**
@@ -286,6 +211,7 @@ public class VPayment extends CDialog
 		kExpLabel.setText(Msg.getMsg(Env.getCtx(), "Expires"));
 		kApprovalLabel.setText(Msg.translate(Env.getCtx(), "VoiceAuthCode"));
 		kAmountLabel.setText(Msg.getMsg(Env.getCtx(), "Amount"));
+		kAmountField.setDisplayType(DisplayType.Amount);
 		kOnline.setText(Msg.getMsg(Env.getCtx(), "Online"));
 		kOnline.addActionListener(this);
 		kStatus.setText(" ");
@@ -322,11 +248,10 @@ public class VPayment extends CDialog
 		//	DircetDebit/Credit
 		tPanel.setLayout(tPanelLayout);
 		tAccountLabel.setText(Msg.translate(Env.getCtx(), "C_BP_BankAccount_ID"));
-		tRoutingField.setColumns(8);
-		tNumberField.setColumns(10);
-		tRoutingText.setText(Msg.translate(Env.getCtx(), "RoutingNo"));
-		tNumberText.setText(Msg.translate(Env.getCtx(), "AccountNo"));
+		tAmountLabel.setText(Msg.translate(Env.getCtx(), "Amount"));
+		tAmountField.setDisplayType(DisplayType.Amount);
 		tOnline.setText(Msg.getMsg(Env.getCtx(), "Online"));
+		tOnline.addActionListener(this);
 		tStatus.setText(" ");
 		centerPanel.add(tPanel, "tPanel");
 		centerLayout.addLayoutComponent(tPanel, "tPanel");
@@ -334,32 +259,29 @@ public class VPayment extends CDialog
 			,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(5, 5, 5, 0), 0, 0));
 		tPanel.add(tAccountCombo, new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0
 			,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
-		tPanel.add(tRoutingField, new GridBagConstraints(1, 1, 2, 1, 0.0, 0.0
-			,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(5, 5, 0, 5), 0, 0));
-		tPanel.add(tNumberField, new GridBagConstraints(1, 2, 1, 1, 0.0, 0.0
+		tPanel.add(tAmountLabel, new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0
+				,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(5, 5, 0, 0), 0, 0));
+		tPanel.add(tAmountField, new GridBagConstraints(1, 1, 2, 1, 0.0, 0.0
 			,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(5, 5, 0, 5), 0, 0));
 		tPanel.add(tStatus, new GridBagConstraints(0, 3, 2, 1, 0.0, 0.0
 			,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
-		tPanel.add(tRoutingText, new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0
-			,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(5, 5, 0, 0), 0, 0));
-		tPanel.add(tNumberText, new GridBagConstraints(0, 2, 1, 1, 0.0, 0.0
-			,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(5, 5, 0, 0), 0, 0));
 		tPanel.add(tOnline, new GridBagConstraints(3, 2, 1, 1, 0.0, 0.0
 			,GridBagConstraints.NORTHEAST, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
 		// Cheque
 		sPanel.setLayout(sPanelLayout);
 		sBankAccountLabel.setText(Msg.translate(Env.getCtx(), "C_BankAccount_ID"));
 		sAmountLabel.setText(Msg.getMsg(Env.getCtx(), "Amount"));
-		//sAmountField.setText("");
+		sAmountField.setDisplayType(DisplayType.Amount);
 		sRoutingLabel.setText(Msg.translate(Env.getCtx(), "RoutingNo"));
-		sNumberLabel.setText(Msg.translate(Env.getCtx(), "AccountNo"));
-		sCheckLabel.setText(Msg.translate(Env.getCtx(), "CheckNo"));
-		sCheckField.setColumns(8);
+		sAccountNumberLabel.setText(Msg.translate(Env.getCtx(), "AccountNo"));
+		sCheckNumberLabel.setText(Msg.translate(Env.getCtx(), "CheckNo"));
+		sCheckNumberField.setColumns(8);
 		sCurrencyLabel.setText(Msg.translate(Env.getCtx(), "C_Currency_ID"));
-		sNumberField.setPreferredSize(new Dimension(100, 21));
+		sAccountNumberField.setPreferredSize(new Dimension(100, 21));
 		sRoutingField.setPreferredSize(new Dimension(70, 21));
 		sStatus.setText(" ");
 		sOnline.setText(Msg.getMsg(Env.getCtx(), "Online"));
+		sOnline.addActionListener(this);
 		centerPanel.add(sPanel, "sPanel");
 		centerLayout.addLayoutComponent(sPanel, "sPanel");
 		sPanel.add(sBankAccountLabel,   new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0
@@ -378,20 +300,20 @@ public class VPayment extends CDialog
 				,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 2, 0), 0, 0));
 		sPanel.add(sRoutingField,    new GridBagConstraints(1, 3, 2, 1, 0.0, 0.0
 			,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 5, 2, 0), 0, 0));
-		sPanel.add(sNumberLabel,   new GridBagConstraints(0, 5, 1, 1, 0.0, 0.0
+		sPanel.add(sAccountNumberLabel,   new GridBagConstraints(0, 5, 1, 1, 0.0, 0.0
 				,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(2, 0, 2, 0), 0, 0));
-		sPanel.add(sNumberField,    new GridBagConstraints(1, 5, 2, 1, 0.0, 0.0
+		sPanel.add(sAccountNumberField,    new GridBagConstraints(1, 5, 2, 1, 0.0, 0.0
 			,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(0, 5, 2, 0), 0, 0));
-		sPanel.add(sCheckLabel,   new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0
+		sPanel.add(sCheckNumberLabel,   new GridBagConstraints(0, 6, 1, 1, 0.0, 0.0
 				,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(2, 0, 2, 0), 0, 0));
-		sPanel.add(sCheckField,    new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0
+		sPanel.add(sCheckNumberField,    new GridBagConstraints(1, 6, 1, 1, 0.0, 0.0
 			,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(2, 5, 2, 0), 0, 0));
 		sPanel.add(sOnline,      new GridBagConstraints(3, 6, 1, 1, 0.0, 0.0
 				,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
 		sPanel.add(sStatus,    new GridBagConstraints(0, 7, 3, 1, 0.0, 0.0
 			,GridBagConstraints.CENTER, GridBagConstraints.NONE, new Insets(5, 5, 5, 5), 0, 0));
 		
-		// Cash
+		// Payment Term
 		pPanel.setLayout(pPanelLayout);
 		pTermLabel.setText(Msg.translate(Env.getCtx(), "C_PaymentTerm_ID"));
 		centerPanel.add(pPanel, "pPanel");
@@ -400,32 +322,24 @@ public class VPayment extends CDialog
 			,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(2, 5, 2, 0), 0, 0));
 		pPanel.add(pTermCombo, new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0
 			,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(2, 5, 2, 5), 0, 0));
-		//
 		
+		
+		// Cash
 		bCurrencyLabel.setText(Msg.translate(Env.getCtx(), "C_Currency_ID"));
-		
 		bPanel.setLayout(bPanelLayout);
 		bAmountLabel.setText(Msg.getMsg(Env.getCtx(), "Amount"));
-		//bAmountField.setText("");
+		bAmountField.setDisplayType(DisplayType.Amount);
 		bDateLabel.setText(Msg.translate(Env.getCtx(), "DateAcct"));
 		centerLayout.addLayoutComponent(bPanel, "bPanel");
 		centerPanel.add(bPanel, "bPanel");
 		
-		if (m_Cash_As_Payment){
-			sBankAccountLabel.setText(Msg.translate(Env.getCtx(), "C_BankAccount_ID"));
-			bPanel.add(sBankAccountLabel,   new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0
-					,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(2, 0, 2, 0), 0, 0));
-			bPanel.add(sBankAccountCombo,    new GridBagConstraints(1, 0, 2, 1, 0.0, 0.0
-					,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(2, 5, 2, 5), 0, 0));
+		bCashBookLabel.setText(Msg.translate(Env.getCtx(), PaymentFormController.MSG_CashJournal));
+		bCashBookCombo.setToolTipText(Msg.translate(Env.getCtx(), PaymentFormController.MSG_CashJournalTip));
+		bPanel.add(bCashBookLabel,   new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0
+				,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(2, 0, 2, 0), 0, 0));
+		bPanel.add(bCashBookCombo,    new GridBagConstraints(1, 0, 2, 1, 0.0, 0.0
+				,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(2, 5, 2, 5), 0, 0));
 
-		} else {
-			bCashBookLabel.setText(Msg.translate(Env.getCtx(), "C_CashBook_ID"));
-			bPanel.add(bCashBookLabel,  new GridBagConstraints(0, 0, 1, 1, 0.0, 0.0
-					,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(2, 0, 2, 0), 0, 0));
-			bPanel.add(bCashBookCombo,  new GridBagConstraints(1, 0, 2, 1, 0.0, 0.0
-					,GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(2, 5, 2, 5), 0, 0));
-
-		}
 		
 		bPanel.add(bCurrencyLabel,  new GridBagConstraints(0, 1, 1, 1, 0.0, 0.0
 			,GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(2, 0, 2, 0), 0, 0));
@@ -458,153 +372,42 @@ public class VPayment extends CDialog
 	 *  @return true if init OK
 	 *  @throws Exception
 	 */
+	@SuppressWarnings("unchecked")
 	private boolean dynInit (VButton button) throws Exception
 	{
-		m_DocStatus = (String)m_mTab.getValue("DocStatus");
-		log.config(m_DocStatus);
-
-		if (m_mTab.getValue("C_BPartner_ID") == null)
+		
+		if (!controller.init() && !controller.getErrorMsg().isEmpty())
 		{
-			ADialog.error(0, this, "SaveErrorRowNotFound");
+			ADialog.error(0, this, controller.getErrorMsg());
 			return false;
 		}
 
-		//	Is the Trx posted?
-	//	String Posted = (String)m_mTab.getValue("Posted");
-	//	if (Posted != null && Posted.equals("Y"))
-	//		return false;
-
-		//  DocStatus
-		m_DocStatus = (String)m_mTab.getValue("DocStatus");
-		if (m_DocStatus == null)
-			m_DocStatus = "";
-		//	Is the Trx closed?		Reversed / Voided / Closed
-		if (m_DocStatus.equals("RE") || m_DocStatus.equals("VO") || m_DocStatus.equals("CL"))
-			return false;
-		//  Document is not complete - allow to change the Payment Rule only
-		if (m_DocStatus.equals("CO") || m_DocStatus.equals("WP") )
-			m_onlyRule = false;
-		else
-			m_onlyRule = true;
-		//	PO only  Rule
-		if (!m_onlyRule		//	Only order has Warehouse
-			&& !m_isSOTrx && m_mTab.getValue("M_Warehouse_ID") != null)
-			m_onlyRule = true;
+		centerPanel.setVisible(!controller.isOnlyChangePaymentRule());
 		
-		centerPanel.setVisible(!m_onlyRule);
-		
-		
-		//  Amount
-		m_Amount = (BigDecimal)m_mTab.getValue("GrandTotal");
-		if (!m_onlyRule && m_Amount.compareTo(Env.ZERO) == 0)
-		{
-			ADialog.error(m_WindowNo, this, "PaymentZero");
-			return false;
-		}
-		
-
-		bAmountField.setValue(m_Amount);
-		sAmountField.setValue(m_Amount);
-		kAmountField.setValue(m_Amount);
-		
-
-		/**
-		 *	Get Data from Grid
-		 */
-		m_AD_Client_ID = ((Integer)m_mTab.getValue("AD_Client_ID")).intValue();
-		m_Cash_As_Payment = MSysConfig.getBooleanValue("CASH_AS_PAYMENT",true, m_AD_Client_ID);
-		m_AD_Org_ID = ((Integer)m_mTab.getValue("AD_Org_ID")).intValue();
-		m_C_BPartner_ID = ((Integer)m_mTab.getValue("C_BPartner_ID")).intValue();
-		m_PaymentRule = (String)m_mTab.getValue("PaymentRule");
-		m_C_Currency_ID = ((Integer)m_mTab.getValue("C_Currency_ID")).intValue();
-		m_DateAcct = (Timestamp)m_mTab.getValue("DateAcct");
-		if (m_mTab.getValue("C_PaymentTerm_ID") != null)
-			m_C_PaymentTerm_ID = ((Integer)m_mTab.getValue("C_PaymentTerm_ID")).intValue();
-		//  Existing Payment
-		if (m_mTab.getValue("C_Payment_ID") != null)
-		{
-			m_C_Payment_ID = ((Integer)m_mTab.getValue("C_Payment_ID")).intValue();
-			if (m_C_Payment_ID != 0)
-			{
-				m_mPayment = new MPayment(Env.getCtx(), m_C_Payment_ID, null);
-				m_mPaymentOriginal = new MPayment(Env.getCtx(), m_C_Payment_ID, null);	//	full copy
-				//  CreditCard
-				m_CCType = m_mPayment.getCreditCardType();
-				kNumberField.setText(m_mPayment.getCreditCardNumber());
-				kNameField.setText(m_mPayment.getA_Name());
-				kExpField.setText(m_mPayment.getCreditCardExp(null));
-				kApprovalField.setText(m_mPayment.getVoiceAuthCode());
-				kStatus.setText(m_mPayment.getR_PnRef());
-				kAmountField.setValue(m_mPayment.getPayAmt());
+		BigDecimal amount = controller.getPaymentAmount();
+		bAmountField.setValue(amount);
+		sAmountField.setValue(amount);
+		kAmountField.setValue(amount);
+		tAmountField.setValue(amount);
 				
-				//	if approved/paid, don't let it change
-				kTypeCombo.setReadWrite(!m_mPayment.isApproved());
-				kNumberField.setReadWrite(!m_mPayment.isApproved());
-				kNameField.setReadWrite(!m_mPayment.isApproved());
-				kExpField.setReadWrite(!m_mPayment.isApproved());
-				kApprovalField.setReadWrite(!m_mPayment.isApproved());
-				kOnline.setReadWrite(!m_mPayment.isApproved());
-				kAmountField.setReadWrite(!m_mPayment.isApproved());
-				//  Check
-				m_C_BankAccount_ID = m_mPayment.getC_BankAccount_ID();
-				sRoutingField.setText(m_mPayment.getRoutingNo());
-				sNumberField.setText(m_mPayment.getAccountNo());
-				sCheckField.setText(m_mPayment.getCheckNo());
-				sStatus.setText(m_mPayment.getR_PnRef());
-				sAmountField.setValue(m_mPayment.getPayAmt());
-				//  Transfer
-				tRoutingField.setText(m_mPayment.getRoutingNo());
-				tNumberField.setText(m_mPayment.getAccountNo());
-				tStatus.setText(m_mPayment.getR_PnRef());
-				// Cash
-				bAmountField.setValue(m_mPayment.getPayAmt());
-			}
-		}
-		if (m_mPayment == null)
+		//	For payments, use today's date
+		bDateField.setValue(controller.getDate());
+
+		if(controller.isEMUCurrency())
 		{
-			m_mPayment = new MPayment (Env.getCtx (), 0, null);
-			m_mPayment.setAD_Org_ID(m_AD_Org_ID);
-			m_mPayment.setAmount (m_C_Currency_ID, m_Amount);
-		}
 
-		//  Existing Cashbook entry
-		m_cashLine = null;
-		m_C_CashLine_ID = 0;
-		if (m_mTab.getValue("C_CashLine_ID") != null)
-		{
-			m_C_CashLine_ID = ((Integer)m_mTab.getValue("C_CashLine_ID")).intValue();
-			if (m_C_CashLine_ID == 0)
-				m_cashLine = null;
-			else
-			{
-				m_cashLine = new MCashLine (Env.getCtx(), m_C_CashLine_ID, null);
-				m_DateAcct = m_cashLine.getStatementDate();
-				m_C_CashBook_ID = m_cashLine.getCashBook().getC_CashBook_ID();
-				bAmountField.setValue(m_cashLine.getAmount()); 
-			}
-		}
-
-		//	Accounting Date
-		bDateField.setValue(m_DateAcct);
-
-		if (s_Currencies == null)
-			loadCurrencies();
-
-		//	Is the currency an EMU currency?
-		Integer C_Currency_ID = new Integer(m_C_Currency_ID);
-		if (s_Currencies.containsKey(C_Currency_ID))
-		{
-			Enumeration<Integer> en = s_Currencies.keys();
+			Enumeration<Integer> en = controller.getCurrencies().keys();
 			while (en.hasMoreElements())
 			{
 				Object key = en.nextElement();
-				bCurrencyCombo.addItem(s_Currencies.get(key));
-				sCurrencyCombo.addItem(s_Currencies.get(key));
+				bCurrencyCombo.addItem(controller.getCurrencies().get(key));
+				sCurrencyCombo.addItem(controller.getCurrencies().get(key));
 			}
 			sCurrencyCombo.addActionListener(this);
-			sCurrencyCombo.setSelectedItem(s_Currencies.get(C_Currency_ID));
+			sCurrencyCombo.setSelectedItem(controller.getCurrentCurrency());
 			bCurrencyCombo.addActionListener(this);
-			bCurrencyCombo.setSelectedItem(s_Currencies.get(C_Currency_ID));
+			bCurrencyCombo.setSelectedItem(controller.getCurrentCurrency());
+
 		}
 		else	//	No EMU Currency
 		{
@@ -617,183 +420,78 @@ public class VPayment extends CDialog
 		/**
 		 *	Payment Combo
 		 */
-		if (m_PaymentRule == null)
-			m_PaymentRule = "";
-		ValueNamePair vp = null;
-		HashMap<?, ?> values = button.getValues();
-		Object[] a = values.keySet().toArray();
-		for (int i = 0; i < a.length; i++)
+		for (ValueNamePair paymentRule : controller.getPaymentRules())
 		{			
-            String PaymentRule = (String)a[i];		//	used for Panel selection
-			if (X_C_Order.PAYMENTRULE_DirectDebit.equals(PaymentRule)			//	SO
-				&& !m_isSOTrx)
-				continue;
-			else if (X_C_Order.PAYMENTRULE_DirectDeposit.equals(PaymentRule)	//	PO 
-				&& m_isSOTrx)
-				continue;
-                                                
-			ValueNamePair pp = new ValueNamePair(PaymentRule, (String)values.get(a[i]));
-			paymentCombo.addItem(pp);
-			if (PaymentRule.toString().equals(m_PaymentRule))	//	to select
-				vp = pp;
+			paymentCombo.addItem(paymentRule);
 		}
-
-		//	Set PaymentRule
-		paymentCombo.addActionListener(this);
-		if (vp != null)
-			paymentCombo.setSelectedItem(vp);
 
 		/**
 		 * 	Load Payment Terms
 		 */
-		String SQL = MRole.getDefault().addAccessSQL(
-			"SELECT C_PaymentTerm_ID, Name FROM C_PaymentTerm WHERE IsActive='Y' ORDER BY Name",
-			"C_PaymentTerm", MRole.SQL_NOTQUALIFIED, MRole.SQL_RO);
-		KeyNamePair kp = null;
-		try
-		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int key = rs.getInt(1);
-				String name = rs.getString(2);
-				KeyNamePair pp = new KeyNamePair(key, name);
-				pTermCombo.addItem(pp);
-				if (key == m_C_PaymentTerm_ID)
-					kp = pp;
-			}
-			rs.close();
-			pstmt.close();
-		}
-		catch (SQLException ept)
-		{
-			log.log(Level.SEVERE, SQL, ept);
+		for (KeyNamePair paymentTerm : controller.getPaymentTerms())
+		{			
+				pTermCombo.addItem(paymentTerm);
 		}
 		//	Set Selection
-		if (kp != null)
-			pTermCombo.setSelectedItem(kp);
+		if (controller.getSelectedPaymentTerm() != null)
+			pTermCombo.setSelectedItem(controller.getSelectedPaymentTerm());
+		
 
 		/**
-		 * 	Load Accounts
+		 * 	Load BP Accounts
 		 */
-		SQL = "SELECT a.C_BP_BankAccount_ID, NVL(b.Name, ' ')||'_'||NVL(a.AccountNo, ' ') AS Acct "
-			+ "FROM C_BP_BankAccount a"
-			+ " LEFT OUTER JOIN C_Bank b ON (a.C_Bank_ID=b.C_Bank_ID) "
-			+ "WHERE C_BPartner_ID=?"
-			+ "AND a.IsActive='Y' AND a.IsACH='Y'";
-		kp = null;
-		try
-		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			pstmt.setInt(1, m_C_BPartner_ID);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int key = rs.getInt(1);
-				String name = rs.getString(2);
-				KeyNamePair pp = new KeyNamePair(key, name);
-				tAccountCombo.addItem(pp);
-		//			kp = pp;
-			}
-			rs.close();
-			pstmt.close();
+		for (KeyNamePair account : controller.getBPAccounts())
+		{		
+			tAccountCombo.addItem(account);
 		}
-		catch (SQLException eac)
-		{
-			log.log(Level.SEVERE, SQL, eac);
-		}
-		//	Set Selection
-		if (kp != null)
-			tAccountCombo.setSelectedItem(kp);
 
 		/**
 		 *	Load Credit Cards
 		 */
-		ValueNamePair[] ccs = m_mPayment.getCreditCards();
-		vp = null;
-		for (int i = 0; i < ccs.length; i++)
+		for (ValueNamePair card : controller.getCreditCards())
 		{
-			kTypeCombo.addItem(ccs[i]);
-			if (ccs[i].getValue().equals(m_CCType))
-				vp = ccs[i];
+			
+			kTypeCombo.addItem(card);
 		}
 		//	Set Selection
-		if (vp != null)
-			kTypeCombo.setSelectedItem(vp);
+		if (controller.getSelecteCreditCard() != null)
+			kTypeCombo.setSelectedItem(controller.getSelecteCreditCard());
 
 		/**
 		 *  Load Bank Accounts
 		 */
-		SQL = MRole.getDefault().addAccessSQL(
-			"SELECT C_BankAccount_ID, ba.accountno, IsDefault "
-			+ "FROM C_BankAccount ba"
-			+ " INNER JOIN C_Bank b ON (ba.C_Bank_ID=b.C_Bank_ID) "
-			+ "WHERE b.IsActive='Y'",
-			"ba", MRole.SQL_FULLYQUALIFIED, MRole.SQL_RO);
-		kp = null;
-		try
+		for (KeyNamePair account : controller.getBankAccounts())
 		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int key = rs.getInt(1);
-				String name = rs.getString(2);
-				KeyNamePair pp = new KeyNamePair(key, name);
-				sBankAccountCombo.addItem(pp);
-				if (key == m_C_BankAccount_ID)
-					kp = pp;
-				if (kp == null && rs.getString(3).equals("Y"))    //  Default
-					kp = pp;
-			}
-			rs.close();
-			pstmt.close();
-		}
-		catch (SQLException ept)
-		{
-			log.log(Level.SEVERE, SQL, ept);
+			sBankAccountCombo.addItem(account);
 		}
 		//	Set Selection
-		if (kp != null)
-			sBankAccountCombo.setSelectedItem(kp);
+		if (controller.getSelectedBankAccount() != null)
+		{
+			sBankAccountCombo.setSelectedItem(controller.getSelectedBankAccount());
+		}
 
 
 		/**
 		 *  Load Cash Books
 		 */
-		SQL = MRole.getDefault().addAccessSQL(
-			"SELECT C_CashBook_ID, Name, AD_Org_ID FROM C_CashBook WHERE IsActive='Y'",
-			"C_CashBook", MRole.SQL_NOTQUALIFIED, MRole.SQL_RO);
-		kp = null;
-		try
+		for (KeyNamePair cashBook : controller.getCashBooks())
 		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int key = rs.getInt(1);
-				String name = rs.getString(2);
-				KeyNamePair pp = new KeyNamePair(key, name);
-				bCashBookCombo.addItem(pp);
-				if (key == m_C_CashBook_ID)
-					kp = pp;
-				if (kp == null && key == m_AD_Org_ID)       //  Default Org
-					kp = pp;
-			}
-			rs.close();
-			pstmt.close();
+			
+			bCashBookCombo.addItem(cashBook);
+			
 		}
-		catch (SQLException epc)
+		
+		if (controller.getSelectedCashBook() != null)
 		{
-			log.log(Level.SEVERE, SQL, epc);
+			
+			bCashBookCombo.setSelectedItem(controller.getSelectedCashBook());
+			
 		}
-		//	Set Selection
-		if (kp != null)
-		{
-			bCashBookCombo.setSelectedItem(kp);
-			if (m_C_CashBook_ID == 0)
-				m_C_CashBook_ID = kp.getKey();  //  set to default to avoid 'cashbook changed' message
+
+		//	Set PaymentRule do this last as the action will trigger other events
+		paymentCombo.addActionListener(this);
+		if (controller.getSelectedPaymentRule() != null) {
+			paymentCombo.setSelectedItem(controller.getSelectedPaymentRule());
 		}
 
 		//
@@ -810,33 +508,6 @@ public class VPayment extends CDialog
 	}	//	isInitOK
 
 
-	/**
-	 *	Fill s_Currencies with EMU currencies
-	 */
-	private void loadCurrencies()
-	{
-		s_Currencies = new Hashtable<Integer,KeyNamePair>(12);	//	Currenly only 10+1
-		String SQL = "SELECT C_Currency_ID, ISO_Code FROM C_Currency "
-			+ "WHERE (IsEMUMember='Y' AND EMUEntryDate<SysDate) OR IsEuro='Y' "
-			+ "ORDER BY 2";
-		try
-		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int id = rs.getInt(1);
-				String name = rs.getString(2);
-				s_Currencies.put(new Integer(id), new KeyNamePair(id, name));
-			}
-			rs.close();
-			pstmt.close();
-		}
-		catch (SQLException e)
-		{
-			log.log(Level.SEVERE, SQL, e);
-		}
-	}	//	loadCurrencies
 
 
 	/**************************************************************************
@@ -850,10 +521,13 @@ public class VPayment extends CDialog
 		//	Finish
 		if (e.getActionCommand().equals(ConfirmPanel.A_OK))
 		{
-			if (checkMandatory())
+			if (controller.isOnlyChangePaymentRule() 
+				|| ADialog.ask(windowNo, this, PaymentFormController.MSG_PaymentCreateConfirmation))
 			{
-				saveChanges (); // cannot recover
-				dispose ();
+				if (saveChanges())
+				{
+					dispose ();
+				}
 			}
 		}
 		else if (e.getActionCommand().equals(ConfirmPanel.A_CANCEL))
@@ -862,51 +536,48 @@ public class VPayment extends CDialog
 		//	Payment Method Change
 		else if (e.getSource() == paymentCombo)
 		{
-			//	get selection
-			ValueNamePair pp = (ValueNamePair)paymentCombo.getSelectedItem();
-			if (pp != null)
-			{
-				String s = pp.getValue().toLowerCase();
-				if (X_C_Order.PAYMENTRULE_DirectDebit.equalsIgnoreCase(s))
-					s = X_C_Order.PAYMENTRULE_DirectDeposit.toLowerCase();
-				s += "Panel";	
-				centerLayout.show(centerPanel, s);	//	switch to panel
-				//Bojana&Daniel
-				//If Invoice is Vendor invoice then Cash has to be created by negative amount
-				int C_Invoice_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Invoice_ID");
-				MInvoice invoice_tmp = new MInvoice (Env.getCtx(), C_Invoice_ID, null);
-				if (! invoice_tmp.isSOTrx())
-				{
-					bAmountField.setValue(m_Amount.negate());
-				}else {
-					bAmountField.setValue(m_Amount);
-				}
-				invoice_tmp = null;
-				
-			}
+			onPaymentComboSelection();
 		}
 
 		//	Check Currency change
 		else if (e.getSource() == sCurrencyCombo)
 		{
-			KeyNamePair pp = (KeyNamePair)sCurrencyCombo.getSelectedItem();
-			BigDecimal amt = MConversionRate.convert(Env.getCtx(),
-				m_Amount, m_C_Currency_ID, pp.getKey(), m_AD_Client_ID, m_AD_Org_ID);
-			sAmountField.setValue(amt);
+			KeyNamePair pp = (KeyNamePair) sCurrencyCombo.getSelectedItem();
+			sAmountField.setValue(controller.getConvertedAmount(pp.getKey()));
 		}
 		//	Cash Currency change
 		else if (e.getSource() == bCurrencyCombo)
 		{
 			KeyNamePair pp = (KeyNamePair)bCurrencyCombo.getSelectedItem();
-			BigDecimal amt = MConversionRate.convert(Env.getCtx(),
-				m_Amount, m_C_Currency_ID, pp.getKey(), m_AD_Client_ID, m_AD_Org_ID);
-			bAmountField.setValue(amt);
+			bAmountField.setValue(controller.getConvertedAmount(pp.getKey()));
 		}
 
 		//  Online
-		else if (e.getSource() == kOnline || e.getSource() == sOnline)
+		else if (e.getSource() == kOnline || e.getSource() == sOnline || e.getSource() == tOnline)
+		{
 			processOnline();
+			if (controller.getErrorMsg().isEmpty())
+			{
+				dispose();
+			}
+		}
 	}	//	actionPerformed
+
+
+	private void onPaymentComboSelection() {
+		//	get selection
+		ValueNamePair pp = (ValueNamePair)paymentCombo.getSelectedItem();
+		if (pp != null)
+		{
+			
+			bAmountField.setValue(controller.getPaymentAmount());
+			sAmountField.setValue(controller.getPaymentAmount());
+			kAmountField.setValue(controller.getPaymentAmount());
+			centerLayout.show(centerPanel, controller.whichPanel(pp));	//	switch to panel
+			controller.checkMandatory();
+			
+		}
+	}
 
 
 	/**************************************************************************
@@ -914,522 +585,27 @@ public class VPayment extends CDialog
 	 *	@return true, if Window can exit
 	 */
 	private boolean saveChanges() {
-
-		// BF [ 1920179 ] perform the save in a trx's context.
-		final boolean[] success = new boolean[] { false };
-		final TrxRunnable r = new TrxRunnable() {
-
-			public void run(String trxName) {
-				success[0] = saveChangesInTrx(trxName);
-			}
-		};
-		try {
-			Trx.run(r);
-		} catch (Throwable e) {
-			success[0] = false;
-			ADialog.error(m_WindowNo, this, "PaymentError", e.getLocalizedMessage());
-		}
-		if (m_cashLine != null)
-			m_cashLine.set_TrxName(null);
-		if (m_mPayment != null)
-			m_mPayment.set_TrxName(null);
-		if (m_mPaymentOriginal != null)
-			m_mPayment.set_TrxName(null);
-		return success[0];
-	} // saveChanges
-
-	private boolean saveChangesInTrx(final String trxName){
-
-		// set trxname for class objects
-		if (m_cashLine != null)
-			m_cashLine.set_TrxName(trxName);
-		if (m_mPayment != null)
-			m_mPayment.set_TrxName(trxName);
-		if (m_mPaymentOriginal != null)
-			m_mPaymentOriginal.set_TrxName(trxName);
 		
-		ValueNamePair vp = (ValueNamePair)paymentCombo.getSelectedItem();
-		String newPaymentRule = vp.getValue();
-		log.info("New Rule: " + newPaymentRule);
-
-		//  only Payment Rule
-		if (m_onlyRule)
+		if (!controller.saveChanges())
 		{
-			if (!newPaymentRule.equals(m_PaymentRule))
-				m_mTab.setValue("PaymentRule", newPaymentRule);
-			return true;
-		}
-
-		//	New Values
-		Timestamp newDateAcct = m_DateAcct;
-		int newC_PaymentTerm_ID = m_C_PaymentTerm_ID;
-		int newC_CashLine_ID = m_C_CashLine_ID;
-		int newC_CashBook_ID = m_C_CashBook_ID;
-		String newCCType = m_CCType;
-		int newC_BankAccount_ID = 0;
-		String payTypes = m_Cash_As_Payment ? "KTSDB" : "KTSD";
-		
-		//	B (Cash)		(Currency)
-		if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_Cash))
-		{
-			if (m_Cash_As_Payment){
-				// get bank account
-				KeyNamePair kp = (KeyNamePair)sBankAccountCombo.getSelectedItem();
-				if (kp != null)
-					newC_BankAccount_ID = kp.getKey();
-			} else {
-				// get cash book
-				KeyNamePair kp = (KeyNamePair)bCashBookCombo.getSelectedItem();
-				if (kp != null)
-					newC_CashBook_ID = kp.getKey();	
-			}
-			
-			newDateAcct = (Timestamp)bDateField.getValue();
-			
-			// Get changes to cash amount
-			m_mPayment.setAmount(m_C_Currency_ID, (BigDecimal) bAmountField.getValue());
-			m_Amount = (BigDecimal) bAmountField.getValue();			
-		}
-
-		//	K (CreditCard)  Type, Number, Exp, Approval
-		else if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_CreditCard))
-		{
-			vp = (ValueNamePair)kTypeCombo.getSelectedItem();
-			if (vp != null)
-				newCCType = vp.getValue();
-		}
-
-		//	T (Transfer)	BPartner_Bank
-		else if (newPaymentRule.equals(MOrder.PAYMENTRULE_DirectDeposit) 
-			|| newPaymentRule.equals(MOrder.PAYMENTRULE_DirectDebit) )
-		{
-			tAccountCombo.getSelectedItem();
-		}
-
-		//	P (PaymentTerm)	PaymentTerm
-		else if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_OnCredit))
-		{
-			KeyNamePair kp = (KeyNamePair)pTermCombo.getSelectedItem();
-			if (kp != null)
-				newC_PaymentTerm_ID = kp.getKey();
-		}
-
-		//	S (Check)		(Currency) CheckNo, Routing
-		else if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_Check))
-		{
-		//	sCurrencyCombo.getSelectedItem();
-			KeyNamePair kp = (KeyNamePair)sBankAccountCombo.getSelectedItem();
-			if (kp != null)
-				newC_BankAccount_ID = kp.getKey();
-		}
-		else
+			ADialog.error(windowNo, this, PaymentFormController.MSG_PaymentError, controller.getErrorMsg());			
 			return false;
-
-		/***********************
-		 *  Changed PaymentRule
-		 */
-		if (!newPaymentRule.equals(m_PaymentRule))
-		{
-			log.fine("Changed PaymentRule: " + m_PaymentRule + " -> " + newPaymentRule);
-			//  We had a CashBook Entry
-			if (m_PaymentRule.equals(X_C_Order.PAYMENTRULE_Cash) && !m_Cash_As_Payment) 
-			{
-				log.fine("Old Cash - " + m_cashLine);
-				if (m_cashLine != null)
-				{
-					MCashLine cl = m_cashLine.createReversal();
-					cl.saveEx();
-				}
-				newC_CashLine_ID = 0;      //  reset
-			}
-			//  We had a change in Payment type (e.g. Check to CC)
-			else if (payTypes.indexOf(m_PaymentRule) != -1 && payTypes.indexOf(newPaymentRule) != -1 && m_mPaymentOriginal != null)
-			{
-				log.fine("Old Payment(1) - " + m_mPaymentOriginal);
-				m_mPaymentOriginal.setDocAction(DocAction.ACTION_Reverse_Correct);
-				boolean ok = m_mPaymentOriginal.processIt(DocAction.ACTION_Reverse_Correct);
-				m_mPaymentOriginal.saveEx();
-				if (ok)
-					log.info( "Payment Cancelled - " + m_mPaymentOriginal);
-				else
-					ADialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCancelled " + m_mPaymentOriginal.getDocumentNo());
-				m_mPayment.resetNew();
-			}
-			//	We had a Payment and something else (e.g. Check to Cash)
-			else if (payTypes.indexOf(m_PaymentRule) != -1 && payTypes.indexOf(newPaymentRule) == -1) 
-			{
-				log.fine("Old Payment(2) - " + m_mPaymentOriginal);
-				if (m_mPaymentOriginal != null)
-				{
-					m_mPaymentOriginal.setDocAction(DocAction.ACTION_Reverse_Correct);
-					boolean ok = m_mPaymentOriginal.processIt(DocAction.ACTION_Reverse_Correct);
-					m_mPaymentOriginal.saveEx();
-					if (ok)        //  Cancel Payment
-					{
-						log.fine("PaymentCancelled " + m_mPayment.getDocumentNo ());
-						m_mTab.getTableModel().dataSave(true);
-						m_mPayment.resetNew();
-						m_mPayment.setAmount(m_C_Currency_ID, m_Amount);
-					}
-					else
-						ADialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCancelled " + m_mPayment.getDocumentNo());
-				}
-			}
 		}
-
-		//  Get Order and optionally Invoice
-		int C_Order_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Order_ID");
-		int C_Invoice_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Invoice_ID");
-		if (C_Invoice_ID == 0 && m_DocStatus.equals("CO"))
-			C_Invoice_ID = getInvoiceID (C_Order_ID, trxName);
-
-		//  Amount sign negative, if ARC (Credit Memo) or API (AP Invoice)
-		boolean negateAmt = false;
-		MInvoice invoice = null;
-		if (C_Invoice_ID != 0)
-		{
-			invoice = new MInvoice (Env.getCtx(), C_Invoice_ID, trxName);
-			negateAmt = invoice.isCreditMemo();
-		}
-		MOrder order = null;
-		if (invoice == null && C_Order_ID != 0)
-			order = new MOrder (Env.getCtx(), C_Order_ID, trxName);
 		
-		BigDecimal payAmount = m_Amount;
+		// Check the message in case
+		if (controller.getErrorMsg() != null && !controller.getErrorMsg().isEmpty())
+		{
+			ADialog.error(windowNo, this, PaymentFormController.MSG_PaymentError, controller.getErrorMsg());
+		}
 		
-
-		if (negateAmt)
-			payAmount = m_Amount.negate();
-		// Info
-		log.config("C_Order_ID=" + C_Order_ID + ", C_Invoice_ID=" + C_Invoice_ID + ", NegateAmt=" + negateAmt);
-
-		/***********************
-		 *  CashBook
-		 */
-		if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_Cash) && !m_Cash_As_Payment)
+		if (controller.getPaymentDocNumber() != null && !controller.getPaymentDocNumber().isEmpty())
 		{
-			log.fine("Cash");
-			if (C_Invoice_ID == 0 && order == null)
-			{
-				log.config("No Invoice!");
-				ADialog.error(m_WindowNo, this, "PaymentError", "CashNotCreated");
-			}
-			else
-			{
-				payAmount = (BigDecimal) bAmountField.getValue();
-				//  Changed Amount
-				if (m_cashLine != null
-					&& payAmount.compareTo(m_cashLine.getAmount()) != 0)
-				{
-					log.config("Changed CashBook Amount");
-					//m_cashLine.setAmount(payAmount);
-					m_cashLine.setAmount((BigDecimal) bAmountField.getValue());
-					// ADialog.info(m_WindowNo, this, "m_cashLine - Changed Amount", "Amount: "+m_cashLine.getAmount());
-					m_cashLine.saveEx();
-					log.config("CashAmt Changed");
-				}
-				//	Different Date/CashBook
-				if (m_cashLine != null
-					&& (newC_CashBook_ID != m_C_CashBook_ID 
-						|| !TimeUtil.isSameDay(m_cashLine.getStatementDate(), newDateAcct)))
-				{
-					log.config("Changed CashBook/Date: " + m_C_CashBook_ID + "->" + newC_CashBook_ID);
-					MCashLine reverse = m_cashLine.createReversal();
-					reverse.saveEx();
-					m_cashLine = null;
-				}
-				
-				//	Create new
-				if (m_cashLine == null)
-				{
-					log.config("New CashBook");
-					int C_Currency_ID = 0;
-					if (invoice != null)
-						C_Currency_ID = invoice.getC_Currency_ID();
-					if (C_Currency_ID == 0 && order != null)
-						C_Currency_ID = order.getC_Currency_ID();
-					MCash cash = null;
-					if (newC_CashBook_ID != 0)
-						cash = MCash.get (Env.getCtx(), newC_CashBook_ID, newDateAcct, trxName);
-					else	//	Default
-						cash = MCash.get (Env.getCtx(), m_AD_Org_ID, newDateAcct, C_Currency_ID, trxName);
-					if (cash == null || cash.get_ID() == 0)
-						ADialog.error(m_WindowNo, this, "PaymentError", CLogger.retrieveErrorString("CashNotCreated"));
-					else
-					{
-						MCashLine cl = new MCashLine (cash);
-						// cl.setAmount(new BigDecimal(bAmountField.getText()));
-						//ADialog.info(m_WindowNo, this, "m_cashLine - New Cashbook", "Amount: "+cl.getAmount());
-						if (invoice != null)
-							cl.setInvoice(invoice);	// overrides amount
-						if (order != null)
-						{
-							cl.setOrder(order, trxName); // overrides amount
-							m_needSave = true;
-						}
-						cl.setAmount((BigDecimal)bAmountField.getValue());
-						cl.saveEx();
-						log.config("CashCreated");
-						if (invoice == null && C_Invoice_ID != 0)
-						{
-							invoice = new MInvoice (Env.getCtx(), C_Invoice_ID, trxName);	
-						}
-						if (invoice != null) {
-							invoice.setC_CashLine_ID(cl.getC_CashLine_ID());
-							invoice.saveEx(trxName);
-						}	
-						if (order == null && C_Order_ID != 0)
-						{
-							order = new MOrder (Env.getCtx(), C_Order_ID, trxName);
-						}
-						if (order != null) {
-							order.setC_CashLine_ID(cl.getC_CashLine_ID());
-							order.saveEx(trxName);
-						}
-						log.config("Update Order & Invoice with CashLine");
-					}
-				}
-			}	//	have invoice
-		}
-		/***********************
-		 *  Payments
-		 */
-		if (("KS".indexOf(newPaymentRule) != -1) || 
-				(newPaymentRule.equals(MOrder.PAYMENTRULE_Cash) && m_Cash_As_Payment))
-		{
-			log.fine("Payment - " + newPaymentRule);
-			//  Set Amount
-			m_mPayment.setAmount(m_C_Currency_ID, payAmount);
-			if (newPaymentRule.equals(MOrder.PAYMENTRULE_CreditCard))
-			{
-				m_mPayment.setCreditCard(MPayment.TRXTYPE_Sales, newCCType,
-					kNumberField.getText(), "", kExpField.getText());
-				m_mPayment.setA_Name(kNameField.getText());
-				// Get changes to credit card amount
-				m_mPayment.setAmount(m_C_Currency_ID, (BigDecimal) kAmountField.getValue());
-				m_mPayment.setPaymentProcessor();
-			}
-			else if (newPaymentRule.equals(MOrder.PAYMENTRULE_DirectDeposit)
-				|| newPaymentRule.equals(MOrder.PAYMENTRULE_DirectDebit))
-			{
-				m_mPayment.setBankACH(newC_BankAccount_ID, m_isSOTrx, newPaymentRule, 
-					tRoutingField.getText(), tNumberField.getText());
-				m_mPayment.setAmount(m_C_Currency_ID, payAmount);
-			}
-			else if (newPaymentRule.equals(MOrder.PAYMENTRULE_Check))
-			{
-				m_mPayment.setBankCheck(newC_BankAccount_ID, m_isSOTrx, sRoutingField.getText(),
-					sNumberField.getText(), sCheckField.getText());
-				// Get changes to check amount
-				m_mPayment.setAmount(m_C_Currency_ID, (BigDecimal) sAmountField.getValue());
-			}
-			else if (newPaymentRule.equals(MOrder.PAYMENTRULE_Cash))
-			{
-				// Get changes to cash amount
-				m_mPayment.setTenderType(MPayment.TENDERTYPE_Cash);
-				m_mPayment.setBankCash(newC_BankAccount_ID, m_isSOTrx, MPayment.TENDERTYPE_Cash);
-				m_mPayment.setAmount(m_C_Currency_ID, payAmount);
-			}
-			m_mPayment.setC_BPartner_ID(m_C_BPartner_ID);
-			m_mPayment.setC_Invoice_ID(C_Invoice_ID);
-			if (order != null)
-			{
-				m_mPayment.setC_Order_ID(C_Order_ID);
-				m_needSave = true;
-			}
-			m_mPayment.setDateTrx(m_DateAcct);
-			m_mPayment.setDateAcct(m_DateAcct);
-			m_mPayment.saveEx();
-			
-			//  Save/Post
-			if (m_mPayment.get_ID() > 0 && MPayment.DOCSTATUS_Drafted.equals(m_mPayment.getDocStatus()))
-			{
-				boolean ok = m_mPayment.processIt(DocAction.ACTION_Complete);
-				m_mPayment.saveEx();
-				if (ok)
-					ADialog.info(m_WindowNo, this, "PaymentCreated", m_mPayment.getDocumentNo());
-				else
-					ADialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCreated");
-			}
-			else
-				log.fine("NotDraft " + m_mPayment);
-		}
-
-
-		/**********************
-		 *	Save Values to mTab
-		 */
-		log.config("Saving changes");
-		//
-		if (!newPaymentRule.equals(m_PaymentRule))
-			m_mTab.setValue("PaymentRule", newPaymentRule);
-		//
-		if (!newDateAcct.equals(m_DateAcct))
-			m_mTab.setValue("DateAcct", newDateAcct);
-		//
-		if (newC_PaymentTerm_ID != m_C_PaymentTerm_ID)
-			m_mTab.setValue("C_PaymentTerm_ID", new Integer(newC_PaymentTerm_ID));
-		//	Set Payment
-		if (m_mPayment.getC_Payment_ID() != m_C_Payment_ID)
-		{
-			if (m_mPayment.getC_Payment_ID() == 0)
-				m_mTab.setValue("C_Payment_ID", null);
-			else
-				m_mTab.setValue("C_Payment_ID", new Integer(m_mPayment.getC_Payment_ID()));
-		}
-		//	Set Cash
-		if (newC_CashLine_ID != m_C_CashLine_ID)
-		{
-			if (newC_CashLine_ID == 0)
-				m_mTab.setValue("C_CashLine_ID", null);
-			else
-				m_mTab.setValue("C_CashLine_ID", new Integer(newC_CashLine_ID));
+			ADialog.info(windowNo, this, PaymentFormController.MSG_PaymentCreated, controller.getPaymentDocNumber());
 		}
 		return true;
-	}
+
+	} // saveChanges
 	
-	/**
-	 *  Check Mandatory
-	 *  @return true if all mandatory items are OK
-	 */
-	private boolean checkMandatory()
-	{
-		log.config( "VPayment.checkMandatory");
-
-		ValueNamePair vp = (ValueNamePair)paymentCombo.getSelectedItem();
-		String PaymentRule = vp.getValue();
-		//  only Payment Rule
-		if (m_onlyRule)
-			return true;
-
-		String CCType = m_CCType;
-		//
-		int C_BankAccount_ID = 0;
-
-		/***********************
-		 *	Mandatory Data Check
-		 */
-		boolean dataOK = true;
-		//	B (Cash)		(Currency)
-		if (PaymentRule.equals(MOrder.PAYMENTRULE_Cash))
-		{
-			if (m_Cash_As_Payment)
-			{
-				KeyNamePair kp = (KeyNamePair)sBankAccountCombo.getSelectedItem();
-				if (kp != null)
-					C_BankAccount_ID = kp.getKey();
-			}
-		}
-
-		//	K (CreditCard)  Type, Number, Exp, Approval
-		else if (PaymentRule.equals(MOrder.PAYMENTRULE_CreditCard))
-		{
-			vp = (ValueNamePair)kTypeCombo.getSelectedItem();
-			if (vp != null)
-				CCType = vp.getValue();
-			// Validation of the credit card number is moved to the payment processor.
-			// Different payment processors can have different validation rules.
-		}
-
-		//	T (Transfer)	BPartner_Bank
-		else if (PaymentRule.equals(X_C_Order.PAYMENTRULE_DirectDeposit)
-			|| PaymentRule.equals(X_C_Order.PAYMENTRULE_DirectDebit))
-		{
-			KeyNamePair bpba = (KeyNamePair)tAccountCombo.getSelectedItem();
-			if (bpba == null)
-
-			{
-				tAccountCombo.setBackground(AdempierePLAF.getFieldBackground_Error());
-				ADialog.error(m_WindowNo, this, "PaymentBPBankNotFound");
-				dataOK = false;
-			}
-		}	//	Direct
-		//      P (PaymentTerm) PaymentTerm 	 
-        else if (PaymentRule.equals(X_C_Order.PAYMENTRULE_OnCredit))
-        {
-            // ok 	 
-        }
-		//	S (Check)		(Currency) CheckNo, Routing
-		else if (PaymentRule.equals(MOrder.PAYMENTRULE_Check))
-		{
-		//	sCurrencyCombo.getSelectedItem();
-			KeyNamePair kp = (KeyNamePair)sBankAccountCombo.getSelectedItem();
-			if (kp != null)
-				C_BankAccount_ID = kp.getKey();
-			String error = MPaymentValidate.validateRoutingNo(sRoutingField.getText());
-			if (error.length() != 0)
-			{
-				sRoutingField.setBackground(AdempierePLAF.getFieldBackground_Error());
-				ADialog.error(m_WindowNo, this, error);
-				dataOK = false;
-			}
-			error = MPaymentValidate.validateAccountNo(sNumberField.getText());
-			if (error.length() != 0)
-			{
-				sNumberField.setBackground(AdempierePLAF.getFieldBackground_Error());
-				ADialog.error(m_WindowNo, this, error);
-				dataOK = false;
-			}
-			error = MPaymentValidate.validateCheckNo(sCheckField.getText());
-			if (error.length() != 0)
-			{
-				sCheckField.setBackground(AdempierePLAF.getFieldBackground_Error());
-				ADialog.error(m_WindowNo, this, error);
-				dataOK = false;
-			}
-		}
-		else
-		{
-			log.log(Level.SEVERE, "Unknown PaymentRule " + PaymentRule);
-			ADialog.error(m_WindowNo, this, "Unknown PaymentRule " + PaymentRule);
-			return false;
-		}
-
-		//  find Bank Account if not qualified yet
-		if (("KTSD".indexOf(PaymentRule) != -1 || 
-				(PaymentRule.equals(MOrder.PAYMENTRULE_Cash) && m_Cash_As_Payment)) 
-					&& C_BankAccount_ID == 0)
-		{
-			//	Check & Cash (Payment) must have a bank account
-			if (C_BankAccount_ID == 0 && (PaymentRule.equals(MOrder.PAYMENTRULE_Check)) || 
-					(PaymentRule.equals(MOrder.PAYMENTRULE_Cash) && m_Cash_As_Payment))
-           {
-				ADialog.error(m_WindowNo, this, "PaymentNoProcessor");
-				dataOK = false;
-			}
-		}
-		//
-		log.config("OK=" + dataOK);
-		return dataOK;
-	}   //  checkMandatory
-
-	/**
-	 *  Get Invoice ID for Order
-	 *  @param C_Order_ID order
-	 *  @return C_Invoice_ID or 0 if not found
-	 */
-	private static int getInvoiceID (int C_Order_ID, String trxName)
-	{
-		int retValue = 0;
-		String sql = "SELECT C_Invoice_ID FROM C_Invoice WHERE C_Order_ID=? "
-			+ "ORDER BY C_Invoice_ID DESC";     //  last invoice
-		try
-		{
-			PreparedStatement pstmt = DB.prepareStatement(sql, trxName);
-			pstmt.setInt(1, C_Order_ID);
-			ResultSet rs = pstmt.executeQuery();
-			if (rs.next())
-				retValue = rs.getInt(1);
-			rs.close();
-			pstmt.close();
-		}
-		catch (SQLException e)
-		{
-			log.log(Level.SEVERE, sql, e);
-		}
-		return retValue;
-	}   //  getInvoiceID
-
 	
 	/**************************************************************************
 	 *  Process Online (sales only) - if approved - exit
@@ -1437,66 +613,17 @@ public class VPayment extends CDialog
 	private void processOnline()
 	{
 		log.config("");
-		if (!checkMandatory())
-			return;
-
-		boolean approved = false;
-		String info = "";
-		//
-		ValueNamePair vp = (ValueNamePair)paymentCombo.getSelectedItem();
-		String PaymentRule = vp.getValue();
-
-		//  --  CreditCard
-		if (PaymentRule.equals(X_C_Order.PAYMENTRULE_CreditCard))
+		
+		if (!controller.processOnline())
 		{
-			vp = (ValueNamePair)kTypeCombo.getSelectedItem();
-			String CCType = vp.getValue();
-
-			m_mPayment.setCreditCard(MPayment.TRXTYPE_Sales, CCType,
-				kNumberField.getText(), "", kExpField.getText());
-			m_mPayment.setA_Name(kNameField.getText());
-			m_mPayment.setAmount(m_C_Currency_ID, m_Amount);
-			m_mPayment.setPaymentProcessor();
-			m_mPayment.setC_BPartner_ID(m_C_BPartner_ID);
-			//
-			int C_Invoice_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Invoice_ID");
-			int C_Order_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Order_ID");
-			if (C_Invoice_ID == 0 && m_DocStatus.equals("CO"))
-				C_Invoice_ID = getInvoiceID (C_Order_ID, null);  // TODO: implement trx in processOnline
-			if ( C_Invoice_ID != 0 )
-				m_mPayment.setC_Invoice_ID(C_Invoice_ID);
-			else if ( C_Order_ID != 0 )
-				m_mPayment.setC_Order_ID(C_Order_ID);
-			m_mPayment.setDateTrx(m_DateAcct);
-			//  Set Amount
-			m_mPayment.setAmount(m_C_Currency_ID, m_Amount);
-			if (!m_mPayment.save()) {
-				ADialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCreated");
-			} else {
-				approved = m_mPayment.processOnline();
-				info = m_mPayment.getR_RespMsg() + " (" + m_mPayment.getR_AuthCode()
-					+ ") ID=" + m_mPayment.getR_PnRef();
-				m_mPayment.saveEx();
-
-				if (approved)
-				{
-					boolean ok = m_mPayment.processIt(DocAction.ACTION_Complete);
-					m_mPayment.saveEx();
-					if (ok)
-						ADialog.info(m_WindowNo, this, "PaymentProcessed", info + "\n" + m_mPayment.getDocumentNo());
-					else
-						ADialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCreated");
-					saveChanges();
-					dispose();
-				}
-				else
-				{
-					ADialog.error(m_WindowNo, this, "PaymentNotProcessed", info);
-				}
-			}
+			ADialog.error(windowNo, this, PaymentFormController.MSG_PaymentError, controller.getErrorMsg());
 		}
 		else
-			ADialog.error(m_WindowNo, this, "PaymentNoProcessor");
+		{
+			String info = controller.getOnlineInfo();
+			ADialog.info(windowNo, this, PaymentFormController.MSG_PaymentProcessed, info + "\n" + controller.getPaymentDocNumber());
+			dispose();
+		}
 	}   //  online
 
 	/**
@@ -1507,5 +634,314 @@ public class VPayment extends CDialog
 	{
 		return m_needSave;
 	}	//	needSave
+	
+	public String getPaymentRule() {
+		return ((ValueNamePair) paymentCombo.getSelectedItem()).getValue();
+	}
+	
+	public int getBankAccount(String paymentRule) {
+
+		KeyNamePair kp = null;
 		
+		if (paymentRule.equalsIgnoreCase("S"))
+		{
+			
+			kp = (KeyNamePair) sBankAccountCombo.getSelectedItem(); 
+		}
+		
+		if (kp != null)
+			return kp.getKey();
+		else
+			return 0;
+			
+	}
+	
+	public int getCashBook(String paymentRule) {
+		
+		KeyNamePair kp = null;
+		
+		if (paymentRule.equalsIgnoreCase("B")) 
+		{
+			
+			kp = (KeyNamePair) bCashBookCombo.getSelectedItem();
+			
+		}
+		
+		if (kp != null)
+			return kp.getKey();
+		else
+			return 0;
+		
+	}
+	
+	public Timestamp getDateAcct(String paymentRule) {
+	
+		// There is only one date
+		if (paymentRule.equalsIgnoreCase("B")) 
+		{
+			
+			return (Timestamp) bDateField.getValue();
+			
+		}
+		
+		return null;
+	}
+	
+	public BigDecimal getPaymentAmount(String paymentRule) {
+
+		BigDecimal amount = null;
+		
+		if (paymentRule.equalsIgnoreCase("B")) 
+		{
+			
+			amount = (BigDecimal) bAmountField.getValue();
+			
+		}
+		else if (paymentRule.equalsIgnoreCase("S"))
+		{
+			
+			amount = (BigDecimal) sAmountField.getValue();
+			
+		}
+		else if (paymentRule.equalsIgnoreCase("K"))
+		{
+			
+			amount = (BigDecimal) kAmountField.getValue();
+			
+		}
+		else if (paymentRule.equalsIgnoreCase("T") || paymentRule.equalsIgnoreCase("D"))
+		{
+			
+			return (BigDecimal) tAmountField.getValue();
+		}
+
+		if (amount != null)
+			return amount;
+		else
+			return Env.ZERO;
+
+	}
+	
+	public String getCreditCardType(String paymentRule) {
+		
+		ValueNamePair vp = null;
+		
+		if (paymentRule.equalsIgnoreCase("K"))
+		{
+			vp = (ValueNamePair) kTypeCombo.getSelectedItem();
+		}
+
+		if (vp != null)
+			return vp.getValue();
+		else
+			return "";
+
+	}
+
+	public int getBPBankAccount(String paymentRule) {
+		
+		KeyNamePair kp = null;
+		
+		if (paymentRule.equalsIgnoreCase("T") || paymentRule.equalsIgnoreCase("D")) 
+		{
+			
+			kp = (KeyNamePair) tAccountCombo.getSelectedItem();
+			
+		}
+		
+		if (kp != null)
+			return kp.getKey();
+		else
+			return 0;
+
+	}
+	
+	public int getPaymentTerm(String paymentRule) {
+		
+		KeyNamePair kp = null;
+		
+		if (paymentRule.equalsIgnoreCase("P")) 
+		{
+			
+			kp = (KeyNamePair) pTermCombo.getSelectedItem();
+			
+		}
+		
+		if (kp != null)
+			return kp.getKey();
+		else
+			return 0;
+
+	}
+
+
+	@Override
+	public String getCreditCardNumber(String paymentRule) {
+				
+		if (paymentRule.equalsIgnoreCase("K"))
+		{
+			return kNumberField.getText();
+		}
+		else
+			return "";
+
+	}
+
+
+	@Override
+	public String getCreditCardExpiry(String paymentRule) {
+	
+		if (paymentRule.equalsIgnoreCase("K"))
+		{
+			return kExpField.getText();
+		}
+		else
+			return "";
+
+	}
+
+	@Override
+	public String getCreditCardName(String paymentRule) {
+		
+		if (paymentRule.equalsIgnoreCase("K"))
+		{
+			return kNameField.getText();
+		}
+		else
+			return "";
+	}
+
+
+	@Override
+	public String getCheckAccountNumber(String paymentRule) {
+		
+		if (paymentRule.equalsIgnoreCase("S"))
+		{
+			return sAccountNumberField.getText();
+		}
+		else
+			return "";
+		
+	}
+
+
+	@Override
+	public String getCheckRoutingNumber(String paymentRule) {
+		
+		if (paymentRule.equalsIgnoreCase("S"))
+		{
+			return sRoutingField.getText();
+		}
+		else
+			return "";
+		
+	}
+
+
+	@Override
+	public String getCheckNumber(String paymentRule) {
+		
+		if (paymentRule.equalsIgnoreCase("S"))
+		{
+			return sCheckNumberField.getText();
+		}
+		else
+			return "";
+		
+	}
+
+
+	@Override
+	public void setMandatory(String field, boolean mandatory) {
+		
+		if (field.equals(FIELD_payment))
+			paymentCombo.setMandatory(mandatory);
+		if (field.equals(FIELD_kType))
+			kTypeCombo.setMandatory(mandatory);	
+		if (field.equals(FIELD_kNumber))
+			kNumberField.setMandatory(mandatory);
+		if (field.equals(FIELD_kName))
+			kNameField.setMandatory(mandatory);
+		if (field.equals(FIELD_kExp))
+			kExpField.setMandatory(mandatory);
+		if (field.equals(FIELD_kApproval))
+			kApprovalField.setMandatory(mandatory);
+		if (field.equals(FIELD_kAmount))
+			kAmountField.setMandatory(mandatory);
+		if (field.equals(FIELD_tAccount))
+			tAccountCombo.setMandatory(mandatory);
+		if (field.equals(FIELD_sCheckNumber))
+			sCheckNumberField.setMandatory(mandatory);
+		if (field.equals(FIELD_sAccountNumber))
+			sAccountNumberField.setMandatory(mandatory);
+		if (field.equals(FIELD_sRouting))
+			sRoutingField.setMandatory(mandatory);
+		if (field.equals(FIELD_sCurrency))
+			sCurrencyCombo.setMandatory(mandatory);
+		if (field.equals(FIELD_bCurrency))
+			bCurrencyCombo.setMandatory(mandatory);
+		if (field.equals(FIELD_pTerm))
+			pTermCombo.setMandatory(mandatory);
+		if (field.equals(FIELD_bAmount))
+			bAmountField.setMandatory(mandatory);
+		if (field.equals(FIELD_sAmount))
+			sAmountField.setMandatory(mandatory);
+		if (field.equals(FIELD_bDate))
+			bDateField.setMandatory(mandatory);
+		if (field.equals(FIELD_sCheck))
+			sCheckNumberField.setMandatory(mandatory);
+		if (field.equals(FIELD_sBankAccount))
+			sBankAccountCombo.setMandatory(mandatory);
+		if (field.equals(FIELD_bCashBook))
+			bCashBookCombo.setMandatory(mandatory);
+		
+	}
+
+
+	@Override
+	public void setError(String field, boolean error) {
+		
+		if (field.equals(FIELD_payment))
+			paymentCombo.setBackground(error);
+		if (field.equals(FIELD_kType))
+			kTypeCombo.setBackground(error);	
+		if (field.equals(FIELD_kNumber))
+			kNumberField.setBackground(error);
+		if (field.equals(FIELD_kName))
+			kNameField.setBackground(error);
+		if (field.equals(FIELD_kExp))
+			kExpField.setBackground(error);
+		if (field.equals(FIELD_kApproval))
+			kApprovalField.setBackground(error);
+		if (field.equals(FIELD_kAmount))
+			kAmountField.setBackground(error);
+		if (field.equals(FIELD_tAccount))
+			tAccountCombo.setBackground(error);
+		if (field.equals(FIELD_sCheckNumber))
+			sCheckNumberField.setBackground(error);
+		if (field.equals(FIELD_sAccountNumber))
+			sAccountNumberField.setBackground(error);
+		if (field.equals(FIELD_sRouting))
+			sRoutingField.setBackground(error);
+		if (field.equals(FIELD_sCurrency))
+			sCurrencyCombo.setBackground(error);
+		if (field.equals(FIELD_bCurrency))
+			bCurrencyCombo.setBackground(error);
+		if (field.equals(FIELD_pTerm))
+			pTermCombo.setBackground(error);
+		if (field.equals(FIELD_bAmount))
+			bAmountField.setBackground(error);
+		if (field.equals(FIELD_sAmount))
+			sAmountField.setBackground(error);
+		if (field.equals(FIELD_bDate))
+			bDateField.setBackground(error);
+		if (field.equals(FIELD_sCheck))
+			sCheckNumberField.setBackground(error);
+		if (field.equals(FIELD_sBankAccount))
+			sBankAccountCombo.setBackground(error);
+		if (field.equals(FIELD_bCashBook))
+			bCashBookCombo.setBackground(error);
+		
+	}
+
 }	//	VPayment

--- a/migration/391lts-392lts/04450_2347_FixWVPaymentReduceDupCode.xml
+++ b/migration/391lts-392lts/04450_2347_FixWVPaymentReduceDupCode.xml
@@ -62,7 +62,7 @@
         <Data AD_Column_ID="609" Column="Created">2019-03-02 07:22:17.195</Data>
         <Data AD_Column_ID="611" Column="Updated">2019-03-02 07:22:17.195</Data>
         <Data AD_Column_ID="608" Column="IsActive">true</Data>
-        <Data AD_Column_ID="343" Column="MsgTip">Seleccione la definici&oacute;n de Diario de Caja a utilizar. Cualquier pago en efectivo creado se agregar&aacute; a un documento de Cierre de Caja del Diario de Caja seleccionado.</Data>
+        <Data AD_Column_ID="343" Column="MsgTip">Seleccione la definición de Diario de Caja a utilizar. Cualquier pago en efectivo creado se agregará a un documento de Cierre de Caja del Diario de Caja seleccionado.</Data>
         <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
@@ -103,7 +103,7 @@
         <Data AD_Column_ID="6767" Column="AD_Message_ID">53572</Data>
         <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
         <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
-        <Data AD_Column_ID="342" Column="MsgText">El pago se aprob&amp;#243; en l&amp;#237;nea, pero el documento de pago no se complet&amp;#243;. Por favor, compruebe el documento de pago creado.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">El pago se aprobó en línea, pero el documento de pago no se completó. Por favor, compruebe el documento de pago creado.</Data>
         <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
       </PO>
     </Step>
@@ -127,7 +127,7 @@
     </Step>
     <Step SeqNo="130" StepType="AD">
       <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
-        <Data AD_Column_ID="342" Column="MsgText">No fue posible guardar el pago creado. No se ha realizado ning&amp;uacute;n procesamiento en l&amp;iacute;nea.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">No fue posible guardar el pago creado. No se ha realizado ningún procesamiento en línea.</Data>
         <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
         <Data AD_Column_ID="609" Column="Created">2019-03-02 08:28:30.451</Data>
         <Data AD_Column_ID="611" Column="Updated">2019-03-02 08:28:30.451</Data>
@@ -174,7 +174,7 @@
         <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
         <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
         <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
-        <Data AD_Column_ID="342" Column="MsgText">El proceso en l&amp;iacute;nea fall&amp;oacute;. El pago fue creado y se dejar&amp;aacute; como borrador.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">El proceso en línea falló. El pago fue creado y se dejará como borrador.</Data>
       </PO>
     </Step>
     <Step SeqNo="210" StepType="AD">
@@ -197,7 +197,7 @@
     </Step>
     <Step SeqNo="220" StepType="AD">
       <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
-        <Data AD_Column_ID="342" Column="MsgText">Se crear&amp;aacute; un documento de pago. &amp;iquest;Quieres continuar?</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Se creará un documento de pago. ¿Quieres continuar?</Data>
         <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
         <Data AD_Column_ID="609" Column="Created">2019-03-02 09:33:02.428</Data>
         <Data AD_Column_ID="611" Column="Updated">2019-03-02 09:33:02.428</Data>
@@ -243,7 +243,7 @@
         <Data AD_Column_ID="6767" Column="AD_Message_ID">53577</Data>
         <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
         <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
-        <Data AD_Column_ID="342" Column="MsgText">Se requiere un Socio del Negocio pero no se pudo identificar. Aseg&amp;uacute;rese de que el pedido o la factura tenga un Socio del Negocio comercial seleccionado e intente nuevamente.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Se requiere un Socio del Negocio pero no se pudo identificar. Asegúrese de que el pedido o la factura tenga un Socio del Negocio comercial seleccionado e intente nuevamente.</Data>
         <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
       </PO>
     </Step>
@@ -302,7 +302,7 @@
     </Step>
     <Step SeqNo="320" StepType="AD">
       <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
-        <Data AD_Column_ID="342" Column="MsgText">No se ha seleccionado ning&amp;uacute;n diario de caja.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">No se ha seleccionado ningún diario de caja.</Data>
         <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
         <Data AD_Column_ID="609" Column="Created">2019-03-02 11:30:47.857</Data>
         <Data AD_Column_ID="611" Column="Updated">2019-03-02 11:30:47.857</Data>
@@ -349,7 +349,7 @@
         <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
         <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
         <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
-        <Data AD_Column_ID="342" Column="MsgText">No se seleccion&amp;oacute; ning&amp;uacute;n tipo de tarjeta de cr&amp;eacute;dito. Un tipo de tarjeta de cr&amp;eacute;dito es obligatorio.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">No se seleccionó ningún tipo de tarjeta de crédito. Un tipo de tarjeta de crédito es obligatorio.</Data>
       </PO>
     </Step>
     <Step SeqNo="360" StepType="AD">
@@ -384,7 +384,7 @@
         <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
         <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
         <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
-        <Data AD_Column_ID="342" Column="MsgText">No se seleccion&amp;oacute; ninguna cuenta bancaria de Socio del Negocio</Data>
+        <Data AD_Column_ID="342" Column="MsgText">No se seleccionó ninguna cuenta bancaria de Socio del Negocio</Data>
       </PO>
     </Step>
     <Step SeqNo="380" StepType="AD">
@@ -408,7 +408,7 @@
     <Step SeqNo="390" StepType="AD">
       <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
         <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
-        <Data AD_Column_ID="342" Column="MsgText">El importe del pago es cero. No se crear&amp;aacute; ning&amp;uacute;n pago.</Data>
+        <Data AD_Column_ID="342" Column="MsgText">El importe del pago es cero. No se creará ningún pago.</Data>
         <Data AD_Column_ID="609" Column="Created">2019-03-05 10:15:01.33</Data>
         <Data AD_Column_ID="611" Column="Updated">2019-03-05 10:15:01.33</Data>
         <Data AD_Column_ID="608" Column="IsActive">true</Data>

--- a/migration/391lts-392lts/04450_2347_FixWVPaymentReduceDupCode.xml
+++ b/migration/391lts-392lts/04450_2347_FixWVPaymentReduceDupCode.xml
@@ -1,0 +1,426 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="#2347 Fix W/VPayment and Reduce Duplicate Code" ReleaseNo="3.9.2" SeqNo="4450">
+    <Comments>See https://github.com/adempiere/adempiere/issues/2347</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53570" Table="AD_Message">
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53570</Data>
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 07:09:18.987</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Cash Journal</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 07:09:18.987</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: CashJournal</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 07:09:28.167</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 07:09:28.167</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53570</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="342" Column="MsgText">Diario de Caja</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53571" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 07:22:15.89</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Cash Journal</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 07:22:15.89</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: CashJournalTip</Data>
+        <Data AD_Column_ID="199" Column="MsgTip">Select the Cash Journal Definition to use.  Any cash payment created will be added to a Cash Closing document of the selected Cash Journal.</Data>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53571</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="342" Column="MsgText">Diario de Caja</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 07:22:17.195</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 07:22:17.195</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip">Seleccione la definici&oacute;n de Diario de Caja a utilizar. Cualquier pago en efectivo creado se agregar&aacute; a un documento de Cierre de Caja del Diario de Caja seleccionado.</Data>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53571</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53572" Table="AD_Message">
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: PaymentNotCompletedAfterProcessApproval</Data>
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 08:11:38.578</Data>
+        <Data AD_Column_ID="198" Column="MsgText">The payment was approved online but the payment document was not completed. Please check the payment document created.</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 08:11:38.578</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53572</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 08:11:41.274</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 08:11:41.274</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53572</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="342" Column="MsgText">El pago se aprob&amp;#243; en l&amp;#237;nea, pero el documento de pago no se complet&amp;#243;. Por favor, compruebe el documento de pago creado.</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="120" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53573" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 08:28:29.067</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 08:28:29.067</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: PaymentNotCreated</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53573</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="198" Column="MsgText">It was not possible to save the created payment.  No online processing has taken place.</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="130" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="342" Column="MsgText">No fue posible guardar el pago creado. No se ha realizado ning&amp;uacute;n procesamiento en l&amp;iacute;nea.</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 08:28:30.451</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 08:28:30.451</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53573</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="150" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53574" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 08:41:17.594</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 08:41:17.594</Data>
+        <Data AD_Column_ID="197" Column="MsgType">E</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: PaymentNotProcessed</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53574</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="198" Column="MsgText">The online process failed.</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="160" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 08:41:18.953</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 08:41:18.953</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53574</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText">El proceso en l&amp;iacute;nea fall&amp;oacute;. El pago fue creado y se dejar&amp;aacute; como borrador.</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="210" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53576" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 09:33:00.825</Data>
+        <Data AD_Column_ID="198" Column="MsgText">A payment document will be created. Do you want to continue?</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 09:33:00.825</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: PaymentCreateConfirmation</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53576</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="220" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="342" Column="MsgText">Se crear&amp;aacute; un documento de pago. &amp;iquest;Quieres continuar?</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 09:33:02.428</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 09:33:02.428</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53576</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="240" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53577" Table="AD_Message">
+        <Data AD_Column_ID="198" Column="MsgText">A Business Partner is required but could not be identified.  Please make sure the order or invoice has a business partner selected and try again.</Data>
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 09:44:34.987</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 09:44:34.987</Data>
+        <Data AD_Column_ID="197" Column="MsgType">E</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: NoBusinessPartnerFound</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53577</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="250" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 09:44:36.336</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 09:44:36.336</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53577</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="342" Column="MsgText">Se requiere un Socio del Negocio pero no se pudo identificar. Aseg&amp;uacute;rese de que el pedido o la factura tenga un Socio del Negocio comercial seleccionado e intente nuevamente.</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="280" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53578" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 09:56:11.186</Data>
+        <Data AD_Column_ID="198" Column="MsgText">The source document is reversed or voided. Its not possible to take a payment referencing this document.</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 09:56:11.186</Data>
+        <Data AD_Column_ID="197" Column="MsgType">E</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: DocumentReversedOrVoided</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53578</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="290" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 09:56:12.81</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 09:56:12.81</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53578</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="342" Column="MsgText">El documento fuente se invierte o se anula. No es posible realizar un pago haciendo referencia a este documento.</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="310" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53579" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 11:30:45.303</Data>
+        <Data AD_Column_ID="198" Column="MsgText">No Cash Journal has been selected.</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 11:30:45.303</Data>
+        <Data AD_Column_ID="197" Column="MsgType">E</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: NoCashJournalSelected</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53579</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="320" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="342" Column="MsgText">No se ha seleccionado ning&amp;uacute;n diario de caja.</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 11:30:47.857</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 11:30:47.857</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53579</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="340" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53580" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-02 11:35:13.193</Data>
+        <Data AD_Column_ID="198" Column="MsgText">No credit card type was selected. A credit card type is mandatory.</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-02 11:35:13.193</Data>
+        <Data AD_Column_ID="197" Column="MsgType">E</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: NoCreditCardTypeSelected</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53580</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="350" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-03-02 11:35:14.568</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-02 11:35:14.568</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53580</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText">No se seleccion&amp;oacute; ning&amp;uacute;n tipo de tarjeta de cr&amp;eacute;dito. Un tipo de tarjeta de cr&amp;eacute;dito es obligatorio.</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="360" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53581" Table="AD_Message">
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: NoBPBankAccountSelected</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-05 07:32:35.689</Data>
+        <Data AD_Column_ID="198" Column="MsgText">No Business Partner bank account was selected.</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-05 07:32:35.689</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53581</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="370" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53581</Data>
+        <Data AD_Column_ID="609" Column="Created">2019-03-05 07:32:55.266</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-05 07:32:55.266</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+        <Data AD_Column_ID="342" Column="MsgText">No se seleccion&amp;oacute; ninguna cuenta bancaria de Socio del Negocio</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="380" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53582" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-03-05 10:14:25.28</Data>
+        <Data AD_Column_ID="198" Column="MsgText">The payment amount is zero.  No payment will be created.</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-03-05 10:14:25.28</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">PaymentFormController: ZeroPaymentAmount</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53582</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="390" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="344" Column="IsTranslated">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText">El importe del pago es cero. No se crear&amp;aacute; ning&amp;uacute;n pago.</Data>
+        <Data AD_Column_ID="609" Column="Created">2019-03-05 10:15:01.33</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-03-05 10:15:01.33</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53582</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID" isNewNull="true"/>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WPayment.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WPayment.java
@@ -17,17 +17,14 @@
 package org.adempiere.webui.apps.form;
 
 import java.math.BigDecimal;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
 import java.util.logging.Level;
 
+import org.adempiere.controller.PaymentFormController;
+import org.adempiere.controller.ed.CPaymentEditor;
 import org.adempiere.webui.LayoutUtils;
 import org.adempiere.webui.apps.BusyDialog;
 import org.adempiere.webui.component.Button;
@@ -48,25 +45,12 @@ import org.adempiere.webui.editor.WDateEditor;
 import org.adempiere.webui.editor.WNumberEditor;
 import org.adempiere.webui.window.FDialog;
 import org.compiere.model.GridTab;
-import org.compiere.model.MCash;
-import org.compiere.model.MCashLine;
-import org.compiere.model.MConversionRate;
-import org.compiere.model.MInvoice;
-import org.compiere.model.MOrder;
-import org.compiere.model.MPayment;
-import org.compiere.model.MPaymentValidate;
-import org.compiere.model.MRole;
-import org.compiere.model.MSysConfig;
-import org.compiere.model.X_C_Order;
-import org.compiere.process.DocAction;
 import org.compiere.util.CLogger;
-import org.compiere.util.DB;
+import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.KeyNamePair;
 import org.compiere.util.Msg;
-import org.compiere.util.TimeUtil;
-import org.compiere.util.Trx;
-import org.compiere.util.TrxRunnable;
+import org.compiere.util.Util;
 import org.compiere.util.ValueNamePair;
 import org.zkforge.keylistener.Keylistener;
 import org.zkoss.zk.au.out.AuEcho;
@@ -113,12 +97,14 @@ import org.zkoss.zul.Space;
  * 				<li>BF [ 1789949 ] VPayment: is displaying just "CashNotCreated"
  */
 public class WPayment extends Window
-	implements EventListener
+	implements EventListener, CPaymentEditor
 {
 	/**
 	 * 
 	 */
 	private static final long serialVersionUID = 3550713503274155601L;
+
+	private int windowNo;
 
 
 	/**
@@ -131,14 +117,12 @@ public class WPayment extends Window
 	public WPayment (int WindowNo, GridTab mTab, WButtonEditor button)
 	{
 		super();
+		windowNo = WindowNo;
+		controller = new PaymentFormController(this, WindowNo, mTab, button.getValues());
 		this.setTitle(Msg.getMsg(Env.getCtx(), "Payment"));
 		this.setAttribute("mode", "modal");
-		m_WindowNo = WindowNo;
-		m_isSOTrx = "Y".equals(Env.getContext(Env.getCtx(), WindowNo, "IsSOTrx"));
-		m_mTab = mTab;
 		try
 		{
-			bDateField = new WDateEditor("DateAcct", false, false, true, "DateAcct");
 			zkInit();
 			m_initOK = dynInit(button);     //  Null Pointer if order/invoice not saved yet
 		}
@@ -148,53 +132,15 @@ public class WPayment extends Window
 			m_initOK = false;
 		}
 		//
-		this.setHeight("400px");
-		this.setWidth("500px");
+//		this.setHeight("400px");
+//		this.setWidth("500px");
 		this.setBorder("normal");
 	}	//	VPayment
 
-	/**	Window						*/
-	private int                 m_WindowNo = 0;
-	/**	Tab							*/
-	private GridTab         		m_mTab;
+	PaymentFormController 		controller;
 
-	//	Data from Order/Invoice
-	private String              m_DocStatus = null;
-	/** Start Payment Rule          */
-	private String				m_PaymentRule = "";
-	/** Start Payment Term          */
-	private int					m_C_PaymentTerm_ID = 0;
-	/** Start Acct Date             */
-	private Timestamp			m_DateAcct = null;
-	/** Start Payment               */
-	private int					m_C_Payment_ID = 0;
-	private MPayment            m_mPayment = null;
-	private MPayment            m_mPaymentOriginal = null;
-	/** Start CashBook Line         */
-	private int                 m_C_CashLine_ID = 0;
-	private MCashLine			m_cashLine = null;
-	/** Start CreditCard            */
-	private String              m_CCType = "";
-	/** Start Bank Account			*/
-	private int					m_C_BankAccount_ID = 0;
-	/** Start CashBook              */
-	private int                 m_C_CashBook_ID = 0;
-
-	/** Is SOTrx					*/
-	private boolean				m_isSOTrx = true;
-
-	/** Invoice Currency              */
-	private int	 				m_C_Currency_ID = 0;
-	private int                 m_AD_Client_ID = 0;
-	private boolean				m_Cash_As_Payment = true;
-	private int                 m_AD_Org_ID = 0;
-	private int                 m_C_BPartner_ID = 0;
-	private BigDecimal			m_Amount = Env.ZERO;	//	Payment Amount
 	//
 	private boolean 			m_initOK = false;
-	/** Only allow changing Rule        */
-	private boolean             m_onlyRule = false;
-	private static Hashtable<Integer,KeyNamePair> s_Currencies = null;	//	EMU Currencies
 	
 	private boolean				m_needSave = false;
 	/**	Logger			*/
@@ -210,9 +156,12 @@ public class WPayment extends Window
 	private List<Panel> centerLayout = new ArrayList<Panel>();
 	private Panel bPanel = new Panel();
 	private Panel kPanel = new Panel();
+	private Grid northLayout = GridFactory.newGridLayout();
 	private Grid kLayout = GridFactory.newGridLayout();
 	private Label kTypeLabel = new Label();
 	private Listbox kTypeCombo = ListboxFactory.newDropdownListbox();
+	private Label kNameLabel = new Label();
+	private Textbox kNameField = new Textbox();
 	private Label kNumberLabel = new Label();
 	private Textbox kNumberField = new Textbox();
 	private Label kExpLabel = new Label();
@@ -226,8 +175,8 @@ public class WPayment extends Window
 	private Listbox tAccountCombo = ListboxFactory.newDropdownListbox();
 	private Panel sPanel = new Panel();
 	private Grid sPanelLayout = GridFactory.newGridLayout();
-	private Label sNumberLabel = new Label();
-	private Textbox sNumberField = new Textbox();
+	private Label sAccountNumberLabel = new Label();
+	private Textbox sAccountNumberField = new Textbox();
 	private Label sRoutingLabel = new Label();
 	private Textbox sRoutingField = new Textbox();
 	private Label sCurrencyLabel = new Label();
@@ -245,25 +194,21 @@ public class WPayment extends Window
 	private WDateEditor bDateField;
 	private Label bDateLabel = new Label();
 	private ConfirmPanel confirmPanel = new ConfirmPanel(true);
-	private Textbox sCheckField = new Textbox();
-	private Label sCheckLabel = new Label();
+	private Textbox sCheckNumberField = new Textbox();
+	private Label sCheckNumberLabel = new Label();
 	private Button kOnline = new Button();
 	private Button sOnline = new Button();
 	private Listbox sBankAccountCombo = ListboxFactory.newDropdownListbox();
 	private Label sBankAccountLabel = new Label();
-	private Listbox bBankAccountCombo = ListboxFactory.newDropdownListbox();
-	private Label bBankAccountLabel = new Label();
 	private Grid pPanelLayout = GridFactory.newGridLayout();
 	private Label bCashBookLabel = new Label();
 	private Listbox bCashBookCombo = ListboxFactory.newDropdownListbox();
 	private Grid tPanelLayout = GridFactory.newGridLayout();
 	private Button tOnline = new Button();
 	private Label kStatus = new Label();
-	private Textbox tRoutingField = new Textbox();
-	private Textbox tNumberField = new Textbox();
 	private Label tStatus = new Label();
-	private Label tRoutingText = new Label();
-	private Label tNumberText = new Label();
+	private Label tAmountLabel = new Label();
+	private WNumberEditor tAmountField = new WNumberEditor();
 	private Label sStatus = new Label();
 
 	private boolean m_isLocked = false;
@@ -280,6 +225,7 @@ public class WPayment extends Window
 	 */
 	private void zkInit() throws Exception
 	{
+		
 		this.appendChild(mainPanel);
 		mainPanel.appendChild(mainLayout);
 		mainPanel.setStyle("width: 100%; height: 100%; padding: 0; margin: 0");
@@ -294,21 +240,32 @@ public class WPayment extends Window
 		north.setStyle("border: none");
 		mainLayout.appendChild(north);
 		north.appendChild(northPanel);
-		northPanel.appendChild(paymentLabel);
-		northPanel.appendChild(new Space());
-		northPanel.appendChild(paymentCombo);
+		northPanel.appendChild(northLayout);
+		Rows rows = northLayout.newRows();
+		Row row = rows.newRow();
+		row.appendChild(paymentLabel.rightAlign());
+		row.appendChild(paymentCombo);
+		row.appendChild(new Space());
+		row.appendChild(new Space());
 		//
+		// Get the display format for amounts
+		bAmountField = new WNumberEditor("Amount", true, false, true, DisplayType.Amount, Msg.translate(Env.getCtx(), "Amount"));
+		kAmountField = new WNumberEditor("Amount", true, false, true, DisplayType.Amount, Msg.translate(Env.getCtx(), "Amount"));
+		sAmountField = new WNumberEditor("Amount", true, false, true, DisplayType.Amount, Msg.translate(Env.getCtx(), "Amount"));
+		tAmountField = new WNumberEditor("Amount", true, false, true, DisplayType.Amount, Msg.translate(Env.getCtx(), "Amount"));
+		
 		//      CreditCard
 		kPanel.appendChild(kLayout);
 		kNumberField.setWidth("160pt");
 		kExpField.setWidth("40pt");
 		kApprovalField.setWidth("120pt");
 		kTypeLabel.setText(Msg.translate(Env.getCtx(), "CreditCardType"));
+		kNameLabel.setText(Util.cleanAmp(Msg.translate(Env.getCtx(), "Name")));
 		kNumberLabel.setText(Msg.translate(Env.getCtx(), "CreditCardNumber"));
 		kExpLabel.setText(Msg.getMsg(Env.getCtx(), "Expires"));
 		kApprovalLabel.setText(Msg.translate(Env.getCtx(), "VoiceAuthCode"));
 		kAmountLabel.setText(Msg.getMsg(Env.getCtx(), "Amount"));
-		kOnline.setLabel(Msg.getMsg(Env.getCtx(), "Online"));
+		kOnline.setLabel(Msg.getMsg(Env.getCtx(), "Online"));  // Check online processing not enabled
 		LayoutUtils.addSclass("action-text-button", kOnline);
 		kOnline.addActionListener(this);
 		kStatus.setText(" ");
@@ -316,13 +273,19 @@ public class WPayment extends Window
 		centerPanel.appendChild(kPanel);
 		centerLayout.add(kPanel);
 		
-		Rows rows = kLayout.newRows();
-		Row row = rows.newRow();
+		rows = kLayout.newRows();
+		row = rows.newRow();
 		row.appendChild(kTypeLabel.rightAlign());
 		row.appendChild(kTypeCombo);
 		row.appendChild(new Space());
 		row.appendChild(new Space());
 		
+		row = rows.newRow();
+		row.appendChild(kNameLabel.rightAlign());
+		row.appendChild(kNameField);
+		row.appendChild(new Space());
+		row.appendChild(new Space());
+
 		row = rows.newRow();
 		row.appendChild(kNumberLabel.rightAlign());
 		row.appendChild(kNumberField);
@@ -345,7 +308,7 @@ public class WPayment extends Window
 		row.appendChild(kApprovalLabel.rightAlign());
 		row.appendChild(kApprovalField);
 		row.appendChild(new Space());
-		row.appendChild(kOnline);
+		row.appendChild(kOnline);   // check online processing not enabled
 		
 		row = rows.newRow();
 		row.setSpans("3,1");
@@ -355,10 +318,7 @@ public class WPayment extends Window
 		//	DircetDebit/Credit
 		tPanel.appendChild(tPanelLayout);
 		tAccountLabel.setText(Msg.translate(Env.getCtx(), "C_BP_BankAccount_ID"));
-		tRoutingField.setCols(8);
-		tNumberField.setCols(10);
-		tRoutingText.setText(Msg.translate(Env.getCtx(), "RoutingNo"));
-		tNumberText.setText(Msg.translate(Env.getCtx(), "AccountNo"));
+		tAmountLabel.setText(Msg.translate(Env.getCtx(), "Amount"));
 		tOnline.setLabel(Msg.getMsg(Env.getCtx(), "Online"));
 		LayoutUtils.addSclass("action-text-button", tOnline);
 		tStatus.setText(" ");
@@ -374,17 +334,11 @@ public class WPayment extends Window
 		row.appendChild(new Space());
 		
 		row = rows.newRow();
-		row.appendChild(tRoutingText.rightAlign());
-		row.appendChild(tRoutingField);
+		row.appendChild(tAmountLabel.rightAlign());
+		row.appendChild(tAmountField.getComponent());
 		row.appendChild(new Space());
-		row.appendChild(new Space());
-		
-		row = rows.newRow();
-		row.appendChild(tNumberText.rightAlign());
-		row.appendChild(tNumberField);
-		row.appendChild(new Space());
-		row.appendChild(tOnline);		
-		
+		row.appendChild(tOnline);
+				
 		row = rows.newRow();
 		row.setSpans("3,1");
 		row.appendChild(tStatus);
@@ -395,14 +349,15 @@ public class WPayment extends Window
 		sBankAccountLabel.setText(Msg.translate(Env.getCtx(), "C_BankAccount_ID"));
 		sAmountLabel.setText(Msg.getMsg(Env.getCtx(), "Amount"));
 		sRoutingLabel.setText(Msg.translate(Env.getCtx(), "RoutingNo"));
-		sNumberLabel.setText(Msg.translate(Env.getCtx(), "AccountNo"));
-		sCheckLabel.setText(Msg.translate(Env.getCtx(), "CheckNo"));
-		sCheckField.setCols(8);
+		sAccountNumberLabel.setText(Msg.translate(Env.getCtx(), "AccountNo"));
+		sCheckNumberLabel.setText(Msg.translate(Env.getCtx(), "CheckNo"));
+		sCheckNumberField.setCols(8);
 		sCurrencyLabel.setText(Msg.translate(Env.getCtx(), "C_Currency_ID"));
-		sNumberField.setWidth("100pt");
+		sAccountNumberField.setWidth("100pt");
 		sRoutingField.setWidth("70pt");
 		sStatus.setText(" ");
 		sOnline.setLabel(Msg.getMsg(Env.getCtx(), "Online"));
+		sOnline.addActionListener(this);
 		LayoutUtils.addSclass("action-text-button", sOnline);
 		sPanel.setId("sPanel");
 		centerPanel.appendChild(sPanel);
@@ -415,11 +370,14 @@ public class WPayment extends Window
 		row.appendChild(new Space());
 		row.appendChild(new Space());
 		
-		row = rows.newRow();
-		row.appendChild(sCurrencyLabel.rightAlign());
-		row.appendChild(sCurrencyCombo);
-		row.appendChild(new Space());
-		row.appendChild(new Space());
+		if (controller.isEMUCurrency())
+		{
+			row = rows.newRow();
+			row.appendChild(sCurrencyLabel.rightAlign());
+			row.appendChild(sCurrencyCombo);
+			row.appendChild(new Space());
+			row.appendChild(new Space());
+		}
 		
 		row = rows.newRow();
 		row.appendChild(sAmountLabel.rightAlign());
@@ -434,14 +392,14 @@ public class WPayment extends Window
 		row.appendChild(new Space());
 		
 		row = rows.newRow();
-		row.appendChild(sNumberLabel.rightAlign());
-		row.appendChild(sNumberField);
+		row.appendChild(sAccountNumberLabel.rightAlign());
+		row.appendChild(sAccountNumberField);
 		row.appendChild(new Space());
 		row.appendChild(new Space());
 		
 		row = rows.newRow();
-		row.appendChild(sCheckLabel.rightAlign());
-		row.appendChild(sCheckField);
+		row.appendChild(sCheckNumberLabel.rightAlign());
+		row.appendChild(sCheckNumberField);
 		row.appendChild(new Space());
 		row.appendChild(sOnline);
 		
@@ -450,7 +408,7 @@ public class WPayment extends Window
 		row.appendChild(sStatus);
 		row.appendChild(new Space());
 		
-		// Cash
+		// Payment Term
 		pPanel.appendChild(pPanelLayout);
 		pTermLabel.setText(Msg.translate(Env.getCtx(), "C_PaymentTerm_ID"));
 		pPanel.setId("pPanel");
@@ -461,27 +419,24 @@ public class WPayment extends Window
 		row = rows.newRow();
 		row.appendChild(pTermLabel.rightAlign());
 		row.appendChild(pTermCombo);
-		//
-		bCashBookLabel.setText(Msg.translate(Env.getCtx(), "C_CashBook_ID"));
+		
+		// Cash
+		bCashBookLabel.setText(Msg.translate(Env.getCtx(), PaymentFormController.MSG_CashJournal));
+		bCashBookLabel.setTooltip(Msg.translate(Env.getCtx(), PaymentFormController.MSG_CashJournalTip));
 		bCurrencyLabel.setText(Msg.translate(Env.getCtx(), "C_Currency_ID"));
 		bPanel.appendChild(bPanelLayout);
 		bAmountLabel.setText(Msg.getMsg(Env.getCtx(), "Amount"));
-		//bAmountField.setText("");
+//		bAmountField.getComponent().setFormat(format);
 		bDateLabel.setText(Msg.translate(Env.getCtx(), "DateAcct"));
+		bDateField = new WDateEditor("DateAcct", false, false, true, "DateAcct");
 		bPanel.setId("bPanel");
 		centerPanel.appendChild(bPanel);
 		centerLayout.add(bPanel);
 		
 		rows = bPanelLayout.newRows();
 		row = rows.newRow();
-		if (m_Cash_As_Payment) {
-			bBankAccountLabel.setText(Msg.translate(Env.getCtx(), "C_BankAccount_ID"));
-			row.appendChild(bBankAccountLabel.rightAlign());
-			row.appendChild(bBankAccountCombo);
-		} else {
-			row.appendChild(bCashBookLabel.rightAlign());
-			row.appendChild(bCashBookCombo);
-		}
+		row.appendChild(bCashBookLabel.rightAlign());
+		row.appendChild(bCashBookCombo);
 		
 		row = rows.newRow();
 		row.appendChild(bCurrencyLabel.rightAlign());
@@ -525,149 +480,38 @@ public class WPayment extends Window
 	 */
 	private boolean dynInit (WButtonEditor button) throws Exception
 	{
-		m_DocStatus = (String)m_mTab.getValue("DocStatus");
-		log.config(m_DocStatus);
-
-		if (m_mTab.getValue("C_BPartner_ID") == null)
+		if (!controller.init() && !controller.getErrorMsg().isEmpty())
 		{
-			FDialog.error(0, this, "SaveErrorRowNotFound");
-			return false;
-		}
-
-		//	Is the Trx posted?
-	//	String Posted = (String)m_mTab.getValue("Posted");
-	//	if (Posted != null && Posted.equals("Y"))
-	//		return false;
-
-		//  DocStatus
-		m_DocStatus = (String)m_mTab.getValue("DocStatus");
-		if (m_DocStatus == null)
-			m_DocStatus = "";
-		//	Is the Trx closed?		Reversed / Voided / Cloased
-		if (m_DocStatus.equals("RE") || m_DocStatus.equals("VO") || m_DocStatus.equals("CL"))
-			return false;
-		//  Document is not complete - allow to change the Payment Rule only
-		if (m_DocStatus.equals("CO") || m_DocStatus.equals("WP") )
-			m_onlyRule = false;
-		else
-			m_onlyRule = true;
-		//	PO only  Rule
-		if (!m_onlyRule		//	Only order has Warehouse
-			&& !m_isSOTrx && m_mTab.getValue("M_Warehouse_ID") != null)
-			m_onlyRule = true;
-		
-		centerPanel.setVisible(!m_onlyRule);
-		
-		
-		//  Amount
-		m_Amount = (BigDecimal)m_mTab.getValue("GrandTotal");
-		if (!m_onlyRule && m_Amount.compareTo(Env.ZERO) == 0)
-		{
-			FDialog.error(m_WindowNo, this, "PaymentZero");
+			FDialog.error(0, this, controller.getErrorMsg());
 			return false;
 		}
 		
+		centerPanel.setVisible(!controller.isOnlyChangePaymentRule());
 
-		bAmountField.setValue(m_Amount);
-		sAmountField.setValue(m_Amount);
-		kAmountField.setValue(m_Amount);
-		
-
-		/**
-		 *	Get Data from Grid
-		 */
-		m_AD_Client_ID = ((Integer)m_mTab.getValue("AD_Client_ID")).intValue();
-		m_Cash_As_Payment = MSysConfig.getBooleanValue("CASH_AS_PAYMENT",true, m_AD_Client_ID);
-		m_AD_Org_ID = ((Integer)m_mTab.getValue("AD_Org_ID")).intValue();
-		m_C_BPartner_ID = ((Integer)m_mTab.getValue("C_BPartner_ID")).intValue();
-		m_PaymentRule = (String)m_mTab.getValue("PaymentRule");
-		m_C_Currency_ID = ((Integer)m_mTab.getValue("C_Currency_ID")).intValue();
-		m_DateAcct = (Timestamp)m_mTab.getValue("DateAcct");
-		if (m_mTab.getValue("C_PaymentTerm_ID") != null)
-			m_C_PaymentTerm_ID = ((Integer)m_mTab.getValue("C_PaymentTerm_ID")).intValue();
-		//  Existing Payment
-		if (m_mTab.getValue("C_Payment_ID") != null)
-		{
-			m_C_Payment_ID = ((Integer)m_mTab.getValue("C_Payment_ID")).intValue();
-			if (m_C_Payment_ID != 0)
-			{
-				m_mPayment = new MPayment(Env.getCtx(), m_C_Payment_ID, null);
-				m_mPaymentOriginal = new MPayment(Env.getCtx(), m_C_Payment_ID, null);	//	full copy
-				//  CreditCard
-				m_CCType = m_mPayment.getCreditCardType();
-				kNumberField.setText(m_mPayment.getCreditCardNumber());
-				kExpField.setText(m_mPayment.getCreditCardExp(null));
-				kApprovalField.setText(m_mPayment.getVoiceAuthCode());
-				kStatus.setText(m_mPayment.getR_PnRef());
-				kAmountField.setValue(m_mPayment.getPayAmt());
-				
-				//	if approved/paid, don't let it change
-				kTypeCombo.setEnabled(!m_mPayment.isApproved());
-				kNumberField.setReadonly(m_mPayment.isApproved());
-				kExpField.setReadonly(m_mPayment.isApproved());
-				kApprovalField.setReadonly(m_mPayment.isApproved());
-				kOnline.setEnabled(!m_mPayment.isApproved());
-				kAmountField.setReadWrite(!m_mPayment.isApproved());
-				//  Check
-				m_C_BankAccount_ID = m_mPayment.getC_BankAccount_ID();
-				sRoutingField.setText(m_mPayment.getRoutingNo());
-				sNumberField.setText(m_mPayment.getAccountNo());
-				sCheckField.setText(m_mPayment.getCheckNo());
-				sStatus.setText(m_mPayment.getR_PnRef());
-				sAmountField.setValue(m_mPayment.getPayAmt());
-				//  Transfer
-				tRoutingField.setText(m_mPayment.getRoutingNo());
-				tNumberField.setText(m_mPayment.getAccountNo());
-				tStatus.setText(m_mPayment.getR_PnRef());
-				// Cash
-				bAmountField.setValue(m_mPayment.getPayAmt());
-			}
-		}
-		if (m_mPayment == null)
-		{
-			m_mPayment = new MPayment (Env.getCtx (), 0, null);
-			m_mPayment.setAD_Org_ID(m_AD_Org_ID);
-			m_mPayment.setAmount (m_C_Currency_ID, m_Amount);
-		}
-
-		//  Existing Cashbook entry
-		m_cashLine = null;
-		m_C_CashLine_ID = 0;
-		if (m_mTab.getValue("C_CashLine_ID") != null)
-		{
-			m_C_CashLine_ID = ((Integer)m_mTab.getValue("C_CashLine_ID")).intValue();
-			if (m_C_CashLine_ID == 0)
-				m_cashLine = null;
-			else
-			{
-				m_cashLine = new MCashLine (Env.getCtx(), m_C_CashLine_ID, null);
-				m_DateAcct = m_cashLine.getStatementDate();
-				m_C_CashBook_ID = m_cashLine.getCashBook().getC_CashBook_ID();
-				bAmountField.setValue(m_cashLine.getAmount()); 
-			}
-		}
+		BigDecimal amount = controller.getPaymentAmount();
+		bAmountField.setValue(amount);
+		sAmountField.setValue(amount);
+		kAmountField.setValue(amount);
+		tAmountField.setValue(amount);
 
 		//	Accounting Date
-		bDateField.setValue(m_DateAcct);
+		bDateField.setValue(controller.getDate());
 
-		if (s_Currencies == null)
-			loadCurrencies();
-
-		//	Is the currency an EMU currency?
-		Integer C_Currency_ID = new Integer(m_C_Currency_ID);
-		if (s_Currencies.containsKey(C_Currency_ID))
+		if(controller.isEMUCurrency())
 		{
-			Enumeration<Integer> en = s_Currencies.keys();
+
+			Enumeration<Integer> en = controller.getCurrencies().keys();
 			while (en.hasMoreElements())
 			{
 				Object key = en.nextElement();
-				bCurrencyCombo.addItem(s_Currencies.get(key));
-				sCurrencyCombo.addItem(s_Currencies.get(key));
+				bCurrencyCombo.addItem(controller.getCurrencies().get(key));
+				sCurrencyCombo.addItem(controller.getCurrencies().get(key));
 			}
 			sCurrencyCombo.addActionListener(this);
-			sCurrencyCombo.setSelectedKeyNamePair(s_Currencies.get(C_Currency_ID));
+			sCurrencyCombo.setSelectedKeyNamePair(controller.getCurrentCurrency());
 			bCurrencyCombo.addActionListener(this);
-			bCurrencyCombo.setSelectedKeyNamePair(s_Currencies.get(C_Currency_ID));
+			bCurrencyCombo.setSelectedKeyNamePair(controller.getCurrentCurrency());
+
 		}
 		else	//	No EMU Currency
 		{
@@ -680,184 +524,82 @@ public class WPayment extends Window
 		/**
 		 *	Payment Combo
 		 */
-		if (m_PaymentRule == null)
-			m_PaymentRule = "";
-		ValueNamePair vp = null;
-		HashMap<String,String> values = button.getValues();
-		Object[] a = values.keySet().toArray();
-		for (int i = 0; i < a.length; i++)
+		for (ValueNamePair paymentRule : controller.getPaymentRules())
 		{			
-			String PaymentRule = (String)a[i];		//	used for Panel selection
-			if (X_C_Order.PAYMENTRULE_DirectDebit.equals(PaymentRule)			//	SO
-				&& !m_isSOTrx)
-				continue;
-			else if (X_C_Order.PAYMENTRULE_DirectDeposit.equals(PaymentRule)	//	PO 
-				&& m_isSOTrx)
-				continue;
-                                                
-			ValueNamePair pp = new ValueNamePair(PaymentRule, (String)values.get(a[i]));
-			paymentCombo.addItem(pp);
-			if (PaymentRule.toString().equals(m_PaymentRule))	//	to select
-				vp = pp;
+			paymentCombo.addItem(paymentRule);
 		}
 
 		//	Set PaymentRule
 		paymentCombo.addActionListener(this);
-		if (vp != null) {
-			paymentCombo.setSelectedValueNamePair(vp);
-			onPaymentComboSelection();
+		if (controller.getSelectedPaymentRule() != null) {
+			paymentCombo.setSelectedValueNamePair(controller.getSelectedPaymentRule());
 		}
+		else
+		{
+			paymentCombo.setSelectedIndex(0);  // pick the first by default
+		}
+		onPaymentComboSelection();  // Sets the window size based on the selection
 
 		/**
 		 * 	Load Payment Terms
 		 */
-		String SQL = MRole.getDefault().addAccessSQL(
-			"SELECT C_PaymentTerm_ID, Name FROM C_PaymentTerm WHERE IsActive='Y' ORDER BY Name",
-			"C_PaymentTerm", MRole.SQL_NOTQUALIFIED, MRole.SQL_RO);
-		KeyNamePair kp = null;
-		try
-		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int key = rs.getInt(1);
-				String name = rs.getString(2);
-				KeyNamePair pp = new KeyNamePair(key, name);
-				pTermCombo.addItem(pp);
-				if (key == m_C_PaymentTerm_ID)
-					kp = pp;
-			}
-			rs.close();
-			pstmt.close();
-		}
-		catch (SQLException ept)
-		{
-			log.log(Level.SEVERE, SQL, ept);
+		for (KeyNamePair paymentTerm : controller.getPaymentTerms())
+		{			
+				pTermCombo.addItem(paymentTerm);
 		}
 		//	Set Selection
-		if (kp != null)
-			pTermCombo.setSelectedKeyNamePair(kp);
+		if (controller.getSelectedPaymentTerm() != null)
+			pTermCombo.setSelectedKeyNamePair(controller.getSelectedPaymentTerm());
 
 		/**
-		 * 	Load Accounts
+		 * 	Load BP Accounts
 		 */
-		SQL = "SELECT a.C_BP_BankAccount_ID, NVL(b.Name, ' ')||'_'||NVL(a.AccountNo, ' ') AS Acct "
-			+ "FROM C_BP_BankAccount a"
-			+ " LEFT OUTER JOIN C_Bank b ON (a.C_Bank_ID=b.C_Bank_ID) "
-			+ "WHERE a.C_BPartner_ID=?"
-			+ "AND a.IsActive='Y' AND a.IsACH='Y'";
-		try
-		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			pstmt.setInt(1, m_C_BPartner_ID);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int key = rs.getInt(1);
-				String name = rs.getString(2);
-				KeyNamePair pp = new KeyNamePair(key, name);
-				tAccountCombo.addItem(pp);
-			}
-			rs.close();
-			pstmt.close();
-		}
-		catch (SQLException eac)
-		{
-			log.log(Level.SEVERE, SQL, eac);
+		for (KeyNamePair account : controller.getBPAccounts())
+		{		
+			tAccountCombo.addItem(account);
 		}
 
 		/**
 		 *	Load Credit Cards
 		 */
-		ValueNamePair[] ccs = m_mPayment.getCreditCards();
-		vp = null;
-		for (int i = 0; i < ccs.length; i++)
+		for (ValueNamePair card : controller.getCreditCards())
 		{
-			kTypeCombo.addItem(ccs[i]);
-			if (ccs[i].getValue().equals(m_CCType))
-				vp = ccs[i];
+			
+			kTypeCombo.addItem(card);
 		}
 		//	Set Selection
-		if (vp != null)
-			kTypeCombo.setSelectedValueNamePair(vp);
+		if (controller.getSelecteCreditCard() != null)
+			kTypeCombo.setSelectedValueNamePair(controller.getSelecteCreditCard());
 
 		/**
 		 *  Load Bank Accounts
 		 */
-		SQL = MRole.getDefault().addAccessSQL(
-			"SELECT C_BankAccount_ID, Name || ' ' || AccountNo, IsDefault "
-			+ "FROM C_BankAccount ba"
-			+ " INNER JOIN C_Bank b ON (ba.C_Bank_ID=b.C_Bank_ID) "
-			+ "WHERE b.IsActive='Y'",
-			"ba", MRole.SQL_FULLYQUALIFIED, MRole.SQL_RO);
-		kp = null;
-		try
+		for (KeyNamePair account : controller.getBankAccounts())
 		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int key = rs.getInt(1);
-				String name = rs.getString(2);
-				KeyNamePair pp = new KeyNamePair(key, name);
-				sBankAccountCombo.addItem(pp);
-				bBankAccountCombo.addItem(pp);
-				if (key == m_C_BankAccount_ID)
-					kp = pp;
-				if (kp == null && rs.getString(3).equals("Y"))    //  Default
-					kp = pp;
-			}
-			rs.close();
-			pstmt.close();
-		}
-		catch (SQLException ept)
-		{
-			log.log(Level.SEVERE, SQL, ept);
+			sBankAccountCombo.addItem(account);
 		}
 		//	Set Selection
-		if (kp != null)
+		if (controller.getSelectedBankAccount() != null)
 		{
-			sBankAccountCombo.setSelectedKeyNamePair(kp);
-			bBankAccountCombo.setSelectedKeyNamePair(kp);
+			sBankAccountCombo.setSelectedKeyNamePair(controller.getSelectedBankAccount());
 		}
 
 
 		/**
 		 *  Load Cash Books
 		 */
-		SQL = MRole.getDefault().addAccessSQL(
-			"SELECT C_CashBook_ID, Name, AD_Org_ID FROM C_CashBook WHERE IsActive='Y'",
-			"C_CashBook", MRole.SQL_NOTQUALIFIED, MRole.SQL_RO);
-		kp = null;
-		try
+		for (KeyNamePair cashBook : controller.getCashBooks())
 		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int key = rs.getInt(1);
-				String name = rs.getString(2);
-				KeyNamePair pp = new KeyNamePair(key, name);
-				bCashBookCombo.addItem(pp);
-				if (key == m_C_CashBook_ID)
-					kp = pp;
-				if (kp == null && key == m_AD_Org_ID)       //  Default Org
-					kp = pp;
-			}
-			rs.close();
-			pstmt.close();
+			
+			bCashBookCombo.addItem(cashBook);
+			
 		}
-		catch (SQLException epc)
+		
+		if (controller.getSelectedCashBook() != null)
 		{
-			log.log(Level.SEVERE, SQL, epc);
-		}
-		//	Set Selection
-		if (kp != null)
-		{
-			bCashBookCombo.setSelectedKeyNamePair(kp);
-			if (m_C_CashBook_ID == 0)
-				m_C_CashBook_ID = kp.getKey();  //  set to default to avoid 'cashbook changed' message
+			
+			bCashBookCombo.setSelectedKeyNamePair(controller.getSelectedCashBook());
+			
 		}
 
 		//
@@ -874,33 +616,6 @@ public class WPayment extends Window
 	}	//	isInitOK
 
 
-	/**
-	 *	Fill s_Currencies with EMU currencies
-	 */
-	private void loadCurrencies()
-	{
-		s_Currencies = new Hashtable<Integer,KeyNamePair>(12);	//	Currenly only 10+1
-		String SQL = "SELECT C_Currency_ID, ISO_Code FROM C_Currency "
-			+ "WHERE (IsEMUMember='Y' AND EMUEntryDate<SysDate) OR IsEuro='Y' "
-			+ "ORDER BY 2";
-		try
-		{
-			PreparedStatement pstmt = DB.prepareStatement(SQL, null);
-			ResultSet rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				int id = rs.getInt(1);
-				String name = rs.getString(2);
-				s_Currencies.put(new Integer(id), new KeyNamePair(id, name));
-			}
-			rs.close();
-			pstmt.close();
-		}
-		catch (SQLException e)
-		{
-			log.log(Level.SEVERE, SQL, e);
-		}
-	}	//	loadCurrencies
 
 
 	/**************************************************************************
@@ -918,10 +633,13 @@ public class WPayment extends Window
 		//	Finish
 		if (e.getTarget().getId().equals(ConfirmPanel.A_OK) || code == KEYBOARD_KEY_RETURN)
 		{
-			if (checkMandatory())
+			if (controller.isOnlyChangePaymentRule() 
+				|| FDialog.ask(windowNo, this, PaymentFormController.MSG_PaymentCreateConfirmation))
 			{
-				saveChanges (); // cannot recover
-				dispose ();
+				if (saveChanges ())
+				{
+					dispose ();
+				}
 			}
 		}
 		else if (e.getTarget().getId().equals(ConfirmPanel.A_CANCEL) || e.getName().equals(Events.ON_CANCEL))
@@ -937,17 +655,13 @@ public class WPayment extends Window
 		else if (e.getTarget() == sCurrencyCombo)
 		{
 			KeyNamePair pp = sCurrencyCombo.getSelectedItem().toKeyNamePair();
-			BigDecimal amt = MConversionRate.convert(Env.getCtx(),
-				m_Amount, m_C_Currency_ID, pp.getKey(), m_AD_Client_ID, m_AD_Org_ID);
-			sAmountField.setValue(amt);
+			sAmountField.setValue(controller.getConvertedAmount(pp.getKey()));
 		}
 		//	Cash Currency change
 		else if (e.getTarget() == bCurrencyCombo)
 		{
 			KeyNamePair pp = bCurrencyCombo.getSelectedItem().toKeyNamePair();
-			BigDecimal amt = MConversionRate.convert(Env.getCtx(),
-				m_Amount, m_C_Currency_ID, pp.getKey(), m_AD_Client_ID, m_AD_Org_ID);
-			bAmountField.setValue(amt);
+			bAmountField.setValue(controller.getConvertedAmount(pp.getKey()));
 		}
 
 		//  Online
@@ -995,10 +709,9 @@ public class WPayment extends Window
 	}
 
 	private void updateUI() {
-		if (m_mPayment.isApproved())
+		if (controller.getErrorMsg().isEmpty())
 			dispose();
 	}
-
 
 	private void onPaymentComboSelection() {
 		//	get selection
@@ -1006,22 +719,11 @@ public class WPayment extends Window
 		ValueNamePair pp = selectedItem != null ? selectedItem.toValueNamePair() : null;
 		if (pp != null)
 		{
-			String s = pp.getValue().toLowerCase();
-			if (X_C_Order.PAYMENTRULE_DirectDebit.equalsIgnoreCase(s))
-				s = X_C_Order.PAYMENTRULE_DirectDeposit.toLowerCase();
-			s += "Panel";	
-			show(s);	//	switch to panel
-			//Bojana&Daniel
-			//If Invoice is Vendor invoice then Cash has to be created by negative amount
-			int C_Invoice_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Invoice_ID");
-			MInvoice invoice_tmp = new MInvoice (Env.getCtx(), C_Invoice_ID, null);
-			if (! invoice_tmp.isSOTrx())
-			{
-				bAmountField.setValue(m_Amount.negate());
-			}else {
-				bAmountField.setValue(m_Amount);
-			}
-			invoice_tmp = null;
+			bAmountField.setValue(controller.getPaymentAmount());
+			sAmountField.setValue(controller.getPaymentAmount());
+			kAmountField.setValue(controller.getPaymentAmount());
+			show(controller.whichPanel(pp));	//	switch to panel
+			controller.checkMandatory();
 			
 		}
 	}
@@ -1039,6 +741,31 @@ public class WPayment extends Window
 				p.setVisible(false);
 			}
 		}
+		if (controller.isOnlyChangePaymentRule() || s.equals("pPanel"))
+		{
+			this.setWidth("420px");
+			this.setHeight("150px");
+		}
+		else if (s.equals("bPanel"))
+		{
+			this.setWidth("420px");
+			this.setHeight("200px");
+		}
+		else if (s.equals("sPanel"))
+		{
+			this.setWidth("470px");
+			this.setHeight("300px");
+		}
+		else if (s.equals("tPanel"))
+		{
+			this.setWidth("470px");
+			this.setHeight("215px");
+		}
+		else if (s.equals("kPanel"))
+		{
+			this.setWidth("500px");
+			this.setHeight("300px");
+		}
 	}
 
 	/**************************************************************************
@@ -1046,525 +773,25 @@ public class WPayment extends Window
 	 *	@return true, if Window can exit
 	 */
 	private boolean saveChanges() {
-
-		// BF [ 1920179 ] perform the save in a trx's context.
-		final boolean[] success = new boolean[] { false };
-		final TrxRunnable r = new TrxRunnable() {
-
-			public void run(String trxName) {
-				success[0] = saveChangesInTrx(trxName);
-			}
-		};
-		try {
-			Trx.run(r);
-		} catch (Throwable e) {
-			success[0] = false;
-			FDialog.error(m_WindowNo, this, "PaymentError", e.getLocalizedMessage());
-		}
-		if (m_cashLine != null)
-			m_cashLine.set_TrxName(null);
-		if (m_mPayment != null)
-			m_mPayment.set_TrxName(null);
-		if (m_mPaymentOriginal != null)
-			m_mPayment.set_TrxName(null);
-		return success[0];
-	} // saveChanges
-	
-	/**************************************************************************
-	 *	Save Changes
-	 *	@return true, if eindow can exit
-	 */
-	private boolean saveChangesInTrx(final String trxName)
-	{
-		// set trxname for class objects
-		if (m_cashLine != null)
-			m_cashLine.set_TrxName(trxName);
-		if (m_mPayment != null)
-			m_mPayment.set_TrxName(trxName);
-		if (m_mPaymentOriginal != null)
-			m_mPaymentOriginal.set_TrxName(trxName);
-	
-		ValueNamePair vp = paymentCombo.getSelectedItem().toValueNamePair();
-		String newPaymentRule = vp.getValue();
-		log.info("New Rule: " + newPaymentRule);
-
-		//  only Payment Rule
-		if (m_onlyRule)
-		{
-			if (!newPaymentRule.equals(m_PaymentRule))
-				m_mTab.setValue("PaymentRule", newPaymentRule);
-			return true;
-		}
-
-		//	New Values
-		Timestamp newDateAcct = m_DateAcct;
-		int newC_PaymentTerm_ID = m_C_PaymentTerm_ID;
-		int newC_CashLine_ID = m_C_CashLine_ID;
-		int newC_CashBook_ID = m_C_CashBook_ID;
-		String newCCType = m_CCType;
-		int newC_BankAccount_ID = 0;
-		String payTypes = m_Cash_As_Payment ? "KTSDB" : "KTSD";
 		
-		//	B (Cash)		(Currency)
-		if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_Cash))
+		if (!controller.saveChanges())
 		{
-			if (m_Cash_As_Payment){
-				// get bank account
-				ListItem selected = bBankAccountCombo.getSelectedItem(); 
-				KeyNamePair kp = selected != null ? selected.toKeyNamePair() : null;
-				if (kp != null)
-					newC_BankAccount_ID = kp.getKey();
-			} else {
-				// get cash book
-				ListItem selected = bCashBookCombo.getSelectedItem(); 
-				KeyNamePair kp = selected != null ? selected.toKeyNamePair() : null;
-				if (kp != null)
-					newC_CashBook_ID = kp.getKey();	
-			}
-			
-			newDateAcct = (Timestamp)bDateField.getValue();
-			
-			// Get changes to cash amount
-			m_mPayment.setAmount(m_C_Currency_ID, (BigDecimal) bAmountField.getValue());
-			m_Amount = (BigDecimal) bAmountField.getValue();			
-		}
-
-		//	K (CreditCard)  Type, Number, Exp, Approval
-		else if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_CreditCard))
-		{
-			ListItem selected = kTypeCombo.getSelectedItem(); 
-			vp = selected != null ? selected.toValueNamePair() : null;
-			if (vp != null)
-				newCCType = vp.getValue();
-		}
-
-		//	T (Transfer)	BPartner_Bank
-		else if (newPaymentRule.equals(MOrder.PAYMENTRULE_DirectDeposit) 
-			|| newPaymentRule.equals(MOrder.PAYMENTRULE_DirectDebit) )
-		{
-			tAccountCombo.getSelectedItem();
-		}
-
-		//	P (PaymentTerm)	PaymentTerm
-		else if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_OnCredit))
-		{
-			ListItem selected = pTermCombo.getSelectedItem(); 
-			KeyNamePair kp = selected != null ? selected.toKeyNamePair() : null;
-			if (kp != null)
-				newC_PaymentTerm_ID = kp.getKey();
-		}
-
-		//	S (Check)		(Currency) CheckNo, Routing
-		else if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_Check))
-		{
-			ListItem selected = sBankAccountCombo.getSelectedItem(); 
-			KeyNamePair kp = selected != null ? selected.toKeyNamePair() : null;
-			if (kp != null)
-				newC_BankAccount_ID = kp.getKey();
-		}
-		else
+			FDialog.error(windowNo, this, "PaymentError", controller.getErrorMsg());			
 			return false;
-
-		/***********************
-		 *  Changed PaymentRule
-		 */
-		if (!newPaymentRule.equals(m_PaymentRule))
-		{
-			log.fine("Changed PaymentRule: " + m_PaymentRule + " -> " + newPaymentRule);
-			//  We had a CashBook Entry
-			if (m_PaymentRule.equals(X_C_Order.PAYMENTRULE_Cash))
-			{
-				log.fine("Old Cash - " + m_cashLine);
-				if (m_cashLine != null)
-				{
-					MCashLine cl = m_cashLine.createReversal();
-					if (cl.save())
-						log.config( "CashCancelled");
-					else
-						FDialog.error(m_WindowNo, this, "PaymentError", "CashNotCancelled");
-				}
-				newC_CashLine_ID = 0;      //  reset
-			}
-			//  We had a change in Payment type (e.g. Check to CC)
-			else if (payTypes.indexOf(m_PaymentRule) != -1 && payTypes.indexOf(newPaymentRule) != -1 && m_mPaymentOriginal != null)
-			{
-				log.fine("Old Payment(1) - " + m_mPaymentOriginal);
-				m_mPaymentOriginal.setDocAction(DocAction.ACTION_Reverse_Correct);
-				boolean ok = m_mPaymentOriginal.processIt(DocAction.ACTION_Reverse_Correct);
-				m_mPaymentOriginal.saveEx();
-				if (ok)
-					log.info( "Payment Canecelled - " + m_mPaymentOriginal);
-				else
-					FDialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCancelled " + m_mPaymentOriginal.getDocumentNo());
-				m_mPayment.resetNew();
-			}
-			//	We had a Payment and something else (e.g. Check to Cash)
-			else if (payTypes.indexOf(m_PaymentRule) != -1 && payTypes.indexOf(newPaymentRule) == -1)
-			{
-				log.fine("Old Payment(2) - " + m_mPaymentOriginal);
-				if (m_mPaymentOriginal != null)
-				{
-					m_mPaymentOriginal.setDocAction(DocAction.ACTION_Reverse_Correct);
-					boolean ok = m_mPaymentOriginal.processIt(DocAction.ACTION_Reverse_Correct);
-					m_mPaymentOriginal.saveEx();
-					if (ok)        //  Cancel Payment
-					{
-						log.fine("PaymentCancelled " + m_mPayment.getDocumentNo ());
-						m_mTab.getTableModel().dataSave(true);
-						m_mPayment.resetNew();
-						m_mPayment.setAmount(m_C_Currency_ID, m_Amount);
-					}
-					else
-						FDialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCancelled " + m_mPayment.getDocumentNo());
-				}
-			}
 		}
-
-		//  Get Order and optionally Invoice
-		int C_Order_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Order_ID");
-		int C_Invoice_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Invoice_ID");
-		if (C_Invoice_ID == 0 && m_DocStatus.equals("CO"))
-			C_Invoice_ID = getInvoiceID (C_Order_ID);
-
-		//  Amount sign negative, if ARC (Credit Memo) or API (AP Invoice)
-		boolean negateAmt = false;
-		MInvoice invoice = null;
-		if (C_Invoice_ID != 0)
-		{
-			invoice = new MInvoice (Env.getCtx(), C_Invoice_ID, null);
-			negateAmt = invoice.isCreditMemo();
-		}
-		MOrder order = null;
-		if (invoice == null && C_Order_ID != 0)
-			order = new MOrder (Env.getCtx(), C_Order_ID, null);
 		
-		BigDecimal payAmount = m_Amount;
+		// Check the message in case
+		if (controller.getErrorMsg() != null && !controller.getErrorMsg().isEmpty())
+		{
+			FDialog.error(windowNo, this, PaymentFormController.MSG_PaymentError, controller.getErrorMsg());
+		}
 		
-
-		if (negateAmt)
-			payAmount = m_Amount.negate();
-		// Info
-		log.config("C_Order_ID=" + C_Order_ID + ", C_Invoice_ID=" + C_Invoice_ID + ", NegateAmt=" + negateAmt);
-
-		/***********************
-		 *  CashBook
-		 */
-		if (newPaymentRule.equals(X_C_Order.PAYMENTRULE_Cash) && !m_Cash_As_Payment)
+		if (controller.getPaymentDocNumber() != null && !controller.getPaymentDocNumber().isEmpty())
 		{
-			log.fine("Cash");
-			
-			if (C_Invoice_ID == 0 && order == null)
-			{
-				log.config("No Invoice!");
-				FDialog.error(m_WindowNo, this, "PaymentError", "CashNotCreated");
-			}
-			else
-			{
-				payAmount = (BigDecimal) bAmountField.getValue();
-				//  Changed Amount
-				if (m_cashLine != null
-					&& payAmount.compareTo(m_cashLine.getAmount()) != 0)
-				{
-					log.config("Changed CashBook Amount");
-					m_cashLine.setAmount((BigDecimal) bAmountField.getValue());
-					m_cashLine.saveEx();
-				}
-				//	Different Date/CashBook
-				if (m_cashLine != null
-					&& (newC_CashBook_ID != m_C_CashBook_ID 
-						|| !TimeUtil.isSameDay(m_cashLine.getStatementDate(), newDateAcct)))
-				{
-					log.config("Changed CashBook/Date: " + m_C_CashBook_ID + "->" + newC_CashBook_ID);
-					MCashLine reverse = m_cashLine.createReversal();
-					reverse.saveEx();
-					m_cashLine = null;
-				}
-				
-				//	Create new
-				if (m_cashLine == null)
-				{
-					log.config("New CashBook");
-					int C_Currency_ID = 0;
-					if (invoice != null)
-						C_Currency_ID = invoice.getC_Currency_ID();
-					if (C_Currency_ID == 0 && order != null)
-						C_Currency_ID = order.getC_Currency_ID();
-					MCash cash = null;
-					if (newC_CashBook_ID != 0)
-						cash = MCash.get (Env.getCtx(), newC_CashBook_ID, newDateAcct, null);
-					else	//	Default
-						cash = MCash.get (Env.getCtx(), m_AD_Org_ID, newDateAcct, C_Currency_ID, null);
-					if (cash == null || cash.get_ID() == 0)
-						FDialog.error(m_WindowNo, this, "PaymentError", CLogger.retrieveErrorString("CashNotCreated"));
-					else
-					{
-						MCashLine cl = new MCashLine (cash);
-						// cl.setAmount(new BigDecimal(bAmountField.getText()));
-						//ADialog.info(m_WindowNo, this, "m_cashLine - New Cashbook", "Amount: "+cl.getAmount());
-						if (invoice != null)
-							cl.setInvoice(invoice);	// overrides amount
-						if (order != null)
-						{
-							cl.setOrder(order, null); // overrides amount
-							m_needSave = true;
-						}
-						cl.setAmount((BigDecimal)bAmountField.getValue());
-						cl.saveEx();
-						log.config("CashCreated");						
-						if (invoice == null && C_Invoice_ID != 0)
-						{
-							invoice = new MInvoice (Env.getCtx(), C_Invoice_ID, null);	
-						}
-						if (invoice != null) {
-							invoice.setC_CashLine_ID(cl.getC_CashLine_ID());
-							invoice.saveEx(trxName);
-						}	
-						if (order == null && C_Order_ID != 0)
-						{
-							order = new MOrder (Env.getCtx(), C_Order_ID, null);
-						}
-						if (order != null) {
-							order.setC_CashLine_ID(cl.getC_CashLine_ID());
-							order.saveEx(trxName);
-						}
-						log.config("Update Order & Invoice with CashLine");						
-					}
-				}
-			}	//	have invoice
-		}
-		/***********************
-		 *  Payments
-		 */
-		if (("KS".indexOf(newPaymentRule) != -1) || 
-				(newPaymentRule.equals(MOrder.PAYMENTRULE_Cash) && m_Cash_As_Payment))
-		{
-			log.fine("Payment - " + newPaymentRule);
-			//  Set Amount
-			m_mPayment.setAmount(m_C_Currency_ID, payAmount);
-			if (newPaymentRule.equals(MOrder.PAYMENTRULE_CreditCard))
-			{
-				m_mPayment.setCreditCard(MPayment.TRXTYPE_Sales, newCCType,
-					kNumberField.getText(), "", kExpField.getText());
-				// Get changes to credit card amount
-				m_mPayment.setAmount(m_C_Currency_ID, (BigDecimal) kAmountField.getValue());
-				m_mPayment.setPaymentProcessor();
-			}
-			else if (newPaymentRule.equals(MOrder.PAYMENTRULE_DirectDeposit)
-				|| newPaymentRule.equals(MOrder.PAYMENTRULE_DirectDebit))
-			{
-				m_mPayment.setBankACH(newC_BankAccount_ID, m_isSOTrx, newPaymentRule, 
-					tRoutingField.getText(), tNumberField.getText());
-				m_mPayment.setAmount(m_C_Currency_ID, payAmount);
-			}
-			else if (newPaymentRule.equals(MOrder.PAYMENTRULE_Check))
-			{
-				m_mPayment.setBankCheck(newC_BankAccount_ID, m_isSOTrx, sRoutingField.getText(),
-					sNumberField.getText(), sCheckField.getText());
-				// Get changes to check amount
-				m_mPayment.setAmount(m_C_Currency_ID, (BigDecimal) sAmountField.getValue());
-			}
-			else if (newPaymentRule.equals(MOrder.PAYMENTRULE_Cash))
-			{
-				// Get changes to cash amount
-				m_mPayment.setTenderType(MPayment.TENDERTYPE_Cash);
-				m_mPayment.setBankCash(newC_BankAccount_ID, m_isSOTrx, MPayment.TENDERTYPE_Cash);
-				m_mPayment.setAmount(m_C_Currency_ID, payAmount);
-			}
-			m_mPayment.setC_BPartner_ID(m_C_BPartner_ID);
-			m_mPayment.setC_Invoice_ID(C_Invoice_ID);
-			if (order != null)
-			{
-				m_mPayment.setC_Order_ID(C_Order_ID);
-				m_needSave = true;
-			}
-			m_mPayment.setDateTrx(m_DateAcct);
-			m_mPayment.setDateAcct(m_DateAcct);
-			m_mPayment.saveEx();
-			
-			//  Save/Post
-			if (m_mPayment.get_ID() > 0 && MPayment.DOCSTATUS_Drafted.equals(m_mPayment.getDocStatus()))
-			{
-				boolean ok = m_mPayment.processIt(DocAction.ACTION_Complete);
-				m_mPayment.saveEx();
-				if (ok)
-					FDialog.info(m_WindowNo, this, "PaymentCreated", m_mPayment.getDocumentNo());
-				else
-					FDialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCreated");
-			}
-			else
-				log.fine("NotDraft " + m_mPayment);
-		}
-
-
-		/**********************
-		 *	Save Values to mTab
-		 */
-		log.config("Saving changes");
-		//
-		if (!newPaymentRule.equals(m_PaymentRule))
-			m_mTab.setValue("PaymentRule", newPaymentRule);
-		//
-		if (!newDateAcct.equals(m_DateAcct))
-			m_mTab.setValue("DateAcct", newDateAcct);
-		//
-		if (newC_PaymentTerm_ID != m_C_PaymentTerm_ID)
-			m_mTab.setValue("C_PaymentTerm_ID", new Integer(newC_PaymentTerm_ID));
-		//	Set Payment
-		if (m_mPayment.getC_Payment_ID() != m_C_Payment_ID)
-		{
-			if (m_mPayment.getC_Payment_ID() == 0)
-				m_mTab.setValue("C_Payment_ID", null);
-			else
-				m_mTab.setValue("C_Payment_ID", new Integer(m_mPayment.getC_Payment_ID()));
-		}
-		//	Set Cash
-		if (newC_CashLine_ID != m_C_CashLine_ID)
-		{
-			if (newC_CashLine_ID == 0)
-				m_mTab.setValue("C_CashLine_ID", null);
-			else
-				m_mTab.setValue("C_CashLine_ID", new Integer(newC_CashLine_ID));
+			FDialog.info(windowNo, this, PaymentFormController.MSG_PaymentCreated, controller.getPaymentDocNumber());
 		}
 		return true;
-	}	//	saveChanges
-
-	/**
-	 *  Check Mandatory
-	 *  @return true if all mandatory items are OK
-	 */
-	private boolean checkMandatory()
-	{
-		log.config( "VPayment.checkMandatory");
-
-		ValueNamePair vp = paymentCombo.getSelectedItem().toValueNamePair();
-		String PaymentRule = vp.getValue();
-		//  only Payment Rule
-		if (m_onlyRule)
-			return true;
-
-		//
-		int C_BankAccount_ID = 0;
-
-		/***********************
-		 *	Mandatory Data Check
-		 */
-		boolean dataOK = true;
-		//	B (Cash)		(Currency)
-		if (PaymentRule.equals(MOrder.PAYMENTRULE_Cash))
-		{
-			if (m_Cash_As_Payment)
-			{
-				ListItem selected = bBankAccountCombo.getSelectedItem(); 
-				KeyNamePair kp = selected != null ? selected.toKeyNamePair() : null;
-				if (kp != null)
-					C_BankAccount_ID = kp.getKey();
-			}
-		}
-
-		//	K (CreditCard)  Type, Number, Exp, Approval
-		else if (PaymentRule.equals(MOrder.PAYMENTRULE_CreditCard))
-		{
-			// Validation of the credit card number is moved to the payment processor.
-			// Different payment processors can have different validation rules.
-		}
-
-		//	T (Transfer)	BPartner_Bank
-		else if (PaymentRule.equals(X_C_Order.PAYMENTRULE_DirectDeposit)
-			|| PaymentRule.equals(X_C_Order.PAYMENTRULE_DirectDebit))
-		{
-			ListItem selected =  tAccountCombo.getSelectedItem();
-			KeyNamePair bpba = selected != null ? selected.toKeyNamePair() : null;
-			if (bpba == null)
-
-			{
-				FDialog.error(m_WindowNo, this, "PaymentBPBankNotFound");
-				dataOK = false;
-			}
-		}	//	Direct
-
-		//	P (PaymentTerm)	PaymentTerm
-		else if (PaymentRule.equals(X_C_Order.PAYMENTRULE_OnCredit))
-		{
-			// ok
-		}
-
-		//	S (Check)		(Currency) CheckNo, Routing
-		else if (PaymentRule.equals(MOrder.PAYMENTRULE_Check))
-		{
-			ListItem selected = sBankAccountCombo.getSelectedItem(); 
-			KeyNamePair kp = selected != null ? selected.toKeyNamePair() : null;
-			if (kp != null)
-				C_BankAccount_ID = kp.getKey();
-			String error = MPaymentValidate.validateRoutingNo(sRoutingField.getText());
-			if (error.length() != 0)
-			{
-				FDialog.error(m_WindowNo, this, error);
-				dataOK = false;
-			}
-			error = MPaymentValidate.validateAccountNo(sNumberField.getText());
-			if (error.length() != 0)
-			{
-				FDialog.error(m_WindowNo, this, error);
-				dataOK = false;
-			}
-			error = MPaymentValidate.validateCheckNo(sCheckField.getText());
-			if (error.length() != 0)
-			{
-				FDialog.error(m_WindowNo, this, error);
-				dataOK = false;
-			}
-		}
-		else
-		{
-			log.log(Level.SEVERE, "Unknown PaymentRule " + PaymentRule);
-			return false;
-		}
-
-		//  find Bank Account if not qualified yet
-		if (("KTSD".indexOf(PaymentRule) != -1 || 
-				(PaymentRule.equals(MOrder.PAYMENTRULE_Cash) && m_Cash_As_Payment)) 
-					&& C_BankAccount_ID == 0)
-		{
-			// Check & Cash (Payment) must have a bank account
-			if (C_BankAccount_ID == 0 && (PaymentRule.equals(MOrder.PAYMENTRULE_Check)) || 
-					(PaymentRule.equals(MOrder.PAYMENTRULE_Cash) && m_Cash_As_Payment))
-           {
-				FDialog.error(m_WindowNo, this, "FillMandatory", bBankAccountLabel.getValue());
-				dataOK = false;
-			}
-		}
-		//
-		log.config("OK=" + dataOK);
-		return dataOK;
-	}   //  checkMandatory
-
-	/**
-	 *  Get Invoice ID for Order
-	 *  @param C_Order_ID order
-	 *  @return C_Invoice_ID or 0 if not found
-	 */
-	private static int getInvoiceID (int C_Order_ID)
-	{
-		int retValue = 0;
-		String sql = "SELECT C_Invoice_ID FROM C_Invoice WHERE C_Order_ID=? "
-			+ "ORDER BY C_Invoice_ID DESC";     //  last invoice
-		try
-		{
-			PreparedStatement pstmt = DB.prepareStatement(sql, null);
-			pstmt.setInt(1, C_Order_ID);
-			ResultSet rs = pstmt.executeQuery();
-			if (rs.next())
-				retValue = rs.getInt(1);
-			rs.close();
-			pstmt.close();
-		}
-		catch (SQLException e)
-		{
-			log.log(Level.SEVERE, sql, e);
-		}
-		return retValue;
-	}   //  getInvoiceID
-
+	} // saveChanges
 	
 	/**************************************************************************
 	 *  Process Online (sales only) - if approved - exit
@@ -1572,65 +799,18 @@ public class WPayment extends Window
 	private void processOnline()
 	{
 		log.config("");
-		if (!checkMandatory())
-			return;
-
-		boolean approved = false;
-		String info = "";
-		//
-		ValueNamePair vp = paymentCombo.getSelectedItem().toValueNamePair();
-		String PaymentRule = vp.getValue();
-
-		//  --  CreditCard
-		if (PaymentRule.equals(X_C_Order.PAYMENTRULE_CreditCard))
+		
+		if (!controller.processOnline())
 		{
-			vp = kTypeCombo.getSelectedItem().toValueNamePair();
-			String CCType = vp.getValue();
-
-			m_mPayment.setCreditCard(MPayment.TRXTYPE_Sales, CCType,
-				kNumberField.getText(), "", kExpField.getText());
-			m_mPayment.setAmount(m_C_Currency_ID, m_Amount);
-			m_mPayment.setPaymentProcessor();
-			m_mPayment.setC_BPartner_ID(m_C_BPartner_ID);
-			//
-			int C_Invoice_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Invoice_ID");
-			if (C_Invoice_ID == 0 && m_DocStatus.equals("CO"))
-			{
-				int C_Order_ID = Env.getContextAsInt(Env.getCtx(), m_WindowNo, "C_Order_ID");
-				C_Invoice_ID = getInvoiceID (C_Order_ID);
-			}
-			m_mPayment.setC_Invoice_ID(C_Invoice_ID);
-			m_mPayment.setDateTrx(m_DateAcct);
-			//  Set Amount
-			m_mPayment.setAmount(m_C_Currency_ID, m_Amount);
-			if (!m_mPayment.save()) {
-				FDialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCreated");
-			} else {
-				approved = m_mPayment.processOnline();
-				info = m_mPayment.getR_RespMsg() + " (" + m_mPayment.getR_AuthCode()
-					+ ") ID=" + m_mPayment.getR_PnRef();
-				m_mPayment.saveEx();
-
-				if (approved)
-				{
-					boolean ok = m_mPayment.processIt(DocAction.ACTION_Complete);
-					m_mPayment.saveEx();
-					if (ok)
-						FDialog.info(m_WindowNo, this, "PaymentProcessed", info + "\n" + m_mPayment.getDocumentNo());
-					else
-						FDialog.error(m_WindowNo, this, "PaymentError", "PaymentNotCreated");
-					saveChanges();
-					// dispose();
-				}
-				else
-				{
-					FDialog.error(m_WindowNo, this, "PaymentNotProcessed", info);
-				}
-			}
+			FDialog.error(windowNo, this, "PaymentError", controller.getErrorMsg());
 		}
 		else
-			FDialog.error(m_WindowNo, this, "PaymentNoProcessor");
-	}   //  online
+		{
+			String info = controller.getOnlineInfo();
+			FDialog.info(windowNo, this, "PaymentProcessed", info + "\n" + controller.getPaymentDocNumber());
+			dispose();
+		}
+	}
 
 	/**
 	 * 	Need Save record (payment with waiting order)
@@ -1641,4 +821,286 @@ public class WPayment extends Window
 		return m_needSave;
 	}	//	needSave
 	
-}	//	VPayment
+	public String getPaymentRule() {
+		return ((ValueNamePair) paymentCombo.getSelectedItem().toValueNamePair()).getValue();
+	}
+
+	public int getBankAccount(String paymentRule) {
+
+		ListItem li = null;
+		
+//		if (paymentRule.equalsIgnoreCase("B")) 
+//		{
+//
+//			li = bBankAccountCombo.getSelectedItem();
+//			
+//		}
+//		else 
+		if (paymentRule.equalsIgnoreCase("S"))
+		{
+			
+			li = sBankAccountCombo.getSelectedItem();
+			
+		}
+		
+		if (li != null)
+			return li.toKeyNamePair().getKey();
+		else
+			return 0;
+			
+	}
+	
+	public int getCashBook(String paymentRule) {
+		
+		ListItem li = null;
+		
+		if (paymentRule.equalsIgnoreCase("B")) 
+		{
+			
+			li = bCashBookCombo.getSelectedItem();
+			
+		}
+		
+		if (li != null)
+			return li.toKeyNamePair().getKey();
+		else
+			return 0;
+		
+	}
+
+	public Timestamp getDateAcct(String paymentRule) {
+		
+		// There is only one date
+		if (paymentRule.equalsIgnoreCase("B")) 
+		{
+			
+			return (Timestamp) bDateField.getValue();
+			
+		}
+		
+		return null;
+		
+	}
+
+	public BigDecimal getPaymentAmount(String paymentRule) {
+
+		BigDecimal amount = null;
+		
+		if (paymentRule.equalsIgnoreCase("B")) 
+		{
+			
+			amount = (BigDecimal) bAmountField.getValue();
+			
+		}
+		else if (paymentRule.equalsIgnoreCase("S"))
+		{
+			
+			amount = (BigDecimal) sAmountField.getValue();
+			
+		}
+		else if (paymentRule.equalsIgnoreCase("K"))
+		{
+			
+			amount = (BigDecimal) kAmountField.getValue();
+			
+		}
+		else if (paymentRule.equalsIgnoreCase("T") || paymentRule.equalsIgnoreCase("D"))
+		{
+			
+			amount = (BigDecimal) tAmountField.getValue();
+
+		}
+		
+		if (amount != null)
+			return amount;
+		else
+			return Env.ZERO;
+
+	}
+	
+	public String getCreditCardType(String paymentRule) {
+		
+		ListItem li = null;
+		
+		if (paymentRule.equalsIgnoreCase("K"))
+		{
+			li = kTypeCombo.getSelectedItem();
+		}
+
+		if (li != null)
+			return li.toValueNamePair().getValue();
+		else
+			return "";
+		
+	}
+	
+	public int getBPBankAccount(String paymentRule) {
+		
+		ListItem li = null;
+		
+		if (paymentRule.equalsIgnoreCase("T") || paymentRule.equalsIgnoreCase("D")) 
+		{
+			
+			li = tAccountCombo.getSelectedItem();
+			
+		}
+		
+		if (li != null)
+			return li.toKeyNamePair().getKey();
+		else
+			return 0;
+
+	}
+
+	public int getPaymentTerm(String paymentRule) {
+		
+		ListItem li = null;
+		
+		if (paymentRule.equalsIgnoreCase("P")) 
+		{
+			
+			li = pTermCombo.getSelectedItem();
+			
+		}
+		
+		if (li != null)
+			return li.toKeyNamePair().getKey();
+		else
+			return 0;
+
+	}
+
+	@Override
+	public String getCreditCardNumber(String paymentRule) {
+				
+		if (paymentRule.equalsIgnoreCase("K"))
+		{
+			return kNumberField.getText();
+		}
+		else
+			return "";
+
+	}
+
+
+	@Override
+	public String getCreditCardExpiry(String paymentRule) {
+	
+		if (paymentRule.equalsIgnoreCase("K"))
+		{
+			return kNumberField.getText();
+		}
+		else
+			return "";
+
+	}
+
+	@Override
+	public String getCreditCardName(String paymentRule) {
+		
+		if (paymentRule.equalsIgnoreCase("K"))
+		{
+			return kNameField.getText();
+		}
+		else
+			return "";
+	}
+
+
+	@Override
+	public String getCheckAccountNumber(String paymentRule) {
+		
+		if (paymentRule.equalsIgnoreCase("S"))
+		{
+			return sAccountNumberField.getText();
+		}
+		else
+			return "";
+		
+	}
+
+
+	@Override
+	public String getCheckRoutingNumber(String paymentRule) {
+		
+		if (paymentRule.equalsIgnoreCase("S"))
+		{
+			return sRoutingField.getText();
+		}
+		else
+			return "";
+		
+	}
+
+
+	@Override
+	public String getCheckNumber(String paymentRule) {
+		
+		if (paymentRule.equalsIgnoreCase("S"))
+		{
+			return sCheckNumberField.getText();
+		}
+		else
+			return "";
+		
+	}
+
+
+	@Override
+	public void setMandatory(String field, boolean mandatory) {
+		
+		if (field.equals(FIELD_payment))
+			paymentLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_kType))
+			kTypeLabel.setMandatory(mandatory);	
+		if (field.equals(FIELD_kNumber))
+			kNumberLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_kName))
+			kNameLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_kExp))
+			kExpLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_kApproval))
+			kApprovalLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_kAmount))
+			kAmountLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_tAccount))
+			tAccountLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_sAccountNumber))
+			sAccountNumberLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_sCheckNumber))
+			sCheckNumberLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_sRouting))
+			sRoutingLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_sCurrency))
+			sCurrencyLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_bCurrency))
+			bCurrencyLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_pTerm))
+			pTermLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_bAmount))
+			bAmountLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_sAmount))
+			sAmountLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_bDate))
+			bDateLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_sCheck))
+			sCheckNumberLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_sBankAccount))
+			sBankAccountLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_bCashBook))
+			bCashBookLabel.setMandatory(mandatory);
+		if (field.equals(FIELD_tAmount))
+			tAmountLabel.setMandatory(mandatory);
+		
+	}
+
+
+	@Override
+	public void setError(String field, boolean error) {
+		
+		setMandatory(field, error);
+		
+	}
+
+
+}	//	WPayment

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WPayment.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WPayment.java
@@ -745,7 +745,7 @@ public class WPayment extends Window
 		SQL = "SELECT a.C_BP_BankAccount_ID, NVL(b.Name, ' ')||'_'||NVL(a.AccountNo, ' ') AS Acct "
 			+ "FROM C_BP_BankAccount a"
 			+ " LEFT OUTER JOIN C_Bank b ON (a.C_Bank_ID=b.C_Bank_ID) "
-			+ "WHERE C_BPartner_ID=?"
+			+ "WHERE a.C_BPartner_ID=?"
 			+ "AND a.IsActive='Y' AND a.IsACH='Y'";
 		try
 		{


### PR DESCRIPTION
Fixes #2347.

See closed pull request #2348 for comments.

This was originally a one character change but there is so much duplicated code between VPayment and WPayment that it was a good opportunity to consolidate it.  I've stripped all but the bare essentials of the UI elements from both and created a common controller to manage the data.  Its pretty rough and doesn't behave as well as other dialogs but it is much better than what was there.

Along the way, I removed the connection to any previous payments.  Each time the payment dialog is run, it will create a new payment.  This allows a mix of cash and credit card, for example.   The amount shown in the dialog will be the outstanding amount.  When this hits zero, no further payment can be taken, but the user can enter another number.   If there is an invoice and it is paid, then no payment will be allowed.

I also changed the cash to use the bank.  I had to make some changes to MBankStatement and MPayment to make this work.  Cash payments will automatically be added to the correct Cash Closing document.  This is a great improvement as the payments are posted and the accounting is correct.

Online processes should work if these are set up.  I don't have a way of testing these but its the same process as the payment document.

Also error messages - I tried to use the special characters for the spanish but you'll have to check my (or google's) translations.  I added some error logging in MPayment as the log error stack is hard to work with.

I've added documentation on the dialog here:  https://adempiere.gitbook.io/docs/introduction/getting-started/dialogs-and-forms/payment-dialog.
