### PR TITLE
Import process hangs

### DIFF
--- a/base/src/org/compiere/process/ImportBankStatement.java
+++ b/base/src/org/compiere/process/ImportBankStatement.java
@@ -36,6 +36,8 @@ import org.compiere.util.Env;
  *	@author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
  *  <li> FR [ 1699 ] Add support view for Bank Statement
  *  @see https://github.com/adempiere/adempiere/issues/1699
+ *  @author Nicolas Sarlabos, nicolas.sarlabos@openupsolutions.com, Openup Solutions http://openupsolutions.com/
+ *  The process hangs because the statement with the transaction is not saved
  */
 public class ImportBankStatement extends ImportBankStatementAbstract {
 
@@ -401,7 +403,7 @@ public class ImportBankStatement extends ImportBankStatementAbstract {
 					statement.setDescription(imp.getDescription());
 					statement.setEftStatementReference(imp.getEftStatementReference());
 					statement.setEftStatementDate(imp.getEftStatementDate());
-					if (statement.save())
+					if (statement.save(get_TrxName()))
 					{
 						noInsert++;
 					}


### PR DESCRIPTION
The process of importing the statement of accounts is suspended, because the statement 'save' is not performed using the transaction.

![Import bank statement](https://user-images.githubusercontent.com/29130825/55486792-4e4bec80-5603-11e9-8eea-1d1b7958bfa6.png)


Openup Solutions
Nicolás Sarlabós