### PR TITLE
#2445 Make the ZK process panel message draggable in size.

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/ProcessPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/ProcessPanel.java
@@ -211,6 +211,7 @@ public class ProcessPanel extends ProcessController implements SmallViewEditable
 			messagePanel = new North();
 			messagePanel.appendChild(messageDiv);
 			messagePanel.setAutoscroll(true);
+			messagePanel.setSplittable(true);
 			messagePanel.setStyle("border: none;");
 			mainLayout.appendChild(messagePanel);
 		}


### PR DESCRIPTION
Fixes #2445 

A simple change to the north panel to allow the user to select the size.