### PR TITLE
#2453 Prevent duplication of process logs in dialogs

### DIFF
--- a/base/src/org/compiere/process/ProcessInfoUtil.java
+++ b/base/src/org/compiere/process/ProcessInfoUtil.java
@@ -32,6 +32,9 @@ import org.compiere.util.Msg;
  *
  *  @author Jorg Janke
  *  @version $Id: ProcessInfoUtil.java,v 1.2 2006/07/30 00:54:44 jjanke Exp $
+ *  
+ *  @author Michael McKay, mckayERP@gmail.com
+ *  	<li><a href="https://github.com/adempiere/adempiere/issues/2453">#2534</a>Duplicated entries in process log
  */
 public class ProcessInfoUtil
 {
@@ -114,6 +117,10 @@ public class ProcessInfoUtil
 	 */
 	public static void setLogFromDB (ProcessInfo pi)
 	{
+		// #2453 Check if the log already exists - don't overwrite or duplicate
+		if (pi.getLogList() != null && pi.getLogList().size() > 0)
+			return;
+		
 	//	s_log.fine("setLogFromDB - AD_PInstance_ID=" + pi.getAD_PInstance_ID());
 		String sql = "SELECT AD_PInstance_Log_ID, P_ID, P_Date, P_Number, P_Msg "
 			+ "FROM AD_PInstance_Log "


### PR DESCRIPTION
Fixes #2453 

See #2453 https://github.com/adempiere/adempiere/issues/2453

Prevents the duplication of the process log when displayed in the post-process dialogs.