### PR TITLE
Revert "#2434 Tax.java"

### DIFF
--- a/base/src/org/compiere/model/Tax.java
+++ b/base/src/org/compiere/model/Tax.java
@@ -39,8 +39,6 @@ import org.compiere.util.DB;
  * 
  * @author Teo Sarca, www.arhipac.ro
  * 			<li>FR [ 2758097 ] Implement TaxNotFoundException
- * @author Michael McKay, mckayERP@gmail.com
- * 			<li><a href="https://github.com/adempiere/adempiere/issues/2434">#2434</a> Wrong test for parent/summary tax.
  */
 public class Tax
 {
@@ -540,7 +538,7 @@ public class Tax
 			//
 			if (tax.getC_TaxCategory_ID() != C_TaxCategory_ID
 				|| !tax.isActive() 
-				|| !tax.isSummary())	//	#2434 - only looking for summary taxes 
+				|| tax.getParent_Tax_ID() != 0)	//	user parent tax
 				continue;
 			if (IsSOTrx && MTax.SOPOTYPE_PurchaseTax.equals(tax.getSOPOType()))
 				continue;
@@ -597,7 +595,7 @@ public class Tax
 		{
 			MTax tax = taxes[i];
 			if (!tax.isDefault() || !tax.isActive()
-				|| !tax.isSummary())	//	#2434 - only looking for summary taxes 
+				|| tax.getParent_Tax_ID() != 0)	//	user parent tax
 				continue;
 			if (IsSOTrx && MTax.SOPOTYPE_PurchaseTax.equals(tax.getSOPOType()))
 				continue;


### PR DESCRIPTION
Reverts adempiere/adempiere#2452

Please review it.

If a product have a Tax Category with tax:

Tax 1:
SO: Yes
IsSummary = False

The result is that is not finded from a sales order.

<pre>
ProjectPhaseGenOrder.process: No se pudo encontrar el impuesto - Categoría del Impuesto:IVA Básico, Transacción de Ventas:Si, Entrega (04/04/2019, , ,  location  -> location 1, State,  State ), Factura (04/04/2019, Address 1: Address , Address,  Address  -> Address2  ) [136]
org.adempiere.exceptions.TaxNotFoundException: No se pudo encontrar el impuesto - Categoría del Impuesto:IVA Básico, Transacción de Ventas:Si, Entrega (04/04/2019, , ,  Location  -> Address ), Factura (04/04/2019, Address 1  -> Address 2 )
	at org.compiere.model.Tax.get(Tax.java:610)
	at org.compiere.model.Tax.getProduct(Tax.java:346)
	at org.compiere.model.Tax.get(Tax.java:96)
	at org.compiere.model.Tax.get(Tax.java:82)
	at org.compiere.model.MOrderLine.setTax(MOrderLine.java:350)
	at org.compiere.process.ProjectPhaseGenOrder.doIt(ProjectPhaseGenOrder.java:193)
	at org.compiere.process.SvrProcess.process(SvrProcess.java:175)
	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:128)
	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:160)
	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:105)
	at org.compiere.apps.ProcessCtl.startProcess(ProcessCtl.java:623)
	at org.compiere.apps.ProcessCtl.run(ProcessCtl.java:372)
</pre>