### PR TITLE
Default values from SQL of process parameter not worked

### DIFF
--- a/base/src/org/adempiere/controller/SmallViewController.java
+++ b/base/src/org/adempiere/controller/SmallViewController.java
@@ -579,7 +579,9 @@ public abstract class SmallViewController implements SmallViewEditable, Vetoable
 						// Don't want to overwrite a user input, so if the field is rw and has
 						// a value, don't change it.
 						Object defaultValue = field.getDefault();
-						if (defaultValue != null && field.getOldValue() == null && (value == null || !value.equals(defaultValue))) {
+						if (defaultValue != null 
+								&& (field.getOldValue() == null || !defaultValue.equals(field.getOldValue()) || (DisplayType.isNumeric(field.getVO().displayType))) 
+								&& (value == null || !value.equals(defaultValue))) {
 							// Set the context and fire events if there is a change in value.
 							// Setting the field value to null fires events even if the field is
 							// already null so don't set null if the value is already null.
@@ -607,9 +609,12 @@ public abstract class SmallViewController implements SmallViewEditable, Vetoable
 							if (valueTo == null 
 									|| valueTo.toString().length() == 0 
 									|| !m_IsLoaded 
-									|| (!rw && DisplayType.isNumeric(fieldTo.getVO().displayType))) {
+									|| (!rw && (DisplayType.isNumeric(fieldTo.getVO().displayType)
+											|| DisplayType.isDate(fieldTo.getVO().displayType)))) {
 								Object defaultValueTo = fieldTo.getDefault();
-								if (defaultValueTo != null && fieldTo.getOldValue() == null && (valueTo == null || !valueTo.equals(defaultValueTo))) {
+								if (defaultValueTo != null 
+										&& (fieldTo.getOldValue() == null || !defaultValueTo.equals(fieldTo.getOldValue()) || DisplayType.isNumeric(fieldTo.getVO().displayType)) 
+										&& (valueTo == null || !valueTo.equals(defaultValueTo))) {
 									fieldTo.setValue(defaultValueTo, false);  // Not inserting - overwriting the current value
 									valueSet = true;
 									// Check for valid values, mandatory (similar to GridController)

--- a/zkwebui/WEB-INF/src/org/eevolution/form/WBrowser.java
+++ b/zkwebui/WEB-INF/src/org/eevolution/form/WBrowser.java
@@ -277,6 +277,7 @@ public class WBrowser extends Browser implements IFormController,
 	 */
 	protected void executeQuery() {
 		//	FR [ 245 ]
+		reloadDependents();
 		String errorMsg = searchGrid.validateParameters();
 		if (errorMsg == null) {
 			if (getAD_Window_ID() > 1)
@@ -294,10 +295,6 @@ public class WBrowser extends Browser implements IFormController,
 			}
 			loadedOK = initBrowser();
 
-			Env.setContext(Env.getCtx(), 0, "currWindowNo", getWindowNo());
-			if (parameterPanel != null)
-				parameterPanel.refreshContext();
-
 			int no = testCount();
 			if (no > 0) {
 				if(!FDialog.ask(getWindowNo(), m_frame, "InfoHighRecordCount",
@@ -314,6 +311,15 @@ public class WBrowser extends Browser implements IFormController,
 			FDialog.error(getWindowNo(), m_frame, 
 					"FillMandatory", Msg.parseTranslation(Env.getCtx(), errorMsg));
 		}
+	}
+	
+	/**
+	 * Reload dependents
+	 */
+	private void reloadDependents() {
+		Env.setContext(Env.getCtx(), 0, "currWindowNo", getWindowNo());
+		if (parameterPanel != null)
+			parameterPanel.refreshContext();
 	}
 
 	/**


### PR DESCRIPTION
Just now exist a big problem when a process parameter have a default value that are updated from browse search parameters, a example of it is the Smart Browse for **POS Close Statement** see gif:
![Smart-Browse-Error](https://user-images.githubusercontent.com/2333092/55449944-91727500-559b-11e9-88cb-a19a99d40042.gif)

This pull request fixed default value for:
- Value From
- Value To
- Numeric
Smart Browse with process

Se result:
![Current ogv](https://user-images.githubusercontent.com/2333092/55449960-a3ecae80-559b-11e9-8692-1ad5d58b3e0f.gif)
