### PR TITLE
Fixed error with UUID for Migration from model

### DIFF
--- a/base/src/org/compiere/model/MSession.java
+++ b/base/src/org/compiere/model/MSession.java
@@ -327,29 +327,6 @@ public class MSession extends X_AD_Session
 	 * @param event
 	 */
 	public void logMigration(PO po, POInfo pinfo, String event) {
-		
-//		String [] exceptionTables = new String[] {
-//				"AD_ACCESSLOG",			"AD_ALERTPROCESSORLOG",		"AD_CHANGELOG",
-//				"AD_ISSUE",				"AD_LDAPPROCESSORLOG",		"AD_PACKAGE_IMP",
-//				"AD_PACKAGE_IMP_BACKUP","AD_PACKAGE_IMP_DETAIL",	"AD_PACKAGE_IMP_INST",
-//				"AD_PACKAGE_IMP_PROC",	"AD_PINSTANCE",				"AD_PINSTANCE_LOG",
-//				"AD_PINSTANCE_PARA",	"AD_REPLICATION_LOG",		"AD_SCHEDULERLOG",
-//				"AD_SESSION",			"AD_WF_ACTIVITY",			"AD_WF_EVENTAUDIT",
-//				"AD_WF_PROCESS",		"AD_WORKFLOWPROCESSORLOG",	"CM_WEBACCESSLOG",
-//				"C_ACCTPROCESSORLOG",	"K_INDEXLOG",				"R_REQUESTPROCESSORLOG",
-//				"T_AGING",				"T_ALTER_COLUMN",			"T_DISTRIBUTIONRUNDETAIL",
-//				"T_INVENTORYVALUE",		"T_INVOICEGL",				"T_REPLENISH",
-//				"T_REPORT",				"T_REPORTSTATEMENT",		"T_SELECTION",
-//				"T_SELECTION2",			"T_SPOOL",					"T_TRANSACTION",
-//				"T_TRIALBALANCE",		"AD_PROCESS_ACCESS",		"AD_WINDOW_ACCESS",
-//				"AD_WORKFLOW_ACCESS",	"AD_FORM_ACCESS",			
-//				"AD_MIGRATION",			"AD_MIGRATIONSTEP",			"AD_MIGRATIONDATA"
-//				//
-//			};
-//		
-//		List<String> list = Arrays.asList(exceptionTables);
-//		if ( list.contains(pinfo.getTableName().toUpperCase()) )
-//				return;
 		//	Valid from Meta Data
 		//	FR [ 390 ]
 		if(pinfo.isIgnoreMigration())

--- a/base/src/org/compiere/model/PO.java
+++ b/base/src/org/compiere/model/PO.java
@@ -327,7 +327,7 @@ public abstract class PO
 	public String toString()
 	{
 		StringBuffer sb = new StringBuffer("PO[")
-			.append(get_WhereClause(true)).append("]");
+			.append(get_WhereClause(true)).append(", UUID=").append(get_UUID()).append("]");
 		return sb.toString();
 	}	//  toString
 
@@ -433,6 +433,14 @@ public abstract class PO
 			return ((Integer)oo).intValue();
 		return 0;
 	}   //  getID
+	
+	/**
+	 * Get UUID
+	 * @return
+	 */
+	public String get_UUID() {
+		return get_ValueAsString(I_AD_Element.COLUMNNAME_UUID);
+	}
 
 	/**
 	 *  Return Deleted Single Key Record ID
@@ -2466,7 +2474,15 @@ public abstract class PO
 		boolean updated = false;
 		boolean updatedBy = false;
 		lobReset();
-
+		//	UUID
+		String columnName = I_AD_Element.COLUMNNAME_UUID;
+		if (p_info.getColumnIndex(columnName) != -1) {
+			String value = get_ValueAsString(columnName);
+			if (value == null || value.length() == 0) {
+				value = DB.getUUID(m_trxName);
+				set_ValueNoCheck(columnName, value);
+			}
+		}
 		//	Change Log
 		MSession session = MSession.get (p_ctx, false);
 		if (session == null)
@@ -2479,13 +2495,8 @@ public abstract class PO
 		int size = get_ColumnCount();
 		for (int i = 0; i < size; i++)
 		{
-			String columnName = p_info.getColumnName(i);
+			columnName = p_info.getColumnName(i);
 			Object value = m_newValues[i];
-			if (columnName.equals("UUID") && get_Value(columnName) == null)
-			{
-				value = DB.getUUID(get_TrxName());
-			}
-
 			if (value == null
 				|| p_info.isVirtualColumn(i))
 				continue;
@@ -2735,6 +2746,15 @@ public abstract class PO
 				set_ValueNoCheck(columnName, value);
 			}
 		}
+		//	UUID
+		columnName = I_AD_Element.COLUMNNAME_UUID;
+		if (p_info.getColumnIndex(columnName) != -1) {
+			String value = get_ValueAsString(columnName);
+			if (value == null || value.length() == 0) {
+				value = DB.getUUID(m_trxName);
+				set_ValueNoCheck(columnName, value);
+			}
+		}
 
 		lobReset();
 
@@ -2756,10 +2776,6 @@ public abstract class PO
 		for (int i = 0; i < size; i++)
 		{
 			Object value = get_Value(i);
-			if (p_info.getColumnName(i).equals("UUID") && value == null) {
-				value = DB.getUUID(get_TrxName());
-			}
-
 			//	Don't insert NULL values (allows Database defaults)
 			if (value == null
 				|| p_info.isVirtualColumn(i))


### PR DESCRIPTION
Hi everybody, this pull request resolve a error with UUID for migration:

Currently and after 3.9.1 ADempiere version is added **UUID** column for all tables. For now this worked but when I try generate a migration from PO the **UUID** is not added to migration step.

Please review it.