### PR TITLE
#2434 Tax.java

### DIFF
--- a/base/src/org/compiere/model/Tax.java
+++ b/base/src/org/compiere/model/Tax.java
@@ -39,6 +39,8 @@ import org.compiere.util.DB;
  * 
  * @author Teo Sarca, www.arhipac.ro
  * 			<li>FR [ 2758097 ] Implement TaxNotFoundException
+ * @author Michael McKay, mckayERP@gmail.com
+ * 			<li><a href="https://github.com/adempiere/adempiere/issues/2434">#2434</a> Wrong test for parent/summary tax.
  */
 public class Tax
 {
@@ -538,7 +540,7 @@ public class Tax
 			//
 			if (tax.getC_TaxCategory_ID() != C_TaxCategory_ID
 				|| !tax.isActive() 
-				|| tax.getParent_Tax_ID() != 0)	//	user parent tax
+				|| !tax.isSummary())	//	#2434 - only looking for summary taxes 
 				continue;
 			if (IsSOTrx && MTax.SOPOTYPE_PurchaseTax.equals(tax.getSOPOType()))
 				continue;
@@ -595,7 +597,7 @@ public class Tax
 		{
 			MTax tax = taxes[i];
 			if (!tax.isDefault() || !tax.isActive()
-				|| tax.getParent_Tax_ID() != 0)	//	user parent tax
+				|| !tax.isSummary())	//	#2434 - only looking for summary taxes 
 				continue;
 			if (IsSOTrx && MTax.SOPOTYPE_PurchaseTax.equals(tax.getSOPOType()))
 				continue;


### PR DESCRIPTION
Fixes #2434

When determining if a tax is a child tax or summary tax, Tax.java uses the test  ```tax.getParent_Tax_ID()!=0```  instead of testing ```!tax.isSummary()```.  In the gui, the parent tax field is hidden if the Is Summary checkbox is selected so there is no way for the user to know that Parent_Tax_ID is non-zero.  

See https://github.com/adempiere/adempiere/issues/2434

To test, create a parent and child tax rate pair.  On the parent tax, deselect the Is Summary checkbox and set the parent tax rate to some other tax rate.  Then reselect the Is Summary check box.  Note the parent tax field is hidden.

Set up an order that would use that tax.  An error occurs as no tax is found.