### PR TITLE
BOM Drop form improvments.  

### DIFF
--- a/base/src/org/adempiere/controller/form/BOMDropController.java
+++ b/base/src/org/adempiere/controller/form/BOMDropController.java
@@ -1,0 +1,1249 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+
+package org.adempiere.controller.form;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyVetoException;
+import java.beans.VetoableChangeListener;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.logging.Level;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.exceptions.ValueChangeEvent;
+import org.adempiere.exceptions.ValueChangeListener;
+import org.compiere.model.MColumn;
+import org.compiere.model.MInvoice;
+import org.compiere.model.MInvoiceLine;
+import org.compiere.model.MLookup;
+import org.compiere.model.MLookupFactory;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProject;
+import org.compiere.model.MProjectLine;
+import org.compiere.model.MTable;
+import org.compiere.model.MUOM;
+import org.compiere.model.MUOMConversion;
+import org.compiere.model.MValRule;
+import org.compiere.model.PO;
+import org.compiere.process.DocAction;
+import org.compiere.process.ProcessInfo;
+import org.compiere.swing.CEditor;
+import org.compiere.util.CLogger;
+import org.compiere.util.DisplayType;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+import org.compiere.util.Trx;
+import org.compiere.util.Util;
+import org.eevolution.model.MPPProductBOM;
+import org.eevolution.model.MPPProductBOMLine;
+
+/**
+ * A controller class for the BOM Drop functionality.  The BOM Drop provides a
+ * means to add BOM components as lines to an Order, Invoice or Project. The
+ * BOM Drop function is accessed as a menu item or from a button/process on the 
+ * window/tab of the document or project.
+ * <p>The controller requires a View in the interface that provides:
+ * <li>A selection panel to choose the BOM, Quantity and, if started 
+ * from the menu, the target document.
+ * <li>A BOM Line selection panel where bom line items can be selected with 
+ * units of measure and quantities.  BOM lines that are components are automatically
+ * selected.  Options and Variants are grouped by the BOM Line Feature and 
+ * the user can select them as required.
+ *   
+ * @author Michael McKay, mckayERP@gmail.com
+ *
+ */
+public class BOMDropController implements ValueChangeListener, VetoableChangeListener {
+
+	/** The BOMDropForm associated with this instance of the controller */
+	private BOMDropForm form;
+	/** The ProcessInfo data associated with this form */
+	private ProcessInfo processInfo;
+	/** The PO object selected or associated with this form */
+	private PO po = null;
+	
+	// Editors used in the BOM selection panel
+	private CEditor productEditor;
+	private CEditor productQtyEditor;
+	private CEditor explodeBomEditor;
+	private CEditor orderEditor;
+	private CEditor invoiceEditor;
+	private CEditor projectEditor;
+	
+	/** 
+	 *  A flag indicating if the type of user interface. True for Swing, false for ZK.
+	 *  This is important as the events created by the editors are different. 
+	 */
+	private boolean isSwing = true;
+	
+	/** The id of the selected product BOM */
+	private int m_product_id;
+	/** The MProduct model of the selected product. The default BOM will be displayed. */
+	private MProduct product;
+	
+	/** A hash map of the features with the featureKey as the key value */
+	private HashMap<String,Object> knownFeatures = new HashMap<String,Object>();
+	
+	/** An array of the selections made.  This is the context of the form
+	 *  and is kept in sync with the form as the user makes selections.
+	 */
+	public ArrayList<Selection> selectionList = new ArrayList<Selection>();
+	
+	//  Message strings for translation
+	private static final String MSG_NothingSelected = "BOMDropController_NothingSelected";
+	private static final String MSG_ItemSelectedSingular = "BOMDropController_ItemSelectedSingular";
+	private static final String MSG_ItemSelectedPlural = "BOMDropController_ItemSelectedPlural";
+	private static final String MSG_ExplodeBOM = "BOMDropController_ExplodeBOM";
+	private static final String MSG_ExplodeBOMTooltip = "BOMDropController_ExplodeBOMTooltip";
+	private static final String MSG_IsExplodeBOMName = "BOMDropController_ExplodeBOM";
+	private static final String MSG_BOMListHeaderProduct = "@M_Product_ID@";
+	private static final String MSG_BOMListHeaderQty = "@Qty@";
+	private static final String MSG_BOMListHeaderUOM = "@C_UOM_ID@";
+	private static final String EDITORTYPE_CHECK = "CHECK";
+	private static final String EDITORTYPE_QTY = "QTY";
+	private static final String EDITORTYPE_UOM = "UOM";
+	
+	CLogger log = CLogger.getCLogger(BOMDropController.class);
+	Properties ctx;
+	private int windowNo;
+	private String trxName;
+	private boolean canExplodeBOM;
+	
+	/**
+	 * A class to hold the state of the form BOM List selection
+	 *
+	 */
+	private class Selection {
+		
+		public Selection() {};
+		
+		public boolean isSelected;
+		public int m_product_id;
+		public BigDecimal qty;
+		public int c_uom_id;
+		public MPPProductBOMLine bomLine;
+		public String name;
+		public CEditor checkEditor;
+		public CEditor qtyEditor;
+		public CEditor uomEditor;
+		public String featureKey;
+		public String type;
+		public int parentProductID;
+		public String feature;
+		public BigDecimal baseQty;		
+	}
+	
+
+	/**
+	 * Standard constructor.
+	 * @param form the BOMDropForm creating this instance of the controller.
+	 */
+	public BOMDropController(BOMDropForm form) {
+		
+		this.form = form;
+		ctx = Env.getCtx();
+
+	}
+
+	/**
+	 * Set the ProcessInfo structure
+	 * @param processInfo
+	 */
+	private void setProcessInfo(ProcessInfo processInfo) {
+		
+		this.processInfo = processInfo;
+		
+	}
+
+	/**
+	 * Initialize the controller
+	 * @param processInfo - the ProcessInfo data to use for this form
+	 * @param windowNo - the window number associated with the form
+	 * @return
+	 */
+	public boolean init(ProcessInfo processInfo, int windowNo) {
+		
+		setProcessInfo(processInfo);
+		this.windowNo = windowNo;
+		
+		//  Check if the process is being run from a document or the menu
+		if (!checkProcessInfo())
+			return false;
+		
+		int ad_column_id = MColumn.getColumn_ID(MProduct.Table_Name, MProduct.COLUMNNAME_M_Product_ID);
+		String name = Msg.translate(ctx, MProduct.COLUMNNAME_M_Product_ID);
+		String validationCode = "IsBOM='Y' AND IsVerified='Y'";
+		MLookup productLookup = null;
+		try {
+
+			productLookup = MLookupFactory.get(ctx, windowNo, 
+					ad_column_id,
+					DisplayType.TableDir, Env.getLanguage(ctx), MProduct.COLUMNNAME_M_Product_ID, 0,
+					false, validationCode);
+			
+		} catch (Exception e) {
+			log.severe("Unable to load product lookup: " + e.getLocalizedMessage());
+			return false;
+		}
+		
+		int row = 0;
+		product = null;
+		m_product_id = 0;
+		productEditor = form.createSelectionEditor(DisplayType.TableDir, productLookup, "", name, "", row, 0);
+		productEditor.setValue(null);
+		productEditor.setMandatory(true);
+		productEditor.setBackground(true);
+		addListener(productEditor);
+		
+		productQtyEditor = form.createSelectionEditor(DisplayType.Quantity, null, Msg.translate(ctx, "Qty"), Msg.translate(ctx, "Qty"), "", row++, 2);
+		productQtyEditor.setValue(Env.ONE);
+		addListener(productQtyEditor);
+		
+		String explodeBOMName = Msg.translate(ctx, MSG_ExplodeBOM);
+		String explodeBOMDesc = Msg.translate(ctx, MSG_ExplodeBOMTooltip);
+		String isExplodeBOMName = Msg.translate(ctx, MSG_IsExplodeBOMName);
+		explodeBomEditor = form.createSelectionEditor(DisplayType.YesNo, null, isExplodeBOMName, explodeBOMName, explodeBOMDesc, row++, 1);
+		explodeBomEditor.setValue(new Boolean(false)); // Default - don't explode 
+		addListener(explodeBomEditor);
+		
+		//  If no PO, create editors for the possible documents
+		if (po == null)
+		{
+		
+			//  C_Order
+			validationCode = "Processed='N' AND (DocStatus='DR' OR DocStatus='IP')"; 
+			MLookup lookup = null;
+			try {
+
+				lookup = MLookupFactory.get(ctx, windowNo, 
+						MColumn.getColumn_ID(MOrder.Table_Name, MOrder.COLUMNNAME_C_Order_ID),
+						DisplayType.TableDir, Env.getLanguage(ctx), MOrder.COLUMNNAME_C_Order_ID, 0,
+						false, validationCode);
+				
+			} catch (Exception e) {
+				log.severe("Unable to load order lookup: " + e.getLocalizedMessage());
+				return false;
+			}
+
+			name = Msg.translate(ctx, MOrder.COLUMNNAME_C_Order_ID);
+			orderEditor = form.createSelectionEditor(DisplayType.TableDir, lookup, "", name, "", row++, 0);
+			orderEditor.setMandatory(true);
+			orderEditor.setBackground(true);
+			addListener(orderEditor);
+			
+			//  C_Invoice
+			try {
+
+				lookup = MLookupFactory.get(ctx, windowNo, 
+						MColumn.getColumn_ID(MInvoice.Table_Name, MInvoice.COLUMNNAME_C_Invoice_ID),
+						DisplayType.TableDir, Env.getLanguage(ctx), MInvoice.COLUMNNAME_C_Invoice_ID, 0,
+						false, validationCode);
+				
+			} catch (Exception e) {
+				log.severe("Unable to load invoice lookup: " + e.getLocalizedMessage());
+				return false;
+			}
+			name = Msg.translate(ctx, MInvoice.COLUMNNAME_C_Invoice_ID);			
+			invoiceEditor = form.createSelectionEditor(DisplayType.TableDir, lookup, "", name, "", row++, 0);
+			invoiceEditor.setMandatory(true);
+			invoiceEditor.setBackground(true);
+			addListener(invoiceEditor);
+			
+			//  C_Project
+			validationCode = "Processed='N' AND IsSummary='N' AND IsActive='Y'"
+					+ " AND ProjectCategory<>'S'";
+			lookup = null;
+			try {
+
+				lookup = MLookupFactory.get(ctx, windowNo, 
+						MColumn.getColumn_ID(MProject.Table_Name, MProject.COLUMNNAME_C_Project_ID),
+						DisplayType.TableDir, Env.getLanguage(ctx), MProject.COLUMNNAME_C_Project_ID, 0,
+						false, validationCode);
+				
+			} catch (Exception e) {
+				log.severe("Unable to load project lookup: " + e.getLocalizedMessage());
+				return false;
+			}
+			name = Msg.translate(ctx, MProject.COLUMNNAME_C_Project_ID);
+			projectEditor = form.createSelectionEditor(DisplayType.TableDir, lookup, "", name, "", row++, 0);
+			projectEditor.setMandatory(true);
+			projectEditor.setBackground(true);
+			addListener(projectEditor);
+			
+		}
+		
+		enableConfirmOK();
+		
+		return true;
+		
+	}  //  init
+
+	/**
+	 * Validate the process info data if it exists. This is mostly dummy data but
+	 * the info can include the table and record associated with the
+	 * target document.
+	 * @return false if there is an incompatibility with the process info
+	 */
+	private boolean checkProcessInfo() {
+		
+		//  The processinfo data may not be set, which is OK. Its mostly dummy data for this controller.
+		// 
+		//  Determine the interface type being used.  Its set explicitly in the ProcessInfo data
+		//  but we will fallback to testing the stack trace in case it wasn't.  Note that the 
+		//  stack trace test may not be accurate as it depends on the calling class names.
+		//  TODO Also note that we are only testing for ZK or Swing.  If another UI is added, we'll 
+		//  have to fix this logic.
+		if (processInfo == null || processInfo.getInterfaceType().equals(ProcessInfo.INTERFACE_TYPE_NOT_SET))
+		{
+			// Need to know which interface is being used as the events may be different and the proper
+			// listeners have to be activated.  Test the calling stack trace for "webui".
+			// If not found, assume the SWING interface
+			StackTraceElement[] stElements = Thread.currentThread().getStackTrace();
+	        for (int i=1; i<stElements.length; i++) {
+	            StackTraceElement ste = stElements[i];
+	            if (ste.getClassName().contains("webui")
+	            		|| ste.getClassName().contains("zk.ui")) {
+	                isSwing  = false;
+	                break;
+	            }
+	        }
+			log.warning("Process Info is null or interface type is not set. Testing isSwing = " + isSwing);
+	        
+		}
+		else 
+		{
+			isSwing = processInfo.getInterfaceType().equals(ProcessInfo.INTERFACE_TYPE_SWING);
+		}
+		
+		// Get the transaction name
+		if (processInfo == null)
+		{	
+			trxName = null;
+			return true;
+		}
+		else
+		{
+			trxName = processInfo.getTransactionName();
+		}
+		
+		int ad_table_id = processInfo.getTable_ID();
+		int record_id = processInfo.getRecord_ID();
+		
+		//  If there is no table, assume we are running from the menu
+		if (ad_table_id != 0)  
+		{
+			//  BOM drop is allowed on three tables: C_Order, C_Invoice and M_Project
+			String allowedTables = "C_Order,C_Invoice,C_Project";
+			MTable table = MTable.get(ctx, ad_table_id);
+			if (table.get_ID () <= 0)
+			{
+				log.severe("Unable to find table: " + ad_table_id);
+				return false;
+			}
+			
+			if (!allowedTables.contains(table.getTableName()))
+			{
+				log.severe("Table not supported for BOM Drop: " + ad_table_id);
+				return false;				
+			}
+
+			po = table.getPO(record_id, processInfo.getTransactionName());
+			if (po == null)
+			{
+				log.severe("Unable to load PO for table and record: " + ad_table_id + ", " + record_id);
+				return false;
+			}
+			
+			// Projects are not Documents
+			if (po instanceof DocAction && !DocAction.STATUS_Drafted.equals(((DocAction) po).getDocStatus())
+				&& !DocAction.STATUS_InProgress.equals(((DocAction) po).getDocStatus()))
+			{
+				log.severe("Document not draft or in progress: " + po.toString());
+				return false;				
+			}
+			
+			// TODO - test for open projects?
+		}
+		
+		return true;
+	}  //  checkProcessInfo
+
+	/**
+	 * Add listeners for the created editor
+	 * @param editor
+	 */
+	private void addListener(CEditor editor) {
+		
+		//	Add event handling.  
+		//  Swing uses vetoableChangeListeners.
+		//  ZK uses ValueChangeListeners.
+		if (isSwing) {
+			editor.addVetoableChangeListener(this);
+		}
+		else {
+			editor.addValueChangeListener(this);
+		}
+	}
+
+	@Override
+	public void valueChange(ValueChangeEvent evt) {
+		
+		try {
+			eventResponse(evt, evt.getSource(), evt.getPropertyName(), evt.getNewValue(), evt.getOldValue());
+		} catch (PropertyVetoException e) {
+			// Shouldn't happen for ZK
+		}
+		
+	}
+
+	@Override
+	public void vetoableChange(PropertyChangeEvent evt) throws PropertyVetoException {
+
+		// Pass the valueChange event to the eventResponse method
+		eventResponse(evt, evt.getSource(), evt.getPropertyName(), evt.getNewValue(), evt.getOldValue());
+		
+	}
+
+
+	/**
+	 * Respond to events
+	 * @param evt
+	 * @param source
+	 * @param propertyName
+	 * @param newValue
+	 * @param oldValue
+	 * @throws PropertyVetoException
+	 */
+	private void eventResponse(Object evt, Object source, String propertyName, Object newValue, Object oldValue) 
+			throws PropertyVetoException {
+		
+		if (!(source instanceof CEditor))
+			return;
+
+		// Check for changes. Null and Empty strings are equivalent values.
+		if ((newValue == null || newValue.toString().isEmpty()) && (oldValue == null || oldValue.toString().isEmpty())
+			|| (newValue != null && newValue.equals(oldValue))) // No change.
+			return;
+		
+		CEditor editor = (CEditor) source;
+		
+		// Set the editor value - In the main application, this is performed in the GridField 
+		// and the value is sent to the editor via a property change.  Here, we don't have the
+		// GridField so we can set the value directly.  If we don't do this, the value of the 
+		// editor and its display may not match.
+		
+		if (editor.equals(productEditor))
+		{
+			if (newValue != null && newValue instanceof Integer)
+			{
+				m_product_id = ((Integer) newValue).intValue();
+				product = MProduct.get(ctx, m_product_id);
+				if (productQtyEditor.getValue() == null || Env.ZERO.compareTo((BigDecimal) productQtyEditor.getValue()) == 0)
+				{
+					productQtyEditor.setValue(Env.ONE);
+				}
+			}
+			else
+			{
+				m_product_id = 0;
+				product = null;
+				productQtyEditor.setValue(null);
+				productEditor.setBackground(true);
+			}
+			productEditor.setValue(newValue);
+			productEditor.setBackground(product == null || product.getM_Product_ID() == 0);  // Assume mandatory
+			productQtyEditor.setBackground(product == null || product.getM_Product_ID() == 0);
+			fillBOMList();  // This will clear the list if the product is null.
+		}
+		
+		if (editor.equals(productQtyEditor))
+		{
+			BigDecimal old;
+
+			try {
+				old = new BigDecimal((String) oldValue);
+			}
+			catch (NumberFormatException e)
+			{
+				old = null;
+			}
+
+			productQtyEditor.setValue(newValue);
+
+			//  Flag null or zero quantity as an error
+			//  Negative qty is allowed for corrections
+			if (newValue == null || newValue.toString().isEmpty() 
+				|| (newValue instanceof Integer && ((Integer) newValue).compareTo(Integer.valueOf(0))==0)
+				|| (newValue instanceof BigDecimal && ((BigDecimal) newValue).compareTo(Env.ZERO)==0))
+			{
+				productQtyEditor.setBackground(true);
+				return;
+			}
+			productQtyEditor.setBackground(false);
+			
+			if (((BigDecimal) newValue).compareTo(old) != 0)
+			{
+				updateBOMListQty();
+			}
+		}
+
+		if (editor.equals(explodeBomEditor))
+		{
+			// No need to set the value for a checkbox
+			fillBOMList();
+		}
+
+		//  The order, invoice and project editors, if they exist,
+		//  need some support to ensure only one is selected at a
+		//  time.
+		if (editor.equals(orderEditor))
+		{
+			orderEditor.setValue(newValue);
+			if (newValue != null && newValue instanceof Integer)
+			{
+				int c_order_id = ((Integer) newValue).intValue();
+				if (c_order_id > 0)
+				{
+					po = new MOrder(ctx, c_order_id, trxName);
+					orderEditor.setMandatory(true);
+					invoiceEditor.setMandatory(false);
+					invoiceEditor.setValue(null);
+					projectEditor.setMandatory(false);
+					projectEditor.setValue(null);
+				}
+				else
+					po = null;
+			}
+		}
+
+		if (editor.equals(invoiceEditor))
+		{
+			invoiceEditor.setValue(newValue);
+			if (newValue != null && newValue instanceof Integer)
+			{
+				int c_invoice_id = ((Integer) newValue).intValue();
+				if (c_invoice_id > 0)
+				{
+					po = new MInvoice(ctx, c_invoice_id, trxName);
+					invoiceEditor.setMandatory(true);
+					orderEditor.setMandatory(false);
+					orderEditor.setValue(null);
+					projectEditor.setMandatory(false);
+					projectEditor.setValue(null);
+				}
+				else
+					po = null;
+			}
+		}
+
+		if (editor.equals(projectEditor))
+		{
+			projectEditor.setValue(newValue);
+			if (newValue != null && newValue instanceof Integer)
+			{
+				int c_project_id = ((Integer) newValue).intValue();
+				if (c_project_id > 0)
+				{
+					po = new MProject(ctx, c_project_id, trxName);
+					projectEditor.setMandatory(true);
+					orderEditor.setMandatory(false);
+					orderEditor.setValue(null);
+					invoiceEditor.setMandatory(false);
+					invoiceEditor.setValue(null);
+				}
+				else
+					po = null;
+			}
+		}
+		
+		if (po == null)
+		{
+			orderEditor.setMandatory(true);
+			invoiceEditor.setMandatory(true);
+			projectEditor.setMandatory(true);
+			orderEditor.setBackground(true);
+			invoiceEditor.setBackground(true);
+			projectEditor.setBackground(true);
+		}
+		else
+		{
+			orderEditor.setBackground(false);
+			invoiceEditor.setBackground(false);
+			projectEditor.setBackground(false);			
+		}
+
+		// In the BOM Item List, was something selected or deselected?
+		int index = getEditorIndex(EDITORTYPE_CHECK, editor);
+		if (index >= 0)
+		{
+			//  Ignore changes from component items
+			if (MPPProductBOMLine.COMPONENTTYPE_Component.equals(selectionList.get(index).bomLine.getComponentType()))
+			{
+				editor.setValue(true);  // Has to be selected
+				if (isSwing)
+				{
+					PropertyChangeEvent pce = (PropertyChangeEvent) evt;
+					throw new PropertyVetoException(pce.getPropertyName(), pce);
+				}
+			}
+			updateSelection ();
+			updateCaption(index, editor);
+		}	//	CheckBox or Radio
+		else
+		{
+			index = getEditorIndex(EDITORTYPE_QTY, editor);
+			if (index >= 0 && newValue instanceof BigDecimal)
+			{
+				selectionList.get(index).qty = (BigDecimal) newValue;
+				editor.setBackground(newValue==null);
+			}
+			else
+			{
+				// Handle changes to the UOM and update the Qty accordingly.
+				index = getEditorIndex(EDITORTYPE_UOM, editor);
+				if (index >= 0 && newValue != null && newValue instanceof Integer)
+				{
+					// Convert qty to new UOM
+					int old_id = ((Integer) oldValue).intValue();
+					int new_id = ((Integer) newValue).intValue();
+					//  Assume qty is for the old UOM and convert to the product uom
+					BigDecimal productQty = MUOMConversion.convertProductFrom(ctx, 
+							selectionList.get(index).m_product_id, old_id, selectionList.get(index).qty);
+					if (productQty == null) 
+					{
+						// No conversion
+						selectionList.get(index).uomEditor.setValue(oldValue);
+						selectionList.get(index).c_uom_id = old_id;
+						if (isSwing)
+						{
+							PropertyChangeEvent pce = (PropertyChangeEvent) evt;
+							throw new PropertyVetoException(pce.getPropertyName(), pce);
+						}
+						return;
+					}
+					// Convert from the product UOM to the new UOM
+					BigDecimal newQty = MUOMConversion.convertProductTo(ctx, 
+							selectionList.get(index).m_product_id, new_id, productQty);
+					if (newQty == null)
+					{
+						// No conversion
+						selectionList.get(index).uomEditor.setValue(oldValue);
+						selectionList.get(index).c_uom_id = old_id;
+						if (isSwing)
+						{
+							PropertyChangeEvent pce = (PropertyChangeEvent) evt;
+							throw new PropertyVetoException(pce.getPropertyName(), pce);
+						}
+						return;						
+					}
+					// Update the qty editor
+					newQty = newQty.setScale(MUOM.getPrecision(ctx, selectionList.get(index).c_uom_id), BigDecimal.ROUND_HALF_UP);
+					selectionList.get(index).c_uom_id = new_id;
+					selectionList.get(index).uomEditor.setValue(new_id);
+					selectionList.get(index).qtyEditor.setValue(newQty);
+					selectionList.get(index).qty = newQty;
+				}
+			}
+		}
+		enableConfirmOK();
+	}  //  eventResponse
+
+	private void updateBOMListQty() {
+		
+		if (productQtyEditor == null)
+			return;
+
+		if (selectionList.isEmpty())
+			return;
+
+		BigDecimal qty = (BigDecimal) productQtyEditor.getValue();
+		if (qty == null)
+			qty = Env.ZERO;
+		
+		for (Selection list : selectionList)
+		{
+			list.qty = list.baseQty.multiply(qty);
+			list.qtyEditor.setValue(list.qty);
+		}
+		
+	}
+
+	/**
+	 * Get the index of the editor in the BOM Item selection list
+	 * @param editorType
+	 * @param editor
+	 * @return the index of the editor or -1 if not found.
+	 */
+	private int getEditorIndex(String editorType, CEditor editor) {
+		
+		if (!(EDITORTYPE_CHECK+EDITORTYPE_QTY+EDITORTYPE_UOM).contains(editorType))
+			throw new IllegalArgumentException("Unknonwn editorType: " + editorType);
+		
+		if (editor == null)
+			return -1;
+		
+        for (int i = 0; i < selectionList.size(); i++)
+        {
+            if (EDITORTYPE_CHECK.equals(editorType) && editor.equals(selectionList.get(i).checkEditor)
+            	|| EDITORTYPE_QTY.equals(editorType) && editor.equals(selectionList.get(i).qtyEditor)
+            	|| EDITORTYPE_UOM.equals(editorType) && editor.equals(selectionList.get(i).uomEditor))
+                return i;
+        }
+        return -1;
+	}
+
+	/**
+	 * Enable the OK button in the form's confirm panel.
+	 */
+	private void enableConfirmOK() {
+		
+		if (m_product_id > 0 && po != null)
+			form.enableConfirmOK(true);
+		else
+			form.enableConfirmOK(false);
+		
+	}
+
+	/**
+	 * Fill the BOM Item list with data or clear it if there is not BOM selected.
+	 */
+	private void fillBOMList() {
+		
+		form.clearBOMList();
+		selectionList.clear();
+		knownFeatures.clear();
+		canExplodeBOM = false;
+		
+		if (product != null)
+		{
+			form.setBOMListHeaders(" ", 
+					Msg.parseTranslation(ctx, MSG_BOMListHeaderProduct),
+					Msg.parseTranslation(ctx, MSG_BOMListHeaderQty),
+					Msg.parseTranslation(ctx, MSG_BOMListHeaderUOM));
+			
+			// A recursive function
+			addBOMLines(product, (BigDecimal) productQtyEditor.getValue(), Env.ONE);
+			
+			updateSelection();
+			updateCaption(-1, null);
+			
+			if (selectionList.size() > 0)
+				form.enableBOMList();
+			
+			if (!canExplodeBOM)
+			{
+				explodeBomEditor.setValue(false);
+				explodeBomEditor.setReadWrite(false);
+			}
+			else
+			{
+				// Leave the current value alone
+				explodeBomEditor.setReadWrite(true);
+			}
+		}
+		
+		form.sizeIt();
+		
+		enableConfirmOK();
+
+	} //  fillBOMList
+
+	/**
+	 * Called by the view when the user selects OK in the confirm panel.
+	 */
+	public void confirmOK() {
+		
+		if (m_product_id <= 0 || po == null)
+		{
+			log.severe("BOMDrop Confirmed (OK) but nothing selected or PO not identified.");
+			dispose();
+		}
+		
+		//  Save the PO.  Rollback if there is an error.  We don't want to 
+		//  save only the good lines as that would represent a partial Drop
+		//  and correcting a partial Drop is a bit tedious.  Its easier to 
+		//  repeat the BOM Drop once the error is fixed.  Most typical error: 
+		//  - Product not on Price List.
+		String trxName = Trx.createTrxName("BOMDrop");
+		Trx localTrx = Trx.get(trxName, true);
+		try {
+			po.set_TrxName(trxName);
+			
+			if (po instanceof MOrder)
+				saveOrder();
+			else if (po instanceof MInvoice)
+				saveInvoice();
+			else if (po instanceof MProject)
+				saveProject();
+			else
+				throw new AdempiereException("Unknown PO: " + po.toString());
+
+		}
+		catch (AdempiereException e)
+		{
+			
+			form.showDialog("Error", e.getLocalizedMessage());
+			localTrx.rollback();
+		}
+		
+		localTrx.close(); //  Will commit		
+		trxName = null;
+		dispose();
+		
+	} //  ConfirmOK
+
+	/**
+	 * Close up and quit.
+	 */
+	private void dispose() {
+		po = null;
+		product = null;
+		productEditor = null;
+		invoiceEditor = null;
+		orderEditor = null;
+		projectEditor = null;
+		
+		form.dispose();
+	}
+
+	/**
+	 * Called by the view when the user cancels the form
+	 */
+	public void confirmCancel() {
+		
+		dispose();
+		
+	}
+
+	/**
+	 * 	Add BOM Lines to the selection list.
+	 * 	Called recursively from addBOMLine if the Explode BOM editor is selected.
+	 * 	@param product product
+	 * 	@param qty quantity
+	 *  @param baseQty At the top level (parent) this is the BOM qty. At lower levels
+	 *  it is the total quantity of the BOM if the top level qty was one. It is required
+	 *  to recalculate the line quantities if the selection panel quantity is changed
+	 *  and we don't want to redraw the BOM list.
+	 */
+	
+	private void addBOMLines (MProduct product, BigDecimal qty, BigDecimal baseQty)
+	{
+		if (product == null)
+			return;
+		
+		MPPProductBOM bom = MPPProductBOM.getDefault(product, null);
+		MPPProductBOMLine[] bomLines = bom.getLines(true);
+		for (int i = 0; i < bomLines.length; i++)
+		{
+			addBOMLine (product.getM_Product_ID(), bomLines[i], qty, baseQty);
+		}
+		
+		log.fine("#" + bomLines.length);
+	}	//	addBOMLines
+
+	/**
+	 * 	Add a BOM Line to the selection list or, if Explode BOM is selected, explode the 
+	 *  line if it represents a BOM itself.
+	 * 	@param bomLines BOM Line
+	 * 	@param qty quantity
+	 */
+	private void addBOMLine (int parentProductID, MPPProductBOMLine line, BigDecimal qty, BigDecimal baseQty)
+	{
+		log.info(line.toString());
+		String bomType = line.getComponentType();
+		String itemType = null;
+		//
+		BigDecimal lineQty = line.getQty();
+		MProduct product = line.getProduct();
+		if (product == null)
+			return;
+		
+		// Set a flag if any subcomponent is a bom that can be exploded
+		if (product.isBOM() && product.isVerified())
+			canExplodeBOM = true;
+		
+		boolean explodeBOM = ((Boolean) explodeBomEditor.getValue()).booleanValue();
+		if (explodeBOM && product.isBOM() && product.isVerified())
+		{
+			addBOMLines (product, lineQty.multiply(qty), lineQty.multiply(baseQty));		//	recursive
+		}
+		else 
+		{
+			if (MPPProductBOMLine.COMPONENTTYPE_Component.equals(bomType)
+				|| MPPProductBOMLine.COMPONENTTYPE_Option.equals(bomType))
+			{
+				itemType = BOMDropForm.ITEMTYPE_CHECK;
+			}
+			else if (MPPProductBOMLine.COMPONENTTYPE_Variant.equals(bomType))
+			{
+				itemType = BOMDropForm.ITEMTYPE_RADIO;
+			}
+			
+			// Ignore other component types - packaging, phantom etc...			
+			if (!Util.isEmpty(itemType))
+			{
+				Selection selection = new Selection();
+				selection.bomLine = line;
+				selection.type = itemType;
+				selection.m_product_id = product.getM_Product_ID();
+				selection.c_uom_id = line.getC_UOM_ID();
+				selection.parentProductID = parentProductID;
+				selection.feature = line.getFeature();
+				selection.name = product.getName();
+				selection.baseQty = line.getQty().multiply(baseQty);
+				BigDecimal displayedQty = line.getQty().multiply(qty).setScale(MUOM.getPrecision(ctx, line.getC_UOM_ID()), BigDecimal.ROUND_HALF_UP);
+				selection.qty = displayedQty;
+				
+				selectionList.add(selection);
+
+				addDisplay (selection);
+			}
+		}
+	}	//	addBOMLine
+
+	/**
+	 * 	Add a BOM line to the selection list Display
+	 *	@param parentM_Product_ID parent product
+	 *	@param M_Product_ID product
+	 *	@param itemType the type of item to display
+	 *	@param name name
+	 *	@param lineQty qty
+	 */
+	private void addDisplay (Selection selection)
+	{
+		Object featureObject = null;
+		
+		if (!Util.isEmpty(selection.bomLine.getFeature(), true)) // non-whitespace
+		{
+			selection.feature = Util.cleanWhitespace(selection.bomLine.getFeature());
+			selection.featureKey = selection.feature + "_" + String.valueOf(selection.parentProductID) + "_" + selection.type;
+			featureObject = knownFeatures.get(selection.featureKey);
+			if (featureObject == null)
+			{
+				featureObject = form.createFeature(selection.featureKey, selection.feature);
+				knownFeatures.put(selection.featureKey, featureObject);
+			}
+		}
+		
+		MLookup uomLookup = null;
+		MValRule valRule = MValRule.get(ctx, 210); //  Hardcoded "C_UOM Product Options"
+		String validation = valRule.getCode();
+		validation = validation.replaceAll("@M_Product_ID@", "" + selection.m_product_id);
+		int ad_column_id = MColumn.getColumn_ID(MUOM.Table_Name, MUOM.COLUMNNAME_C_UOM_ID);
+		try {
+
+			uomLookup = MLookupFactory.get(ctx, windowNo, 
+					ad_column_id,
+					DisplayType.TableDir, Env.getLanguage(ctx), MUOM.COLUMNNAME_C_UOM_ID, 0,
+					false, validation);
+			
+		} catch (Exception e) {
+			log.severe("Unable to load UOM lookup: " + e.getLocalizedMessage());
+		}
+		
+		selection.checkEditor = form.addCheck(featureObject, selection.type, selection.name);
+		selection.qtyEditor = form.addQty(featureObject, selection.qty);
+		selection.uomEditor = form.addUOM(featureObject, uomLookup, selection.c_uom_id);
+		addListener(selection.checkEditor);
+		addListener(selection.qtyEditor);
+		addListener(selection.uomEditor);
+		
+	}	//	addDisplay
+
+	
+	/**
+	 * 	Save to Order
+	 *	@return true if saved
+	 */
+	private boolean saveOrder ()
+	{
+		log.config("C_Order_ID=" + po.get_ID());
+		MOrder order = (MOrder) po;
+		
+		int lineCount = 0;
+		
+		//	for all bom lines
+		for (int i = 0; i < selectionList.size(); i++)
+		{
+			if (selectionList.get(i).isSelected)
+			{
+				BigDecimal qty = selectionList.get(i).qty;
+				int M_Product_ID = selectionList.get(i).m_product_id;
+				int C_UOM_ID = selectionList.get(i).c_uom_id;
+				//	Create Line
+				MOrderLine ol = new MOrderLine (order);
+				
+				//  Set the product and UOM - pricing is based on the product 
+				//  UOM
+				ol.setM_Product_ID(M_Product_ID, true);
+				
+				//  If the BOM Drop UOM is different, convert the quantity to 
+				//  the Product UOM
+				if (ol.getC_UOM_ID() != C_UOM_ID)
+				{
+					//  Convert the quantity
+					qty = MUOMConversion.convertProductFrom(ctx, 
+							M_Product_ID, C_UOM_ID, qty);
+				}
+				ol.setQty(qty);
+				
+				ol.setPrice();
+				ol.setTax();
+				ol.saveEx();
+				lineCount++;
+			}	//	line selected
+		}	//	for all bom lines
+		
+		String result = "@C_Order_ID@ " + order.getDocumentNo() + ": " + lineCount;
+		result = Msg.parseTranslation(ctx, result);
+		form.showDialog("Inserted", result);
+		
+		log.config("#" + lineCount);
+		
+		return true;
+	}	//	saveOrder
+
+	/**
+	 * 	Save to Invoice
+	 *	@return true if saved
+	 */
+	private boolean saveInvoice ()
+	{
+		log.config("C_Invoice_ID=" + po.get_ID());
+		MInvoice invoice = (MInvoice) po;
+		
+		int lineCount = 0;
+		
+		//	for all bom lines
+		for (int i = 0; i < selectionList.size(); i++)
+		{
+			if (selectionList.get(i).isSelected)
+			{
+				BigDecimal qty = selectionList.get(i).qty;
+				int M_Product_ID = selectionList.get(i).m_product_id;
+				int C_UOM_ID = selectionList.get(i).c_uom_id;
+				//	Create Line
+				MInvoiceLine il = new MInvoiceLine (invoice);
+				
+				//  Set the product and UOM - pricing is based on the product 
+				//  UOM
+				il.setM_Product_ID(M_Product_ID, true);
+				
+				//  If the BOM Drop UOM is different, convert the quantity to 
+				//  the Product UOM
+				if (il.getC_UOM_ID() != C_UOM_ID)
+				{
+					//  Convert the quantity
+					qty = MUOMConversion.convertProductFrom(ctx, 
+							M_Product_ID, C_UOM_ID, qty);
+				}
+				il.setQty(qty);
+
+				il.setPrice();
+				il.setTax();
+				if (il.save())
+					lineCount++;
+				else
+					log.log(Level.SEVERE, "Line not saved");
+			}	//	line selected
+		}	//	for all bom lines
+
+		String result = "@C_Invoice_ID@ " + invoice.getDocumentNo() + ": " + lineCount;
+		result = Msg.parseTranslation(ctx, result);
+		form.showDialog("Inserted", result);
+		
+		log.config("#" + lineCount);
+		
+		return true;
+	}	//	saveInvoice
+
+	/**
+	 * 	Save to Project
+	 *	@return true if saved
+	 */
+	private boolean saveProject ()
+	{
+		log.config("C_Project_ID=" + po.get_ID());
+		MProject project = (MProject) po;
+		
+		int lineCount = 0;
+		
+		//	for all bom lines
+		for (int i = 0; i < selectionList.size(); i++)
+		{
+			if (selectionList.get(i).isSelected)
+			{
+				BigDecimal qty = selectionList.get(i).qty;
+				int M_Product_ID = selectionList.get(i).m_product_id;
+				//	Create Line
+				MProjectLine pl = new MProjectLine (project);
+				pl.setM_Product_ID(M_Product_ID);
+				pl.setPlannedQty(qty);
+			//	pl.setPlannedPrice();
+				if (pl.save())
+					lineCount++;
+				else
+					log.log(Level.SEVERE, "Line not saved");
+			}	//	line selected
+		}	//	for all bom lines
+		
+		String result = "@C_Project_ID@ " + project.getValue() + ": " + lineCount;
+		result = Msg.parseTranslation(ctx, result);
+		form.showDialog("Inserted", result);
+		
+		log.config("#" + lineCount);
+
+		return true;
+	}	//	saveProject
+
+	
+	/**
+	 * Update the selectionList structure and set the R/W status of the editors
+	 * according to the items selected.  We need to do all as radio buttons
+	 * do not send events when rows are deselected.
+	 */
+	private void updateSelection ()
+	{
+		
+		for (int i=0; i < selectionList.size(); i++)
+		{
+			selectionList.get(i).isSelected = isItemSelected(selectionList.get(i).checkEditor);
+			selectionList.get(i).qtyEditor.setReadWrite(selectionList.get(i).isSelected);
+			selectionList.get(i).uomEditor.setReadWrite(selectionList.get(i).isSelected);
+		}		
+		
+	}	//	updateSelection
+
+	/**
+	 * Update the caption of the feature groups
+	 * @param index
+	 * @param editor
+	 */
+	private void updateCaption(int index, CEditor editor) {	
+		
+		if (knownFeatures.isEmpty())
+			return;		//  No features with captions
+		
+		String featureDetail = "";
+		
+		ArrayList<String> features = new ArrayList<String>();
+		ArrayList<String> names = new ArrayList<String>();
+		
+		//  Find the affected feature or all features
+		if (index >= 0)
+		{
+			
+			String featureKey = selectionList.get(index).featureKey;
+			if (Util.isEmpty(featureKey))
+				return;
+			
+			features.add(featureKey);
+			names.add(selectionList.get(index).feature);
+			
+		}
+		else
+		{
+			for (int i=0; i < selectionList.size(); i++)
+			{
+				String featureKey = selectionList.get(i).featureKey;;
+				if (Util.isEmpty(featureKey))
+					continue;
+				
+				if (features.indexOf(featureKey) < 0)
+				{
+					features.add(featureKey);
+					names.add(selectionList.get(i).feature);
+				}
+			}
+		}
+		
+		if (features.isEmpty())
+			return; // Nothing to update
+		
+		//  Now check which items are selected within the feature
+		for (int fi=0; fi < features.size(); fi++)  // One or all
+		{
+			int countSelected = 0;
+			boolean radioType = false;
+			String name = "";
+			String featureName = "";
+			Object feature = null;
+			BigDecimal qty = Env.ZERO;
+			
+			String featureKey = features.get(fi);
+			featureName = names.get(fi);
+			feature = knownFeatures.get(featureKey);
+			int scale = 0;
+			
+			for (int i = 0; i < selectionList.size(); i++)
+			{
+				if(featureKey.equals(selectionList.get(i).featureKey))
+				{
+					if (isItemSelected(selectionList.get(i).checkEditor))
+					{
+						countSelected++;
+						name = selectionList.get(i).name;
+						radioType = BOMDropForm.ITEMTYPE_RADIO.equals(selectionList.get(i).type);
+						qty = selectionList.get(i).qty;
+						scale = MUOM.getPrecision(ctx, selectionList.get(i).c_uom_id);
+					}					
+				}
+			}
+			
+			if (countSelected == 0) 
+			{
+				featureDetail = Msg.translate(ctx, MSG_NothingSelected);
+			}
+			else if (!radioType)
+			{
+				if (countSelected == 1)
+					featureDetail = countSelected + " " + Msg.translate(ctx, MSG_ItemSelectedSingular);
+				else
+					featureDetail = countSelected + " " + Msg.translate(ctx, MSG_ItemSelectedPlural);
+			}
+			else
+				featureDetail = name + " (" + qty.setScale(scale).toString() + ")";
+
+			form.updateFeatureCaption(feature, featureName + " - " + featureDetail);
+		}		
+	} //  UpdateCaption
+	
+	/**
+	 * Test if the editor is selected
+	 * @param cEditor
+	 * @return true if the editor value is a boolean true value or a string 'Y' 
+	 */
+	private boolean isItemSelected(CEditor cEditor) {
+		
+		Object value = cEditor.getValue();
+		boolean sel = false;
+		if (value != null)
+		{
+			if (value instanceof Boolean)
+				sel = ((Boolean)value).booleanValue();
+			else
+				sel = "Y".equals(value);
+		}		
+		return sel;
+	} //  isItemSelected
+
+}

--- a/base/src/org/adempiere/controller/form/BOMDropForm.java
+++ b/base/src/org/adempiere/controller/form/BOMDropForm.java
@@ -1,0 +1,181 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+
+package org.adempiere.controller.form;
+
+import java.math.BigDecimal;
+
+import org.compiere.model.MLookup;
+import org.compiere.swing.CEditor;
+
+/**
+ * An interface for the BOM Drop custom form.  The form should have three parts:
+ * <ol><li>a
+ * selection panel where the BOM is selected;
+ * <li>another selection panel where the
+ * BOM lines can be selected; and
+ * <li>a confirmation panel with OK and Cancel buttons.</ol>
+ * <p>The BOM selection requires a lookup field for the 
+ * product, a qty field and a checkbox to indicate if the BOM should be exploded.
+ * The controller will request these fields be created with the function 
+ * {@link #createSelectionEditor(int, MLookup, String, String, String, int, int)}. This
+ * call includes the row and column where the editor should be placed.
+ * <p>The BOM Line selection list is created with each line having a selection checkbox or radio button
+ * the product name, a quantity editor and a UOM editor.  These editors are added to the selection list
+ * as they are requested by the controller with the selection editor starting a new line.
+ * <p>The BOM Line selection list may have collapsible groups for the features identified in the BOM Line.
+ * These collapsible groups will be requested by the controller and requests to create the editors will 
+ * reference the groups to which the editors should be added.
+ * 
+ * @author Michael McKay, mckayERP@gmail.com
+ *
+ */
+public interface BOMDropForm {
+
+	/** 
+	 * Item type for checkbox buttons. Provided by the controller in the 
+	 * {@link #addCheck(int, Object, String, String)} method call.
+	 * Buttons using the ITEMTYPE_CHECK value should use standard
+	 * checkbox editors where multiple selection within the feature
+	 * group is possible.
+	 */
+	public final String ITEMTYPE_CHECK = "CHECK";
+
+	/** 
+	 * Item type for radio buttons. Provided by the controller in the 
+	 * {@link #addCheck(int, Object, String, String)} method call.
+	 * Buttons using the ITEMTYPE_RADIO value should use radio
+	 * editors where only one editor can be selected at a time within
+	 * a feature group.
+	 */
+	public final String ITEMTYPE_RADIO = "RADIO";
+	
+	/** Message string for the selection panel label */
+	public final String MSG_SELECTIONPANEL = "BOMDropForm_SelectBOM";
+	/** Message string for the selection of BOM lines */
+	public final String MSG_SELECTBOMLINES = "BOMDropForm_SelectProducts";
+	/** Message string for collapsible feature group tool tip */
+	public final String MSG_ClickToOpen = "BOMDropForm_ClickToOpen";
+
+	
+	/**
+	 * Clear the BOM list. Called by the controller prior to adding items to the BOM list
+	 * or when the main BOM selection changes. The form will remove any editors and groups
+	 * from the BOM Item selection panel and hide the panel until the {@link #enableBOMList()}
+	 * method is called.
+	 */
+	public void clearBOMList();
+
+	/**
+	 * Create an editor in the BOM selection panel
+	 * @param displayType - from {@link org.compiere.util.DisplayType}. Required
+	 * @param lookup - the Lookup for the editor, if required
+	 * @param columnName - the columnName represented by the editor
+	 * @param name - the label (if used), translated
+	 * @param description - the description/tooltip text, translated
+	 * @param row - the row to add the editor to
+	 * @param col - the column to add the editor to
+	 * @return the CEditor created
+	 */
+	public CEditor createSelectionEditor(int displayType, MLookup lookup, String columnName, String name, String description, int row, int col);
+	
+	/**
+	 * Enable or disable the confirm panel OK button.
+	 * @param enable - when true, enable the OK button
+	 */
+	public void enableConfirmOK(boolean enable);
+	
+	/**
+	 * Dispose of the view form;
+	 */
+	public void dispose();
+
+	/**
+	 * Display a dialog to the user with the message and results.
+	 * @param message, translated
+	 * @param result, translated
+	 */
+	public void showDialog(String message, String result);
+	
+	/**
+	 * Adjust the size of the form, if required. Called by the 
+	 * controller after all the editors have been requested/created.
+	 */
+	public void sizeIt();
+	
+	/**
+	 * Update the caption of the provided feature or collapsible group
+	 * @param feature - the object representing the collapsible group
+	 * @param caption - the new translated caption to display
+	 */
+	public void updateFeatureCaption(Object feature, String caption);  
+
+	/**
+	 * Create a collapsible group in the BOM Line selection list.
+	 * @param featureKey - a unique key for this feature
+	 * @param caption - the String to use as the initial caption or title
+	 * @return The object created representing the feature.
+	 */
+	public Object createFeature(String featureKey, String caption);
+
+	/**
+	 * Add a check/radio button to the BOM Line selection list as the first item in a new row.  
+	 * The itemType parameter should be one of {@link #ITEMTYPE_CHECK} or {@link #ITEMTYPE_RADIO} 
+	 * depending on the type of check button required.  Radio item types require a feature. Check
+	 * item types may or may not have a feature.
+	 * @param feature - the object representing the collapsible group or null
+	 * @param itemType - the itemType match either {@link #ITEMTYPE_CHECK} or {@link #ITEMTYPE_RADIO}
+	 * @param name - the translated name of the editor to use in the label.
+	 * @return the CEditor created
+	 */
+	public CEditor addCheck(Object feature, String itemType, String name);
+
+	/**
+	 * Add a qty editor to the BOM Line selection list in the current row. The row may be in 
+	 * a feature or collapsible group if this parameter is not null. 
+	 * @param feature - the object representing the collapsible group or null
+	 * @param qty - the initial quantity value.
+	 * @return the CEditor created
+	 */
+	public CEditor addQty(Object feature, BigDecimal qty);
+
+	/**
+	 * Add a UOM/lookup editor to the BOM Line selection list in the current row. The row may be in 
+	 * a feature or collapsible group if this parameter is not null. 
+	 * @param feature - the object representing the collapsible group or null
+	 * @param uomLookup - the lookup to use for this editor
+	 * @param c_uom_id - the initial value of the editor.
+	 * @return the CEditor created
+	 */
+	public CEditor addUOM(Object feature, MLookup uomLookup, int c_uom_id);
+
+	/**
+	 *  Enable the BOM item selection list for use. Called after all items 
+	 *  are added to the BOM item selection list.
+	 */
+	public void enableBOMList();
+
+	/**
+ 	 * Add headers to the columns in the BOM list
+	 * @param check
+	 * @param productName
+	 * @param qtyName
+	 * @param uomName
+	 */
+	public void setBOMListHeaders(String check, String productName, String qtyName,
+			String uomName);
+
+}

--- a/base/src/org/compiere/swing/CRadioButton.java
+++ b/base/src/org/compiere/swing/CRadioButton.java
@@ -1,0 +1,359 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+
+package org.compiere.swing;
+
+import java.awt.Color;
+import java.awt.event.InputEvent;
+import java.beans.PropertyChangeEvent;
+
+import javax.swing.Action;
+import javax.swing.Icon;
+import javax.swing.InputMap;
+import javax.swing.JComponent;
+import javax.swing.JRadioButton;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.plaf.ComponentInputMapUIResource;
+
+import org.adempiere.exceptions.ValueChangeListener;
+import org.compiere.model.GridField;
+
+/**
+ * Adempiere Radio Button
+ * 
+ * @author Michael McKay, mckayERP@gmail.com
+ */
+public class CRadioButton extends JRadioButton implements CEditor {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 6115543971487470944L;
+
+	/**
+	 * Creates a radio button button with no text, no icon.
+	 */
+	public CRadioButton() {
+		super();
+		init();
+	}
+
+	/**
+	 * Creates a radio button with an icon.
+	 * 
+	 * @param icon
+	 *            the Icon image to display
+	 */
+	public CRadioButton(Icon icon) {
+		super(icon);
+		init();
+	}
+
+	/**
+	 * Creates a radio button with an icon and specifies whether or not it is
+	 * initially selected.
+	 * 
+	 * @param icon
+	 *            the Icon image to display
+	 * @param selected
+	 *            a boolean value indicating the initial selection state. If
+	 *            <code>true</code> the radio button is selected
+	 */
+	public CRadioButton(Icon icon, boolean selected) {
+		super(icon, selected);
+		init();
+	}
+
+	/**
+	 * Creates a radio button with text.
+	 * 
+	 * @param text
+	 *            the text of the radio button.
+	 */
+	public CRadioButton(String text) {
+		super(text);
+		init();
+	}
+
+	/**
+	 * Creates a radio button where properties are taken from the Action supplied.
+	 * 
+	 * @param a
+	 */
+	public CRadioButton(Action a) {
+		super(a);
+		init();
+	}
+
+	/**
+	 * Creates a radio button with text and specifies whether or not it is
+	 * initially selected.
+	 * 
+	 * @param text
+	 *            the text of the radio button.
+	 * @param selected
+	 *            a boolean value indicating the initial selection state. If
+	 *            <code>true</code> the radio button is selected
+	 */
+	public CRadioButton(String text, boolean selected) {
+		super(text, selected);
+		init();
+	}
+
+	/**
+	 * Creates a radio button with the specified text and
+	 * icon.
+	 * 
+	 * @param text
+	 *            the text of the radio button.
+	 * @param icon
+	 *            the Icon image to display
+	 */
+	public CRadioButton(String text, Icon icon) {
+		super(text, icon, false);
+		init();
+	}
+
+	/**
+	 * Creates a radio button with text and icon, and specifies whether or not it
+	 * is initially selected.
+	 * 
+	 * @param text
+	 *            the text of the radio button.
+	 * @param icon
+	 *            the Icon image to display
+	 * @param selected
+	 *            a boolean value indicating the initial selection state. If
+	 *            <code>true</code> the radio button is selected
+	 */
+	public CRadioButton(String text, Icon icon, boolean selected) {
+		super(text, icon, selected);
+		init();
+	}
+
+	/**
+	 * Common Init
+	 */
+	private void init() {
+		// Default to transparent, works better under windows look and feel
+		setOpaque(false);
+	} // init
+
+	/** ********************************************************************** */
+
+	/** Mandatory (default false) */
+	private boolean m_mandatory = false;
+
+	/** Read-Write */
+	private boolean m_readWrite = true;
+
+	/**
+	 * Set Editor Mandatory
+	 * 
+	 * @param mandatory
+	 *            true, if you have to enter data
+	 */
+	public void setMandatory(boolean mandatory) {
+		m_mandatory = mandatory;
+		setBackground(false);
+	} // setMandatory
+
+	/**
+	 * Is Field mandatory
+	 * 
+	 * @return true, if mandatory
+	 */
+	public boolean isMandatory() {
+		return m_mandatory;
+	} // isMandatory
+
+	/**
+	 * Enable Editor
+	 * 
+	 * @param rw
+	 *            true, if you can enter/select data
+	 */
+	public void setReadWrite(boolean rw) {
+		if (super.isEnabled() != rw)
+			super.setEnabled(rw);
+		setBackground(false);
+		m_readWrite = rw;
+	} // setEditable
+
+	/**
+	 * Is it possible to edit
+	 * 
+	 * @return true, if editable
+	 */
+	public boolean isReadWrite() {
+		return m_readWrite;
+	} // isEditable
+
+	/**
+	 * Set Background based on editable/mandatory/error - ignored -
+	 * 
+	 * @param error
+	 *            if true, set background to error color, otherwise
+	 *            mandatory/editable
+	 */
+	public void setBackground(boolean error) {
+	} // setBackground
+
+	/**
+	 * Set Background
+	 * 
+	 * @param bg
+	 */
+	public void setBackground(Color bg) {
+		if (bg.equals(getBackground()))
+			return;
+		super.setBackground(bg);
+	} // setBackground
+
+	/** Retain value */
+	private Object m_value = null;
+
+	/**
+	 * Set Editor to value. Interpret Y/N and Boolean
+	 * 
+	 * @param value
+	 *            value of the editor
+	 */
+	public void setValue(Object value) {
+		m_value = value;
+		boolean sel = false;
+		if (value == null)
+			sel = false;
+		else if (value.toString().equals("Y"))
+			sel = true;
+		else if (value.toString().equals("N"))
+			sel = false;
+		else if (value instanceof Boolean)
+			sel = ((Boolean) value).booleanValue();
+		else {
+			try {
+				sel = Boolean.getBoolean(value.toString());
+			} catch (Exception e) {
+			}
+		}
+		this.setSelected(sel);
+	} // setValue
+
+	/**
+	 * Return Editor value
+	 * 
+	 * @return current value as String or Boolean
+	 */
+	public Object getValue() {
+		if (m_value instanceof String)
+			return super.isSelected() ? "Y" : "N";
+		return new Boolean(isSelected());
+	} // getValue
+
+	/**
+	 * Return Display Value
+	 * 
+	 * @return displayed String value
+	 */
+	public String getDisplay() {
+		if (m_value instanceof String)
+			return super.isSelected() ? "Y" : "N";
+		return Boolean.toString(super.isSelected());
+	} // getDisplay
+
+	/**
+	 * Set Text
+	 * 
+	 * @param mnemonicLabel
+	 *            text
+	 */
+	public void setText(String mnemonicLabel) {
+		super.setText(createMnemonic(mnemonicLabel));
+	} // setText
+
+	/**
+	 * Create Mnemonics of text containing "&". Based on MS notation of &Help =>
+	 * H is Mnemonics Creates ALT_
+	 * 
+	 * @param text
+	 *            test with Mnemonics
+	 * @return text w/o &
+	 */
+	private String createMnemonic(String text) {
+		if (text == null)
+			return text;
+		int pos = text.indexOf('&');
+		if (pos != -1) // We have a nemonic
+		{
+			char ch = text.charAt(pos + 1);
+			if (ch != ' ') // &_ - is the & character
+			{
+				setMnemonic(ch);
+				return text.substring(0, pos) + text.substring(pos + 1);
+			}
+		}
+		return text;
+	} // createMnemonic
+
+	/**
+	 * Overrides the JCheckBox.setMnemonic() method, setting modifier keys to
+	 * CTRL+SHIFT.
+	 * 
+	 * @param mnemonic
+	 *            The mnemonic character code.
+	 */
+	public void setMnemonic(int mnemonic) {
+		super.setMnemonic(mnemonic);
+
+		InputMap map = SwingUtilities.getUIInputMap(this,
+				JComponent.WHEN_IN_FOCUSED_WINDOW);
+
+		if (map == null) {
+			map = new ComponentInputMapUIResource(this);
+			SwingUtilities.replaceUIInputMap(this,
+					JComponent.WHEN_IN_FOCUSED_WINDOW, map);
+		}
+		map.clear();
+		String className = this.getClass().getName();
+		int mask = InputEvent.ALT_MASK; // Default Buttons
+		if (this instanceof JRadioButton // In Tab
+				|| className.indexOf("VButton") != -1)
+			mask = InputEvent.SHIFT_MASK + InputEvent.CTRL_MASK;
+		map.put(KeyStroke.getKeyStroke(mnemonic, mask, false), "pressed");
+		map.put(KeyStroke.getKeyStroke(mnemonic, mask, true), "released");
+		map.put(KeyStroke.getKeyStroke(mnemonic, 0, true), "released");
+		setInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW, map);
+	} // setMnemonic
+
+	@Override
+	public void propertyChange(PropertyChangeEvent evt) {
+		// Not used
+		
+	}
+
+	@Override
+	public void addValueChangeListener(ValueChangeListener listener) {
+		// Not used
+		
+	}
+
+	@Override
+	public GridField getField() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+} // CCheckBox

--- a/client/src/org/compiere/grid/ed/VRadioButton.java
+++ b/client/src/org/compiere/grid/ed/VRadioButton.java
@@ -1,0 +1,300 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+
+package org.compiere.grid.ed;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyVetoException;
+
+import javax.swing.JLabel;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+
+import org.compiere.apps.RecordInfo;
+import org.compiere.model.GridField;
+import org.compiere.swing.CRadioButton;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+
+/**
+ *  Radio Button Control - selects one of a number of options. Created to enable
+ *  variant selection on the BOM Drop form.  Copied from VCheckbox.
+ *
+ *  @author Michael McKay, mckayERP@gmail.com
+ *  
+ */
+public class VRadioButton extends CRadioButton
+	implements VEditor, ActionListener
+{
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -9199643773556184995L;
+
+	/******************************************************************************
+	 *	Mouse Listener
+	 */
+	final class VRadioButton_mouseAdapter extends MouseAdapter
+	{
+		/**
+		 *	Constructor
+		 *  @param adaptee adaptee
+		 */
+		VRadioButton_mouseAdapter(VRadioButton adaptee)
+		{
+			m_adaptee = adaptee;
+		}	//	mouseAdapter
+
+		private VRadioButton m_adaptee;
+
+		/**
+		 *	Mouse Listener
+		 *  @param e event
+		 */
+		public void mouseClicked(MouseEvent e)
+		{
+			//	popup menu
+			if (SwingUtilities.isRightMouseButton(e))
+				m_adaptee.popupMenu.show((Component)e.getSource(), e.getX(), e.getY());
+		}	//	mouseClicked
+
+	}
+	
+	/**
+	 *	Default Constructor
+	 */
+	public VRadioButton()
+	{
+		this("", false, false, true, "", null, false);
+	}	//	VCheckBox
+
+	/**
+	 *	Standard Constructor
+	 *  @param columnName
+	 *  @param mandatory
+	 *  @param isReadOnly
+	 *  @param isUpdateable
+	 *  @param title
+	 *  @param description
+	 *  @param tableEditor
+	 */
+	public VRadioButton(String columnName, boolean mandatory, boolean isReadOnly, boolean isUpdateable,
+		String title, String description, boolean tableEditor)
+	{
+		super();
+		super.setName(columnName);
+		this.columnName = columnName;
+		setMandatory(mandatory);
+		//
+		if (isReadOnly || !isUpdateable)
+			setEditable(false);
+		else
+			setEditable(true);
+
+		//  Normal
+		if (!tableEditor)
+		{
+			setText(title);
+			if (description != null && description.length() > 0)
+				setToolTipText(description);
+		}
+		else
+		{
+			setHorizontalAlignment(JLabel.CENTER);
+		}
+		//
+		this.addActionListener(this);
+		addMouseListener(new VRadioButton_mouseAdapter(this));
+	}	//	VCheckBox
+
+	/** Mnemonic saved			*/
+	private char	savedMnemonic = 0;
+
+	/**
+	 *  Dispose
+	 */
+	public void dispose()
+	{
+	}   //  dispose
+
+	private String		columnName;
+	private GridField 	field;
+	//	Popup
+	JPopupMenu 			popupMenu = new JPopupMenu();
+	private Object 		oldValue;
+
+	/**
+	 *	Set Editable
+	 *  @param value
+	 */
+	public void setEditable (boolean value)
+	{
+		super.setReadWrite(value);
+	}	//	setEditable
+
+	/**
+	 *	IsEditable
+	 *  @return true if editable
+	 */
+	public boolean isEditable()
+	{
+		return super.isReadWrite();
+	}	//	isEditable
+
+	/**
+	 *	Set Editor to value
+	 *  @param value
+	 */
+	public void setValue (Object value)
+	{
+		boolean sel = false;
+		if (value != null)
+		{
+			if (value instanceof Boolean)
+				sel = ((Boolean)value).booleanValue();
+			else
+				sel = "Y".equals(value);
+		}
+		setSelected(sel);
+	}	//	setValue
+
+	/**
+	 *  Property Change Listener
+	 *  @param evt
+	 */
+	public void propertyChange (PropertyChangeEvent evt)
+	{
+		if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY))
+			setValue(evt.getNewValue());
+	}   //  propertyChange
+
+	/**
+	 *	Return Editor value
+	 *  @return value
+	 */
+	public Object getValue()
+	{
+		return new Boolean (isSelected());
+	}	//	getValue
+
+	/**
+	 *  Return Display Value
+	 *  @return value
+	 */
+	public String getDisplay()
+	{
+		String value = isSelected() ? "Y" : "N";
+		return Msg.translate(Env.getCtx(), value);
+	}   //  getDisplay
+
+	/**
+	 *	Set Background (nop)
+	 */
+	public void setBackground()
+	{
+	}	//	setBackground
+
+	/**
+	 *	Action Listener	- data binding
+	 *  @param e
+	 */
+	public void actionPerformed(ActionEvent e)
+	{
+		if (e.getActionCommand().equals(RecordInfo.CHANGE_LOG_COMMAND))
+		{
+			RecordInfo.start(field);
+			return;
+		}
+		//	ADebug.info("VCheckBox.actionPerformed");
+		try
+		{
+			fireVetoableChange(columnName, null, getValue());
+		}
+		catch (PropertyVetoException pve)
+		{
+		}
+	}	//	actionPerformed
+
+	/**
+	 *  Set Field/WindowNo for ValuePreference (NOP)
+	 *  @param mField
+	 */
+	public void setField (org.compiere.model.GridField mField)
+	{
+		field = mField;
+		if (field != null)
+			RecordInfo.addMenu(this, popupMenu);
+	}   //  setField
+
+	@Override
+	public GridField getField() {
+		return field;
+	}
+	
+	/**
+	 * @return Returns the savedMnemonic.
+	 */
+	public char getSavedMnemonic ()
+	{
+		return savedMnemonic;
+	}	//	getSavedMnemonic
+	
+	/**
+	 * @param savedMnemonic The savedMnemonic to set.
+	 */
+	public void setSavedMnemonic (char savedMnemonic)
+	{
+		this.savedMnemonic = savedMnemonic;
+	}	//	getSavedMnemonic
+	/**
+	 * Set the old value of the field.  For use in future comparisons.
+	 * The old value must be explicitly set though this call.
+	 * @param oldValue
+	 */
+	public void set_oldValue() {
+		this.oldValue = getValue();
+	}
+	/**
+	 * Get the old value of the field explicitly set in the past
+	 * @return
+	 */
+	public Object get_oldValue() {
+		return oldValue;
+	}
+	/**
+	 * Has the field changed over time?
+	 * @return true if the old value is different than the current.
+	 */
+	public boolean hasChanged() {
+		// Both or either could be null
+		if(getValue() != null)
+			if(oldValue != null)
+				return !oldValue.equals(getValue());
+			else
+				return true;
+		else  // getValue() is null
+			if(oldValue != null)
+				return true;
+			else
+				return false;
+	}
+
+}	//	VCheckBox

--- a/migration/391lts-392lts/04530_2435_BOMDrop.xml
+++ b/migration/391lts-392lts/04530_2435_BOMDrop.xml
@@ -1,0 +1,5060 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="#2435 BOM Drop" ReleaseNo="3.9.2" SeqNo="4530">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="284" Action="I" Record_ID="54214" Table="AD_Process">
+        <Data AD_Column_ID="4374" Column="AD_ReportView_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84383" Column="UUID">bfff8fd6-526f-11e9-9026-00ff97344bad</Data>
+        <Data AD_Column_ID="4656" Column="Classname" isNewNull="true"/>
+        <Data AD_Column_ID="2811" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="12458" Column="IsBetaFunctionality">false</Data>
+        <Data AD_Column_ID="3371" Column="IsReport">false</Data>
+        <Data AD_Column_ID="6652" Column="Statistic_Count">0</Data>
+        <Data AD_Column_ID="63488" Column="AD_Browse_ID" isNewNull="true"/>
+        <Data AD_Column_ID="4214" Column="IsDirectPrint">false</Data>
+        <Data AD_Column_ID="57920" Column="CopyFromProcess">N</Data>
+        <Data AD_Column_ID="2808" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="2806" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="2801" Column="AD_Process_ID">54214</Data>
+        <Data AD_Column_ID="2802" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2803" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="11834" Column="AD_Workflow_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6653" Column="Statistic_Seconds">0</Data>
+        <Data AD_Column_ID="2813" Column="ProcedureName" isNewNull="true"/>
+        <Data AD_Column_ID="50182" Column="JasperReport" isNewNull="true"/>
+        <Data AD_Column_ID="6485" Column="EntityType">D</Data>
+        <Data AD_Column_ID="2805" Column="Created">2019-03-29 18:12:31.855</Data>
+        <Data AD_Column_ID="2807" Column="Updated">2019-03-29 18:12:31.855</Data>
+        <Data AD_Column_ID="2809" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="2810" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="56515" Column="AD_Form_ID">114</Data>
+        <Data AD_Column_ID="5790" Column="AccessLevel">3</Data>
+        <Data AD_Column_ID="7752" Column="AD_PrintFormat_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2804" Column="IsActive">true</Data>
+        <Data AD_Column_ID="50181" Column="ShowHelp">Y</Data>
+        <Data AD_Column_ID="4023" Column="Value">BOMDrop</Data>
+        <Data AD_Column_ID="11563" Column="WorkflowValue" isNewNull="true"/>
+        <Data AD_Column_ID="14084" Column="IsServerProcess">false</Data>
+        <Data AD_Column_ID="78843" Column="GenerateClass">N</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="287" Action="I" Record_ID="0" Table="AD_Process_Trl">
+        <Data AD_Column_ID="2847" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2850" Column="Updated">2019-03-29 18:14:06.897</Data>
+        <Data AD_Column_ID="2848" Column="Created">2019-03-29 18:14:06.897</Data>
+        <Data AD_Column_ID="2853" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="2854" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="2855" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2852" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="2846" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2845" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2851" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="2844" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="2843" Column="AD_Process_ID">54214</Data>
+        <Data AD_Column_ID="2849" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="84387" Column="UUID">f81d2900-526f-11e9-904a-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="287" Action="U" Record_ID="0" Table="AD_Process_Trl">
+        <Data AD_Column_ID="2853" Column="Description" oldValue="Drop (expand) Bill of Materials into an Order, Invoice, etc.">Expandir Listas de Materiales en una orden, factura, etc.</Data>
+        <Data AD_Column_ID="2843" Column="AD_Process_ID" oldValue="54214">54214</Data>
+        <Data AD_Column_ID="2855" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="2852" Column="Name" oldValue="BOM Drop">Expansi&amp;oacute;n LDM</Data>
+        <Data AD_Column_ID="2844" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="2854" Column="Help" oldValue="Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!">Traer (expandir) la lista de materiales en una orden, factura, etc. Los documentos deben estar en un estado Borrador. Aseg&amp;uacute;rese de que los art&amp;iacute;culos incluidos en la LDM est&amp;aacute;n en la lista de precios de la orden, factura, etc. de lo contrario el precio ser&amp;aacute; cero!</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="276" Action="I" Record_ID="60953" Table="AD_Element">
+        <Data AD_Column_ID="2600" Column="Updated">2019-03-29 18:21:03.493</Data>
+        <Data AD_Column_ID="2597" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2603" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="2604" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="2598" Column="Created">2019-03-29 18:21:03.493</Data>
+        <Data AD_Column_ID="2602" Column="ColumnName">BOMDrop</Data>
+        <Data AD_Column_ID="2605" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="6284" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="6285" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="4299" Column="PrintName">BOM Drop</Data>
+        <Data AD_Column_ID="6286" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="6283" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="58589" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="58588" Column="AD_Reference_ID">28</Data>
+        <Data AD_Column_ID="2594" Column="AD_Element_ID">60953</Data>
+        <Data AD_Column_ID="2596" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2595" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="6484" Column="EntityType">D</Data>
+        <Data AD_Column_ID="2599" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="58590" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2601" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84316" Column="UUID">f0abf768-5270-11e9-80ac-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="277" Action="I" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2642" Column="Created">2019-03-29 18:21:05.398</Data>
+        <Data AD_Column_ID="6449" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="2641" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2644" Column="Updated">2019-03-29 18:21:05.398</Data>
+        <Data AD_Column_ID="2638" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6450" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="2648" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="2646" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="2647" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="2649" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="4300" Column="PrintName">BOM Drop</Data>
+        <Data AD_Column_ID="6451" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="6448" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="2640" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2639" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2645" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="2643" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID">60953</Data>
+        <Data AD_Column_ID="84317" Column="UUID">f18fa3fa-5270-11e9-80c5-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2648" Column="Help" oldValue="Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!">Traer (expandir) la lista de materiales en una orden, factura, etc. Los documentos deben estar en un estado Borrador. Aseg&amp;uacute;rese de que los art&amp;iacute;culos incluidos en la LDM est&amp;aacute;n en la lista de precios de la orden, factura, etc. de lo contrario el precio ser&amp;aacute; cero!</Data>
+        <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="2646" Column="Name" oldValue="BOM Drop">Expansi&amp;oacute;n LDM</Data>
+        <Data AD_Column_ID="2647" Column="Description" oldValue="Drop (expand) Bill of Materials into an Order, Invoice, etc.">Expandir Listas de Materiales en una orden, factura, etc.</Data>
+        <Data AD_Column_ID="2649" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="4300" Column="PrintName" oldValue="BOM Drop">Expansi&amp;oacute;n LDM</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="60953">60953</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="101" Action="I" Record_ID="92893" Table="AD_Column">
+        <Data AD_Column_ID="552" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84306" Column="UUID">5f9a598a-5271-11e9-8160-00ff97344bad</Data>
+        <Data AD_Column_ID="3369" Column="AD_Process_ID" isNewNull="true"/>
+        <Data AD_Column_ID="112" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="548" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90939" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="549" Column="Created">2019-03-29 18:24:09.675</Data>
+        <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="551" Column="Updated">2019-03-29 18:24:09.675</Data>
+        <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="109" Column="AD_Column_ID">92893</Data>
+        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="111" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="120" Column="IsParent">false</Data>
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
+        <Data AD_Column_ID="6483" Column="IsSyncDatabase">N</Data>
+        <Data AD_Column_ID="119" Column="IsKey">false</Data>
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="56352" Column="FormatPattern" isNewNull="true"/>
+        <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
+        <Data AD_Column_ID="110" Column="Version">0</Data>
+        <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
+        <Data AD_Column_ID="116" Column="ColumnName">BOMDrop</Data>
+        <Data AD_Column_ID="113" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="3360" Column="IsUpdateable">true</Data>
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="11617" Column="IsAlwaysUpdateable">false</Data>
+        <Data AD_Column_ID="128" Column="IsEncrypted">N</Data>
+        <Data AD_Column_ID="54358" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="56187" Column="IsAllowLogging">true</Data>
+        <Data AD_Column_ID="56149" Column="IsAutocomplete">false</Data>
+        <Data AD_Column_ID="68024" Column="IsRange">false</Data>
+        <Data AD_Column_ID="62199" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="127" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="6482" Column="EntityType">D</Data>
+        <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">259</Data>
+        <Data AD_Column_ID="550" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="2608" Column="AD_Element_ID">60953</Data>
+        <Data AD_Column_ID="227" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="115" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="118" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="226" Column="AD_Reference_ID">28</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="752" Action="I" Record_ID="92893" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="12958" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="12960" Column="Created">2019-03-29 18:24:11.859</Data>
+        <Data AD_Column_ID="12959" Column="IsActive">true</Data>
+        <Data AD_Column_ID="12952" Column="Updated">2019-03-29 18:24:11.859</Data>
+        <Data AD_Column_ID="12955" Column="AD_Column_ID">92893</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="12957" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="12956" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84310" Column="UUID">60b320a4-5271-11e9-8196-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="90" StepType="AD">
+      <PO AD_Table_ID="752" Action="U" Record_ID="92893" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12955" Column="AD_Column_ID" oldValue="92893">92893</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="12957" Column="Name" oldValue="BOM Drop">Expansi&amp;oacute;n LDM</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="100" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="92893" Table="AD_Column">
+        <Data AD_Column_ID="125" Column="IsTranslated" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="110" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93621" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-03-29 18:25:51.033</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-03-29 18:25:51.033</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93621</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">92893</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">1</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">186</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">9c00d002-5271-11e9-a631-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="120" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93621" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-03-29 18:25:53.181</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-03-29 18:25:53.181</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="286" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="288" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93621</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">9d179b42-5271-11e9-a660-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="130" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93622" Table="AD_Field">
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">36</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">186</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">9e0a1520-5271-11e9-a670-00ff97344bad</Data>
+        <Data AD_Column_ID="168" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-03-29 18:25:54.476</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-03-29 18:25:54.476</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93622</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">84683</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="140" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93622" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-03-29 18:25:56.138</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-03-29 18:25:56.138</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="286" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="288" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93622</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">9eda396c-5271-11e9-a69f-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="150" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93621" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="0">490</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="160" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="1082" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="490">500</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="170" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="1084" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="500">510</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="180" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6560" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="510">520</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="190" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="1083" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="520">530</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="200" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="58037" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="530">540</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="210" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3660" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="530">550</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="220" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="52014" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="540">560</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="230" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93621" Table="AD_Field">
+        <Data AD_Column_ID="177" Column="DisplayLogic" isOldNull="true">@DocStatus@='DR'</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="240" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93621" Table="AD_Field">
+        <Data AD_Column_ID="177" Column="DisplayLogic" oldValue="@DocStatus@='DR'">@DocStatus@=DR</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="250" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93621" Table="AD_Field">
+        <Data AD_Column_ID="177" Column="DisplayLogic" oldValue="@DocStatus@=DR">@DocStatus@=DR | @DocStatus@=PR</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="260" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="92893" Table="AD_Column">
+        <Data AD_Column_ID="3369" Column="AD_Process_ID" isOldNull="true">54214</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="270" StepType="AD">
+      <PO AD_Table_ID="208" Action="I" Record_ID="50038" Table="M_Product">
+        <Data AD_Column_ID="1767" Column="Weight">0</Data>
+        <Data AD_Column_ID="1405" Column="IsActive">true</Data>
+        <Data AD_Column_ID="1406" Column="Created">2019-04-02 12:19:24.091</Data>
+        <Data AD_Column_ID="3014" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="1408" Column="Updated">2019-04-02 12:19:24.091</Data>
+        <Data AD_Column_ID="2704" Column="DiscontinuedAt" isNewNull="true"/>
+        <Data AD_Column_ID="85500" Column="C_TaxType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7963" Column="DescriptionURL" isNewNull="true"/>
+        <Data AD_Column_ID="10261" Column="IsSelfService">true</Data>
+        <Data AD_Column_ID="4712" Column="Processing">false</Data>
+        <Data AD_Column_ID="14505" Column="IsExcludeAutoDelivery">false</Data>
+        <Data AD_Column_ID="61997" Column="IsManufactured">false</Data>
+        <Data AD_Column_ID="61996" Column="IsKanban">false</Data>
+        <Data AD_Column_ID="2305" Column="SKU" isNewNull="true"/>
+        <Data AD_Column_ID="7973" Column="VersionNo" isNewNull="true"/>
+        <Data AD_Column_ID="3015" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1413" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="1411" Column="Description">A seed starter tray with 16 small pots</Data>
+        <Data AD_Column_ID="1766" Column="Volume">0</Data>
+        <Data AD_Column_ID="1410" Column="Name">Seedling Tray - 16 Bins</Data>
+        <Data AD_Column_ID="61995" Column="M_PartType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2308" Column="ShelfHeight">0</Data>
+        <Data AD_Column_ID="2304" Column="UPC" isNewNull="true"/>
+        <Data AD_Column_ID="4709" Column="IsInvoicePrintDetails">false</Data>
+        <Data AD_Column_ID="4711" Column="IsVerified">false</Data>
+        <Data AD_Column_ID="7962" Column="ImageURL" isNewNull="true"/>
+        <Data AD_Column_ID="7795" Column="ProductType">I</Data>
+        <Data AD_Column_ID="10260" Column="IsWebStoreFeatured">false</Data>
+        <Data AD_Column_ID="4708" Column="IsBOM">false</Data>
+        <Data AD_Column_ID="68433" Column="IsPhantom">false</Data>
+        <Data AD_Column_ID="68432" Column="IsToFormule">false</Data>
+        <Data AD_Column_ID="52062" Column="Group2" isNewNull="true"/>
+        <Data AD_Column_ID="52061" Column="Group1" isNewNull="true"/>
+        <Data AD_Column_ID="1761" Column="IsStocked">true</Data>
+        <Data AD_Column_ID="1762" Column="IsPurchased">true</Data>
+        <Data AD_Column_ID="2011" Column="Value">SeedTray-16</Data>
+        <Data AD_Column_ID="1763" Column="IsSold">true</Data>
+        <Data AD_Column_ID="2703" Column="Discontinued">false</Data>
+        <Data AD_Column_ID="2310" Column="UnitsPerPallet">0</Data>
+        <Data AD_Column_ID="4710" Column="IsPickListPrintDetails">false</Data>
+        <Data AD_Column_ID="12147" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="59231" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="68430" Column="DiscontinuedBy" isNewNull="true"/>
+        <Data AD_Column_ID="68431" Column="DownloadURL" isNewNull="true"/>
+        <Data AD_Column_ID="3016" Column="Classification" isNewNull="true"/>
+        <Data AD_Column_ID="1402" Column="M_Product_ID">50038</Data>
+        <Data AD_Column_ID="1403" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1404" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2307" Column="ShelfWidth">0</Data>
+        <Data AD_Column_ID="2019" Column="C_TaxCategory_ID">107</Data>
+        <Data AD_Column_ID="1409" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1407" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3391" Column="SalesRep_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7974" Column="GuaranteeDays">0</Data>
+        <Data AD_Column_ID="2309" Column="ShelfDepth">0</Data>
+        <Data AD_Column_ID="8417" Column="M_AttributeSet_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9889" Column="GuaranteeDaysMin">0</Data>
+        <Data AD_Column_ID="10919" Column="C_SubscriptionType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7972" Column="R_MailText_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53408" Column="LowLevel">0</Data>
+        <Data AD_Column_ID="67105" Column="M_Product_Group_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67106" Column="M_Product_Classification_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2012" Column="M_Product_Category_ID">105</Data>
+        <Data AD_Column_ID="9420" Column="M_Locator_ID">50006</Data>
+        <Data AD_Column_ID="6771" Column="S_ExpenseType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6773" Column="S_Resource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3909" Column="C_RevenueRecognition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8418" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1760" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="9329" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52116" Column="UnitsPerPack">0</Data>
+        <Data AD_Column_ID="67104" Column="M_Product_Class_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84959" Column="UUID">14738090-5563-11e9-ac42-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="280" StepType="AD">
+      <PO AD_Table_ID="312" Action="I" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="3326" Column="Created">2019-04-02 12:19:39.509</Data>
+        <Data AD_Column_ID="3325" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3328" Column="Updated">2019-04-02 12:19:39.509</Data>
+        <Data AD_Column_ID="13008" Column="Description">A seed starter tray with 16 small pots</Data>
+        <Data AD_Column_ID="3330" Column="Name">Seedling Tray - 16 Bins</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="3323" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3324" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3327" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3329" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID">50038</Data>
+        <Data AD_Column_ID="84974" Column="UUID">1d6a8e28-5563-11e9-ac8d-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="290" StepType="AD">
+      <PO AD_Table_ID="273" Action="I" Record_ID="50038" Table="M_Product_Acct">
+        <Data AD_Column_ID="2561" Column="Created">2019-04-02 12:19:41.259</Data>
+        <Data AD_Column_ID="2563" Column="Updated">2019-04-02 12:19:41.259</Data>
+        <Data AD_Column_ID="2560" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3421" Column="P_COGS_Acct">233</Data>
+        <Data AD_Column_ID="56558" Column="P_MethodChangeVariance_Acct">50003</Data>
+        <Data AD_Column_ID="56566" Column="P_OutsideProcessing_Acct">50010</Data>
+        <Data AD_Column_ID="56565" Column="P_Burden_Acct">50008</Data>
+        <Data AD_Column_ID="56571" Column="P_Overhead_Acct">50011</Data>
+        <Data AD_Column_ID="56572" Column="P_Scrap_Acct">50012</Data>
+        <Data AD_Column_ID="14431" Column="P_InventoryClearing_Acct">299</Data>
+        <Data AD_Column_ID="59073" Column="P_AverageCostVariance_Acct">50013</Data>
+        <Data AD_Column_ID="14432" Column="P_CostAdjustment_Acct">298</Data>
+        <Data AD_Column_ID="2559" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2558" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2565" Column="M_Product_ID">50038</Data>
+        <Data AD_Column_ID="2556" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="56557" Column="P_WIP_Acct">50001</Data>
+        <Data AD_Column_ID="2564" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="5109" Column="P_PurchasePriceVariance_Acct">232</Data>
+        <Data AD_Column_ID="3420" Column="P_Asset_Acct">231</Data>
+        <Data AD_Column_ID="3419" Column="P_Expense_Acct">230</Data>
+        <Data AD_Column_ID="6119" Column="P_TradeDiscountRec_Acct">283</Data>
+        <Data AD_Column_ID="6118" Column="P_InvoicePriceVariance_Acct">282</Data>
+        <Data AD_Column_ID="56563" Column="P_CostOfProduction_Acct">50009</Data>
+        <Data AD_Column_ID="56564" Column="P_Labor_Acct">50007</Data>
+        <Data AD_Column_ID="56560" Column="P_RateVariance_Acct">50005</Data>
+        <Data AD_Column_ID="56561" Column="P_MixVariance_Acct">50006</Data>
+        <Data AD_Column_ID="56562" Column="P_FloorStock_Acct">50002</Data>
+        <Data AD_Column_ID="56559" Column="P_UsageVariance_Acct">50004</Data>
+        <Data AD_Column_ID="2562" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3418" Column="P_Revenue_Acct">229</Data>
+        <Data AD_Column_ID="6120" Column="P_TradeDiscountGrant_Acct">284</Data>
+        <Data AD_Column_ID="84964" Column="UUID">1e757260-5563-11e9-ac9d-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="300" StepType="AD">
+      <PO AD_Table_ID="327" Action="I" Record_ID="101" Table="M_Product_Costing">
+        <Data AD_Column_ID="3629" Column="Created">2019-04-02 12:19:42.682</Data>
+        <Data AD_Column_ID="3633" Column="CostStandard" isNewNull="true"/>
+        <Data AD_Column_ID="3628" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3631" Column="Updated">2019-04-02 12:19:42.682</Data>
+        <Data AD_Column_ID="6708" Column="PriceLastPO" isNewNull="true"/>
+        <Data AD_Column_ID="6711" Column="TotalInvAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3634" Column="CostAverage" isNewNull="true"/>
+        <Data AD_Column_ID="6703" Column="CostStandardPOAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6704" Column="CostStandardCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="6709" Column="PriceLastInv" isNewNull="true"/>
+        <Data AD_Column_ID="6710" Column="TotalInvQty" isNewNull="true"/>
+        <Data AD_Column_ID="6702" Column="CostStandardPOQty" isNewNull="true"/>
+        <Data AD_Column_ID="6705" Column="CostStandardCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6706" Column="CostAverageCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="5125" Column="CurrentCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="5126" Column="FutureCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="6707" Column="CostAverageCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3626" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3627" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3632" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3630" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3625" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="3624" Column="M_Product_ID">50038</Data>
+        <Data AD_Column_ID="84970" Column="UUID">1f4e4964-5563-11e9-acc0-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="310" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:19:44.288</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:19:44.288</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">100</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50038</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">2045301c-5563-11e9-acda-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="320" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:19:45.518</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:19:45.518</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">50000</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50038</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">20ff3408-5563-11e9-acf5-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="330" StepType="AD">
+      <PO AD_Table_ID="453" Action="I" Record_ID="50038" Table="AD_TreeNodePR">
+        <Data AD_Column_ID="84443" Column="UUID">21b58e60-5563-11e9-ad10-00ff97344bad</Data>
+        <Data AD_Column_ID="6170" Column="Updated">2019-04-02 12:19:46.714</Data>
+        <Data AD_Column_ID="6167" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6168" Column="Created">2019-04-02 12:19:46.714</Data>
+        <Data AD_Column_ID="6164" Column="Node_ID">50038</Data>
+        <Data AD_Column_ID="6174" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6172" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6165" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="6166" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6163" Column="AD_Tree_ID">102</Data>
+        <Data AD_Column_ID="6171" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6169" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="340" StepType="AD">
+      <PO AD_Table_ID="208" Action="I" Record_ID="50039" Table="M_Product">
+        <Data AD_Column_ID="1767" Column="Weight">0</Data>
+        <Data AD_Column_ID="1405" Column="IsActive">true</Data>
+        <Data AD_Column_ID="1406" Column="Created">2019-04-02 12:20:40.162</Data>
+        <Data AD_Column_ID="3014" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="1408" Column="Updated">2019-04-02 12:20:40.162</Data>
+        <Data AD_Column_ID="2704" Column="DiscontinuedAt" isNewNull="true"/>
+        <Data AD_Column_ID="85500" Column="C_TaxType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7963" Column="DescriptionURL" isNewNull="true"/>
+        <Data AD_Column_ID="10261" Column="IsSelfService">true</Data>
+        <Data AD_Column_ID="4712" Column="Processing">false</Data>
+        <Data AD_Column_ID="14505" Column="IsExcludeAutoDelivery">false</Data>
+        <Data AD_Column_ID="61997" Column="IsManufactured">false</Data>
+        <Data AD_Column_ID="61996" Column="IsKanban">false</Data>
+        <Data AD_Column_ID="2305" Column="SKU" isNewNull="true"/>
+        <Data AD_Column_ID="7973" Column="VersionNo" isNewNull="true"/>
+        <Data AD_Column_ID="3015" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1413" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="1411" Column="Description">A seed starter tray with 36 small pots</Data>
+        <Data AD_Column_ID="1766" Column="Volume">0</Data>
+        <Data AD_Column_ID="1410" Column="Name">Seedling Tray - 36 bins</Data>
+        <Data AD_Column_ID="61995" Column="M_PartType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2308" Column="ShelfHeight">0</Data>
+        <Data AD_Column_ID="2304" Column="UPC" isNewNull="true"/>
+        <Data AD_Column_ID="4709" Column="IsInvoicePrintDetails">false</Data>
+        <Data AD_Column_ID="4711" Column="IsVerified">false</Data>
+        <Data AD_Column_ID="7962" Column="ImageURL" isNewNull="true"/>
+        <Data AD_Column_ID="7795" Column="ProductType">I</Data>
+        <Data AD_Column_ID="10260" Column="IsWebStoreFeatured">false</Data>
+        <Data AD_Column_ID="4708" Column="IsBOM">false</Data>
+        <Data AD_Column_ID="68433" Column="IsPhantom">false</Data>
+        <Data AD_Column_ID="68432" Column="IsToFormule">false</Data>
+        <Data AD_Column_ID="52062" Column="Group2" isNewNull="true"/>
+        <Data AD_Column_ID="52061" Column="Group1" isNewNull="true"/>
+        <Data AD_Column_ID="1761" Column="IsStocked">true</Data>
+        <Data AD_Column_ID="1762" Column="IsPurchased">true</Data>
+        <Data AD_Column_ID="2011" Column="Value">SeedTray-36</Data>
+        <Data AD_Column_ID="1763" Column="IsSold">true</Data>
+        <Data AD_Column_ID="2703" Column="Discontinued">false</Data>
+        <Data AD_Column_ID="2310" Column="UnitsPerPallet">0</Data>
+        <Data AD_Column_ID="4710" Column="IsPickListPrintDetails">false</Data>
+        <Data AD_Column_ID="12147" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="59231" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="68430" Column="DiscontinuedBy" isNewNull="true"/>
+        <Data AD_Column_ID="68431" Column="DownloadURL" isNewNull="true"/>
+        <Data AD_Column_ID="3016" Column="Classification" isNewNull="true"/>
+        <Data AD_Column_ID="1402" Column="M_Product_ID">50039</Data>
+        <Data AD_Column_ID="1403" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1404" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2307" Column="ShelfWidth">0</Data>
+        <Data AD_Column_ID="2019" Column="C_TaxCategory_ID">107</Data>
+        <Data AD_Column_ID="1409" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1407" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3391" Column="SalesRep_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7974" Column="GuaranteeDays">0</Data>
+        <Data AD_Column_ID="2309" Column="ShelfDepth">0</Data>
+        <Data AD_Column_ID="8417" Column="M_AttributeSet_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9889" Column="GuaranteeDaysMin">0</Data>
+        <Data AD_Column_ID="10919" Column="C_SubscriptionType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7972" Column="R_MailText_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53408" Column="LowLevel">0</Data>
+        <Data AD_Column_ID="67105" Column="M_Product_Group_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67106" Column="M_Product_Classification_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2012" Column="M_Product_Category_ID">105</Data>
+        <Data AD_Column_ID="9420" Column="M_Locator_ID">50006</Data>
+        <Data AD_Column_ID="6771" Column="S_ExpenseType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6773" Column="S_Resource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3909" Column="C_RevenueRecognition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8418" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1760" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="9329" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52116" Column="UnitsPerPack">0</Data>
+        <Data AD_Column_ID="67104" Column="M_Product_Class_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84959" Column="UUID">41bb32fa-5563-11e9-914f-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="350" StepType="AD">
+      <PO AD_Table_ID="312" Action="I" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="3326" Column="Created">2019-04-02 12:20:42.6</Data>
+        <Data AD_Column_ID="3325" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3328" Column="Updated">2019-04-02 12:20:42.6</Data>
+        <Data AD_Column_ID="13008" Column="Description">A seed starter tray with 36 small pots</Data>
+        <Data AD_Column_ID="3330" Column="Name">Seedling Tray - 36 bins</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="3323" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3324" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3327" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3329" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID">50039</Data>
+        <Data AD_Column_ID="84974" Column="UUID">4304a7c2-5563-11e9-919a-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="360" StepType="AD">
+      <PO AD_Table_ID="273" Action="I" Record_ID="50039" Table="M_Product_Acct">
+        <Data AD_Column_ID="2561" Column="Created">2019-04-02 12:20:43.549</Data>
+        <Data AD_Column_ID="2563" Column="Updated">2019-04-02 12:20:43.549</Data>
+        <Data AD_Column_ID="2560" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3421" Column="P_COGS_Acct">233</Data>
+        <Data AD_Column_ID="56558" Column="P_MethodChangeVariance_Acct">50003</Data>
+        <Data AD_Column_ID="56566" Column="P_OutsideProcessing_Acct">50010</Data>
+        <Data AD_Column_ID="56565" Column="P_Burden_Acct">50008</Data>
+        <Data AD_Column_ID="56571" Column="P_Overhead_Acct">50011</Data>
+        <Data AD_Column_ID="56572" Column="P_Scrap_Acct">50012</Data>
+        <Data AD_Column_ID="14431" Column="P_InventoryClearing_Acct">299</Data>
+        <Data AD_Column_ID="59073" Column="P_AverageCostVariance_Acct">50013</Data>
+        <Data AD_Column_ID="14432" Column="P_CostAdjustment_Acct">298</Data>
+        <Data AD_Column_ID="2559" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2558" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2565" Column="M_Product_ID">50039</Data>
+        <Data AD_Column_ID="2556" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="56557" Column="P_WIP_Acct">50001</Data>
+        <Data AD_Column_ID="2564" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="5109" Column="P_PurchasePriceVariance_Acct">232</Data>
+        <Data AD_Column_ID="3420" Column="P_Asset_Acct">231</Data>
+        <Data AD_Column_ID="3419" Column="P_Expense_Acct">230</Data>
+        <Data AD_Column_ID="6119" Column="P_TradeDiscountRec_Acct">283</Data>
+        <Data AD_Column_ID="6118" Column="P_InvoicePriceVariance_Acct">282</Data>
+        <Data AD_Column_ID="56563" Column="P_CostOfProduction_Acct">50009</Data>
+        <Data AD_Column_ID="56564" Column="P_Labor_Acct">50007</Data>
+        <Data AD_Column_ID="56560" Column="P_RateVariance_Acct">50005</Data>
+        <Data AD_Column_ID="56561" Column="P_MixVariance_Acct">50006</Data>
+        <Data AD_Column_ID="56562" Column="P_FloorStock_Acct">50002</Data>
+        <Data AD_Column_ID="56559" Column="P_UsageVariance_Acct">50004</Data>
+        <Data AD_Column_ID="2562" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3418" Column="P_Revenue_Acct">229</Data>
+        <Data AD_Column_ID="6120" Column="P_TradeDiscountGrant_Acct">284</Data>
+        <Data AD_Column_ID="84964" Column="UUID">43959f3e-5563-11e9-91aa-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="370" StepType="AD">
+      <PO AD_Table_ID="327" Action="I" Record_ID="101" Table="M_Product_Costing">
+        <Data AD_Column_ID="3629" Column="Created">2019-04-02 12:20:44.691</Data>
+        <Data AD_Column_ID="3633" Column="CostStandard" isNewNull="true"/>
+        <Data AD_Column_ID="3628" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3631" Column="Updated">2019-04-02 12:20:44.691</Data>
+        <Data AD_Column_ID="6708" Column="PriceLastPO" isNewNull="true"/>
+        <Data AD_Column_ID="6711" Column="TotalInvAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3634" Column="CostAverage" isNewNull="true"/>
+        <Data AD_Column_ID="6703" Column="CostStandardPOAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6704" Column="CostStandardCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="6709" Column="PriceLastInv" isNewNull="true"/>
+        <Data AD_Column_ID="6710" Column="TotalInvQty" isNewNull="true"/>
+        <Data AD_Column_ID="6702" Column="CostStandardPOQty" isNewNull="true"/>
+        <Data AD_Column_ID="6705" Column="CostStandardCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6706" Column="CostAverageCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="5125" Column="CurrentCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="5126" Column="FutureCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="6707" Column="CostAverageCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3626" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3627" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3632" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3630" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3625" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="3624" Column="M_Product_ID">50039</Data>
+        <Data AD_Column_ID="84970" Column="UUID">4443bc18-5563-11e9-91cd-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="380" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:20:45.753</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:20:45.753</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">100</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50039</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">44e618fa-5563-11e9-91e7-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="390" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:20:46.749</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:20:46.749</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">50000</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50039</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">457f4dfe-5563-11e9-9202-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="400" StepType="AD">
+      <PO AD_Table_ID="453" Action="I" Record_ID="50039" Table="AD_TreeNodePR">
+        <Data AD_Column_ID="84443" Column="UUID">4619bb78-5563-11e9-921d-00ff97344bad</Data>
+        <Data AD_Column_ID="6170" Column="Updated">2019-04-02 12:20:47.771</Data>
+        <Data AD_Column_ID="6167" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6168" Column="Created">2019-04-02 12:20:47.771</Data>
+        <Data AD_Column_ID="6164" Column="Node_ID">50039</Data>
+        <Data AD_Column_ID="6174" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6172" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6165" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="6166" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6163" Column="AD_Tree_ID">102</Data>
+        <Data AD_Column_ID="6171" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6169" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="410" StepType="AD">
+      <PO AD_Table_ID="208" Action="I" Record_ID="50041" Table="M_Product">
+        <Data AD_Column_ID="1767" Column="Weight">0</Data>
+        <Data AD_Column_ID="1405" Column="IsActive">true</Data>
+        <Data AD_Column_ID="1406" Column="Created">2019-04-02 12:21:37.504</Data>
+        <Data AD_Column_ID="3014" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="1408" Column="Updated">2019-04-02 12:21:37.504</Data>
+        <Data AD_Column_ID="2704" Column="DiscontinuedAt" isNewNull="true"/>
+        <Data AD_Column_ID="85500" Column="C_TaxType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7963" Column="DescriptionURL" isNewNull="true"/>
+        <Data AD_Column_ID="10261" Column="IsSelfService">true</Data>
+        <Data AD_Column_ID="4712" Column="Processing">false</Data>
+        <Data AD_Column_ID="14505" Column="IsExcludeAutoDelivery">false</Data>
+        <Data AD_Column_ID="61997" Column="IsManufactured">false</Data>
+        <Data AD_Column_ID="61996" Column="IsKanban">false</Data>
+        <Data AD_Column_ID="2305" Column="SKU" isNewNull="true"/>
+        <Data AD_Column_ID="7973" Column="VersionNo" isNewNull="true"/>
+        <Data AD_Column_ID="3015" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1413" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="1411" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="1766" Column="Volume">0</Data>
+        <Data AD_Column_ID="1410" Column="Name">Peat</Data>
+        <Data AD_Column_ID="61995" Column="M_PartType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2308" Column="ShelfHeight">0</Data>
+        <Data AD_Column_ID="2304" Column="UPC" isNewNull="true"/>
+        <Data AD_Column_ID="4709" Column="IsInvoicePrintDetails">false</Data>
+        <Data AD_Column_ID="4711" Column="IsVerified">false</Data>
+        <Data AD_Column_ID="7962" Column="ImageURL" isNewNull="true"/>
+        <Data AD_Column_ID="7795" Column="ProductType">I</Data>
+        <Data AD_Column_ID="10260" Column="IsWebStoreFeatured">false</Data>
+        <Data AD_Column_ID="4708" Column="IsBOM">false</Data>
+        <Data AD_Column_ID="68433" Column="IsPhantom">false</Data>
+        <Data AD_Column_ID="68432" Column="IsToFormule">false</Data>
+        <Data AD_Column_ID="52062" Column="Group2" isNewNull="true"/>
+        <Data AD_Column_ID="52061" Column="Group1" isNewNull="true"/>
+        <Data AD_Column_ID="1761" Column="IsStocked">true</Data>
+        <Data AD_Column_ID="1762" Column="IsPurchased">true</Data>
+        <Data AD_Column_ID="2011" Column="Value">Peat</Data>
+        <Data AD_Column_ID="1763" Column="IsSold">true</Data>
+        <Data AD_Column_ID="2703" Column="Discontinued">false</Data>
+        <Data AD_Column_ID="2310" Column="UnitsPerPallet">0</Data>
+        <Data AD_Column_ID="4710" Column="IsPickListPrintDetails">false</Data>
+        <Data AD_Column_ID="12147" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="59231" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="68430" Column="DiscontinuedBy" isNewNull="true"/>
+        <Data AD_Column_ID="68431" Column="DownloadURL" isNewNull="true"/>
+        <Data AD_Column_ID="3016" Column="Classification" isNewNull="true"/>
+        <Data AD_Column_ID="1402" Column="M_Product_ID">50041</Data>
+        <Data AD_Column_ID="1403" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1404" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2307" Column="ShelfWidth">0</Data>
+        <Data AD_Column_ID="2019" Column="C_TaxCategory_ID">107</Data>
+        <Data AD_Column_ID="1409" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1407" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3391" Column="SalesRep_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7974" Column="GuaranteeDays">0</Data>
+        <Data AD_Column_ID="2309" Column="ShelfDepth">0</Data>
+        <Data AD_Column_ID="8417" Column="M_AttributeSet_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9889" Column="GuaranteeDaysMin">0</Data>
+        <Data AD_Column_ID="10919" Column="C_SubscriptionType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7972" Column="R_MailText_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53408" Column="LowLevel">0</Data>
+        <Data AD_Column_ID="67105" Column="M_Product_Group_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67106" Column="M_Product_Classification_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2012" Column="M_Product_Category_ID">105</Data>
+        <Data AD_Column_ID="9420" Column="M_Locator_ID">50006</Data>
+        <Data AD_Column_ID="6771" Column="S_ExpenseType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6773" Column="S_Resource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3909" Column="C_RevenueRecognition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8418" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1760" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="9329" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52116" Column="UnitsPerPack">0</Data>
+        <Data AD_Column_ID="67104" Column="M_Product_Class_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84959" Column="UUID">63eb12b4-5563-11e9-8ca7-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="420" StepType="AD">
+      <PO AD_Table_ID="312" Action="I" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="3326" Column="Created">2019-04-02 12:21:39.761</Data>
+        <Data AD_Column_ID="3325" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3328" Column="Updated">2019-04-02 12:21:39.761</Data>
+        <Data AD_Column_ID="13008" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="3330" Column="Name">Peat</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="3323" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3324" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3327" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3329" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID">50041</Data>
+        <Data AD_Column_ID="84974" Column="UUID">6516ece4-5563-11e9-8cf2-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="430" StepType="AD">
+      <PO AD_Table_ID="273" Action="I" Record_ID="50041" Table="M_Product_Acct">
+        <Data AD_Column_ID="2561" Column="Created">2019-04-02 12:21:40.624</Data>
+        <Data AD_Column_ID="2563" Column="Updated">2019-04-02 12:21:40.624</Data>
+        <Data AD_Column_ID="2560" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3421" Column="P_COGS_Acct">233</Data>
+        <Data AD_Column_ID="56558" Column="P_MethodChangeVariance_Acct">50003</Data>
+        <Data AD_Column_ID="56566" Column="P_OutsideProcessing_Acct">50010</Data>
+        <Data AD_Column_ID="56565" Column="P_Burden_Acct">50008</Data>
+        <Data AD_Column_ID="56571" Column="P_Overhead_Acct">50011</Data>
+        <Data AD_Column_ID="56572" Column="P_Scrap_Acct">50012</Data>
+        <Data AD_Column_ID="14431" Column="P_InventoryClearing_Acct">299</Data>
+        <Data AD_Column_ID="59073" Column="P_AverageCostVariance_Acct">50013</Data>
+        <Data AD_Column_ID="14432" Column="P_CostAdjustment_Acct">298</Data>
+        <Data AD_Column_ID="2559" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2558" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2565" Column="M_Product_ID">50041</Data>
+        <Data AD_Column_ID="2556" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="56557" Column="P_WIP_Acct">50001</Data>
+        <Data AD_Column_ID="2564" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="5109" Column="P_PurchasePriceVariance_Acct">232</Data>
+        <Data AD_Column_ID="3420" Column="P_Asset_Acct">231</Data>
+        <Data AD_Column_ID="3419" Column="P_Expense_Acct">230</Data>
+        <Data AD_Column_ID="6119" Column="P_TradeDiscountRec_Acct">283</Data>
+        <Data AD_Column_ID="6118" Column="P_InvoicePriceVariance_Acct">282</Data>
+        <Data AD_Column_ID="56563" Column="P_CostOfProduction_Acct">50009</Data>
+        <Data AD_Column_ID="56564" Column="P_Labor_Acct">50007</Data>
+        <Data AD_Column_ID="56560" Column="P_RateVariance_Acct">50005</Data>
+        <Data AD_Column_ID="56561" Column="P_MixVariance_Acct">50006</Data>
+        <Data AD_Column_ID="56562" Column="P_FloorStock_Acct">50002</Data>
+        <Data AD_Column_ID="56559" Column="P_UsageVariance_Acct">50004</Data>
+        <Data AD_Column_ID="2562" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3418" Column="P_Revenue_Acct">229</Data>
+        <Data AD_Column_ID="6120" Column="P_TradeDiscountGrant_Acct">284</Data>
+        <Data AD_Column_ID="84964" Column="UUID">659a76ae-5563-11e9-8d02-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="440" StepType="AD">
+      <PO AD_Table_ID="327" Action="I" Record_ID="101" Table="M_Product_Costing">
+        <Data AD_Column_ID="3629" Column="Created">2019-04-02 12:21:41.729</Data>
+        <Data AD_Column_ID="3633" Column="CostStandard" isNewNull="true"/>
+        <Data AD_Column_ID="3628" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3631" Column="Updated">2019-04-02 12:21:41.729</Data>
+        <Data AD_Column_ID="6708" Column="PriceLastPO" isNewNull="true"/>
+        <Data AD_Column_ID="6711" Column="TotalInvAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3634" Column="CostAverage" isNewNull="true"/>
+        <Data AD_Column_ID="6703" Column="CostStandardPOAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6704" Column="CostStandardCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="6709" Column="PriceLastInv" isNewNull="true"/>
+        <Data AD_Column_ID="6710" Column="TotalInvQty" isNewNull="true"/>
+        <Data AD_Column_ID="6702" Column="CostStandardPOQty" isNewNull="true"/>
+        <Data AD_Column_ID="6705" Column="CostStandardCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6706" Column="CostAverageCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="5125" Column="CurrentCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="5126" Column="FutureCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="6707" Column="CostAverageCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3626" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3627" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3632" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3630" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3625" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="3624" Column="M_Product_ID">50041</Data>
+        <Data AD_Column_ID="84970" Column="UUID">66433c4e-5563-11e9-8d25-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="450" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:21:42.799</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:21:42.799</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">100</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50041</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">66e6aaa0-5563-11e9-8d3f-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="460" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:21:43.861</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:21:43.861</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">50000</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50041</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">6788b962-5563-11e9-8d5a-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="470" StepType="AD">
+      <PO AD_Table_ID="453" Action="I" Record_ID="50041" Table="AD_TreeNodePR">
+        <Data AD_Column_ID="84443" Column="UUID">682c4ec4-5563-11e9-8d75-00ff97344bad</Data>
+        <Data AD_Column_ID="6170" Column="Updated">2019-04-02 12:21:44.935</Data>
+        <Data AD_Column_ID="6167" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6168" Column="Created">2019-04-02 12:21:44.935</Data>
+        <Data AD_Column_ID="6164" Column="Node_ID">50041</Data>
+        <Data AD_Column_ID="6174" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6172" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6165" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="6166" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6163" Column="AD_Tree_ID">102</Data>
+        <Data AD_Column_ID="6171" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6169" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="480" StepType="AD">
+      <PO AD_Table_ID="208" Action="I" Record_ID="50042" Table="M_Product">
+        <Data AD_Column_ID="1767" Column="Weight">0</Data>
+        <Data AD_Column_ID="1405" Column="IsActive">true</Data>
+        <Data AD_Column_ID="1406" Column="Created">2019-04-02 12:22:04.866</Data>
+        <Data AD_Column_ID="3014" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="1408" Column="Updated">2019-04-02 12:22:04.866</Data>
+        <Data AD_Column_ID="2704" Column="DiscontinuedAt" isNewNull="true"/>
+        <Data AD_Column_ID="85500" Column="C_TaxType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7963" Column="DescriptionURL" isNewNull="true"/>
+        <Data AD_Column_ID="10261" Column="IsSelfService">true</Data>
+        <Data AD_Column_ID="4712" Column="Processing">false</Data>
+        <Data AD_Column_ID="14505" Column="IsExcludeAutoDelivery">false</Data>
+        <Data AD_Column_ID="61997" Column="IsManufactured">false</Data>
+        <Data AD_Column_ID="61996" Column="IsKanban">false</Data>
+        <Data AD_Column_ID="2305" Column="SKU" isNewNull="true"/>
+        <Data AD_Column_ID="7973" Column="VersionNo" isNewNull="true"/>
+        <Data AD_Column_ID="3015" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1413" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="1411" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="1766" Column="Volume">0</Data>
+        <Data AD_Column_ID="1410" Column="Name">Potting Soil</Data>
+        <Data AD_Column_ID="61995" Column="M_PartType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2308" Column="ShelfHeight">0</Data>
+        <Data AD_Column_ID="2304" Column="UPC" isNewNull="true"/>
+        <Data AD_Column_ID="4709" Column="IsInvoicePrintDetails">false</Data>
+        <Data AD_Column_ID="4711" Column="IsVerified">false</Data>
+        <Data AD_Column_ID="7962" Column="ImageURL" isNewNull="true"/>
+        <Data AD_Column_ID="7795" Column="ProductType">I</Data>
+        <Data AD_Column_ID="10260" Column="IsWebStoreFeatured">false</Data>
+        <Data AD_Column_ID="4708" Column="IsBOM">false</Data>
+        <Data AD_Column_ID="68433" Column="IsPhantom">false</Data>
+        <Data AD_Column_ID="68432" Column="IsToFormule">false</Data>
+        <Data AD_Column_ID="52062" Column="Group2" isNewNull="true"/>
+        <Data AD_Column_ID="52061" Column="Group1" isNewNull="true"/>
+        <Data AD_Column_ID="1761" Column="IsStocked">true</Data>
+        <Data AD_Column_ID="1762" Column="IsPurchased">true</Data>
+        <Data AD_Column_ID="2011" Column="Value">PottingSoil</Data>
+        <Data AD_Column_ID="1763" Column="IsSold">true</Data>
+        <Data AD_Column_ID="2703" Column="Discontinued">false</Data>
+        <Data AD_Column_ID="2310" Column="UnitsPerPallet">0</Data>
+        <Data AD_Column_ID="4710" Column="IsPickListPrintDetails">false</Data>
+        <Data AD_Column_ID="12147" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="59231" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="68430" Column="DiscontinuedBy" isNewNull="true"/>
+        <Data AD_Column_ID="68431" Column="DownloadURL" isNewNull="true"/>
+        <Data AD_Column_ID="3016" Column="Classification" isNewNull="true"/>
+        <Data AD_Column_ID="1402" Column="M_Product_ID">50042</Data>
+        <Data AD_Column_ID="1403" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1404" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2307" Column="ShelfWidth">0</Data>
+        <Data AD_Column_ID="2019" Column="C_TaxCategory_ID">107</Data>
+        <Data AD_Column_ID="1409" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1407" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3391" Column="SalesRep_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7974" Column="GuaranteeDays">0</Data>
+        <Data AD_Column_ID="2309" Column="ShelfDepth">0</Data>
+        <Data AD_Column_ID="8417" Column="M_AttributeSet_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9889" Column="GuaranteeDaysMin">0</Data>
+        <Data AD_Column_ID="10919" Column="C_SubscriptionType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7972" Column="R_MailText_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53408" Column="LowLevel">0</Data>
+        <Data AD_Column_ID="67105" Column="M_Product_Group_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67106" Column="M_Product_Classification_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2012" Column="M_Product_Category_ID">105</Data>
+        <Data AD_Column_ID="9420" Column="M_Locator_ID">50006</Data>
+        <Data AD_Column_ID="6771" Column="S_ExpenseType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6773" Column="S_Resource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3909" Column="C_RevenueRecognition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8418" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1760" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="9329" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52116" Column="UnitsPerPack">0</Data>
+        <Data AD_Column_ID="67104" Column="M_Product_Class_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84959" Column="UUID">74369b52-5563-11e9-8d83-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="490" StepType="AD">
+      <PO AD_Table_ID="312" Action="I" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="3326" Column="Created">2019-04-02 12:22:07.443</Data>
+        <Data AD_Column_ID="3325" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3328" Column="Updated">2019-04-02 12:22:07.443</Data>
+        <Data AD_Column_ID="13008" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="3330" Column="Name">Potting Soil</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="3323" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3324" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3327" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3329" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID">50042</Data>
+        <Data AD_Column_ID="84974" Column="UUID">7596a5aa-5563-11e9-8dce-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="500" StepType="AD">
+      <PO AD_Table_ID="273" Action="I" Record_ID="50042" Table="M_Product_Acct">
+        <Data AD_Column_ID="2561" Column="Created">2019-04-02 12:22:08.249</Data>
+        <Data AD_Column_ID="2563" Column="Updated">2019-04-02 12:22:08.249</Data>
+        <Data AD_Column_ID="2560" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3421" Column="P_COGS_Acct">233</Data>
+        <Data AD_Column_ID="56558" Column="P_MethodChangeVariance_Acct">50003</Data>
+        <Data AD_Column_ID="56566" Column="P_OutsideProcessing_Acct">50010</Data>
+        <Data AD_Column_ID="56565" Column="P_Burden_Acct">50008</Data>
+        <Data AD_Column_ID="56571" Column="P_Overhead_Acct">50011</Data>
+        <Data AD_Column_ID="56572" Column="P_Scrap_Acct">50012</Data>
+        <Data AD_Column_ID="14431" Column="P_InventoryClearing_Acct">299</Data>
+        <Data AD_Column_ID="59073" Column="P_AverageCostVariance_Acct">50013</Data>
+        <Data AD_Column_ID="14432" Column="P_CostAdjustment_Acct">298</Data>
+        <Data AD_Column_ID="2559" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2558" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2565" Column="M_Product_ID">50042</Data>
+        <Data AD_Column_ID="2556" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="56557" Column="P_WIP_Acct">50001</Data>
+        <Data AD_Column_ID="2564" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="5109" Column="P_PurchasePriceVariance_Acct">232</Data>
+        <Data AD_Column_ID="3420" Column="P_Asset_Acct">231</Data>
+        <Data AD_Column_ID="3419" Column="P_Expense_Acct">230</Data>
+        <Data AD_Column_ID="6119" Column="P_TradeDiscountRec_Acct">283</Data>
+        <Data AD_Column_ID="6118" Column="P_InvoicePriceVariance_Acct">282</Data>
+        <Data AD_Column_ID="56563" Column="P_CostOfProduction_Acct">50009</Data>
+        <Data AD_Column_ID="56564" Column="P_Labor_Acct">50007</Data>
+        <Data AD_Column_ID="56560" Column="P_RateVariance_Acct">50005</Data>
+        <Data AD_Column_ID="56561" Column="P_MixVariance_Acct">50006</Data>
+        <Data AD_Column_ID="56562" Column="P_FloorStock_Acct">50002</Data>
+        <Data AD_Column_ID="56559" Column="P_UsageVariance_Acct">50004</Data>
+        <Data AD_Column_ID="2562" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3418" Column="P_Revenue_Acct">229</Data>
+        <Data AD_Column_ID="6120" Column="P_TradeDiscountGrant_Acct">284</Data>
+        <Data AD_Column_ID="84964" Column="UUID">7611a3d6-5563-11e9-8dde-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="510" StepType="AD">
+      <PO AD_Table_ID="327" Action="I" Record_ID="101" Table="M_Product_Costing">
+        <Data AD_Column_ID="3629" Column="Created">2019-04-02 12:22:09.427</Data>
+        <Data AD_Column_ID="3633" Column="CostStandard" isNewNull="true"/>
+        <Data AD_Column_ID="3628" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3631" Column="Updated">2019-04-02 12:22:09.427</Data>
+        <Data AD_Column_ID="6708" Column="PriceLastPO" isNewNull="true"/>
+        <Data AD_Column_ID="6711" Column="TotalInvAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3634" Column="CostAverage" isNewNull="true"/>
+        <Data AD_Column_ID="6703" Column="CostStandardPOAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6704" Column="CostStandardCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="6709" Column="PriceLastInv" isNewNull="true"/>
+        <Data AD_Column_ID="6710" Column="TotalInvQty" isNewNull="true"/>
+        <Data AD_Column_ID="6702" Column="CostStandardPOQty" isNewNull="true"/>
+        <Data AD_Column_ID="6705" Column="CostStandardCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6706" Column="CostAverageCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="5125" Column="CurrentCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="5126" Column="FutureCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="6707" Column="CostAverageCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3626" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3627" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3632" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3630" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3625" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="3624" Column="M_Product_ID">50042</Data>
+        <Data AD_Column_ID="84970" Column="UUID">76c5661e-5563-11e9-8e01-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="520" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:22:10.381</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:22:10.381</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">100</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50042</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">77574804-5563-11e9-8e1b-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="530" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:22:11.473</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:22:11.473</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">50000</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50042</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">77fdeab0-5563-11e9-8e36-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="540" StepType="AD">
+      <PO AD_Table_ID="453" Action="I" Record_ID="50042" Table="AD_TreeNodePR">
+        <Data AD_Column_ID="84443" Column="UUID">78b4e152-5563-11e9-8e51-00ff97344bad</Data>
+        <Data AD_Column_ID="6170" Column="Updated">2019-04-02 12:22:12.674</Data>
+        <Data AD_Column_ID="6167" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6168" Column="Created">2019-04-02 12:22:12.674</Data>
+        <Data AD_Column_ID="6164" Column="Node_ID">50042</Data>
+        <Data AD_Column_ID="6174" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6172" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6165" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="6166" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6163" Column="AD_Tree_ID">102</Data>
+        <Data AD_Column_ID="6171" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6169" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="550" StepType="AD">
+      <PO AD_Table_ID="208" Action="I" Record_ID="50043" Table="M_Product">
+        <Data AD_Column_ID="1767" Column="Weight">0</Data>
+        <Data AD_Column_ID="1405" Column="IsActive">true</Data>
+        <Data AD_Column_ID="1406" Column="Created">2019-04-02 12:22:46.342</Data>
+        <Data AD_Column_ID="3014" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="1408" Column="Updated">2019-04-02 12:22:46.342</Data>
+        <Data AD_Column_ID="2704" Column="DiscontinuedAt" isNewNull="true"/>
+        <Data AD_Column_ID="85500" Column="C_TaxType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7963" Column="DescriptionURL" isNewNull="true"/>
+        <Data AD_Column_ID="10261" Column="IsSelfService">true</Data>
+        <Data AD_Column_ID="4712" Column="Processing">false</Data>
+        <Data AD_Column_ID="14505" Column="IsExcludeAutoDelivery">false</Data>
+        <Data AD_Column_ID="61997" Column="IsManufactured">false</Data>
+        <Data AD_Column_ID="61996" Column="IsKanban">false</Data>
+        <Data AD_Column_ID="2305" Column="SKU" isNewNull="true"/>
+        <Data AD_Column_ID="7973" Column="VersionNo" isNewNull="true"/>
+        <Data AD_Column_ID="3015" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1413" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="1411" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="1766" Column="Volume">0</Data>
+        <Data AD_Column_ID="1410" Column="Name">Plant Starter Kit</Data>
+        <Data AD_Column_ID="61995" Column="M_PartType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2308" Column="ShelfHeight">0</Data>
+        <Data AD_Column_ID="2304" Column="UPC" isNewNull="true"/>
+        <Data AD_Column_ID="4709" Column="IsInvoicePrintDetails">false</Data>
+        <Data AD_Column_ID="4711" Column="IsVerified">false</Data>
+        <Data AD_Column_ID="7962" Column="ImageURL" isNewNull="true"/>
+        <Data AD_Column_ID="7795" Column="ProductType">I</Data>
+        <Data AD_Column_ID="10260" Column="IsWebStoreFeatured">false</Data>
+        <Data AD_Column_ID="4708" Column="IsBOM">false</Data>
+        <Data AD_Column_ID="68433" Column="IsPhantom">false</Data>
+        <Data AD_Column_ID="68432" Column="IsToFormule">false</Data>
+        <Data AD_Column_ID="52062" Column="Group2" isNewNull="true"/>
+        <Data AD_Column_ID="52061" Column="Group1" isNewNull="true"/>
+        <Data AD_Column_ID="1761" Column="IsStocked">true</Data>
+        <Data AD_Column_ID="1762" Column="IsPurchased">true</Data>
+        <Data AD_Column_ID="2011" Column="Value">Kit-Starter</Data>
+        <Data AD_Column_ID="1763" Column="IsSold">true</Data>
+        <Data AD_Column_ID="2703" Column="Discontinued">false</Data>
+        <Data AD_Column_ID="2310" Column="UnitsPerPallet">0</Data>
+        <Data AD_Column_ID="4710" Column="IsPickListPrintDetails">false</Data>
+        <Data AD_Column_ID="12147" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="59231" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="68430" Column="DiscontinuedBy" isNewNull="true"/>
+        <Data AD_Column_ID="68431" Column="DownloadURL" isNewNull="true"/>
+        <Data AD_Column_ID="3016" Column="Classification" isNewNull="true"/>
+        <Data AD_Column_ID="1402" Column="M_Product_ID">50043</Data>
+        <Data AD_Column_ID="1403" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1404" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2307" Column="ShelfWidth">0</Data>
+        <Data AD_Column_ID="2019" Column="C_TaxCategory_ID">107</Data>
+        <Data AD_Column_ID="1409" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1407" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3391" Column="SalesRep_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7974" Column="GuaranteeDays">0</Data>
+        <Data AD_Column_ID="2309" Column="ShelfDepth">0</Data>
+        <Data AD_Column_ID="8417" Column="M_AttributeSet_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9889" Column="GuaranteeDaysMin">0</Data>
+        <Data AD_Column_ID="10919" Column="C_SubscriptionType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7972" Column="R_MailText_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53408" Column="LowLevel">0</Data>
+        <Data AD_Column_ID="67105" Column="M_Product_Group_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67106" Column="M_Product_Classification_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2012" Column="M_Product_Category_ID">105</Data>
+        <Data AD_Column_ID="9420" Column="M_Locator_ID">50006</Data>
+        <Data AD_Column_ID="6771" Column="S_ExpenseType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6773" Column="S_Resource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3909" Column="C_RevenueRecognition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8418" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1760" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="9329" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52116" Column="UnitsPerPack">0</Data>
+        <Data AD_Column_ID="67104" Column="M_Product_Class_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84959" Column="UUID">8cee7bba-5563-11e9-8e5f-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="560" StepType="AD">
+      <PO AD_Table_ID="312" Action="I" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="3326" Column="Created">2019-04-02 12:22:48.478</Data>
+        <Data AD_Column_ID="3325" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3328" Column="Updated">2019-04-02 12:22:48.478</Data>
+        <Data AD_Column_ID="13008" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="3330" Column="Name">Plant Starter Kit</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="3323" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3324" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3327" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3329" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID">50043</Data>
+        <Data AD_Column_ID="84974" Column="UUID">8e0c4c02-5563-11e9-8eaa-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="570" StepType="AD">
+      <PO AD_Table_ID="273" Action="I" Record_ID="50043" Table="M_Product_Acct">
+        <Data AD_Column_ID="2561" Column="Created">2019-04-02 12:22:49.364</Data>
+        <Data AD_Column_ID="2563" Column="Updated">2019-04-02 12:22:49.364</Data>
+        <Data AD_Column_ID="2560" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3421" Column="P_COGS_Acct">233</Data>
+        <Data AD_Column_ID="56558" Column="P_MethodChangeVariance_Acct">50003</Data>
+        <Data AD_Column_ID="56566" Column="P_OutsideProcessing_Acct">50010</Data>
+        <Data AD_Column_ID="56565" Column="P_Burden_Acct">50008</Data>
+        <Data AD_Column_ID="56571" Column="P_Overhead_Acct">50011</Data>
+        <Data AD_Column_ID="56572" Column="P_Scrap_Acct">50012</Data>
+        <Data AD_Column_ID="14431" Column="P_InventoryClearing_Acct">299</Data>
+        <Data AD_Column_ID="59073" Column="P_AverageCostVariance_Acct">50013</Data>
+        <Data AD_Column_ID="14432" Column="P_CostAdjustment_Acct">298</Data>
+        <Data AD_Column_ID="2559" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2558" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2565" Column="M_Product_ID">50043</Data>
+        <Data AD_Column_ID="2556" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="56557" Column="P_WIP_Acct">50001</Data>
+        <Data AD_Column_ID="2564" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="5109" Column="P_PurchasePriceVariance_Acct">232</Data>
+        <Data AD_Column_ID="3420" Column="P_Asset_Acct">231</Data>
+        <Data AD_Column_ID="3419" Column="P_Expense_Acct">230</Data>
+        <Data AD_Column_ID="6119" Column="P_TradeDiscountRec_Acct">283</Data>
+        <Data AD_Column_ID="6118" Column="P_InvoicePriceVariance_Acct">282</Data>
+        <Data AD_Column_ID="56563" Column="P_CostOfProduction_Acct">50009</Data>
+        <Data AD_Column_ID="56564" Column="P_Labor_Acct">50007</Data>
+        <Data AD_Column_ID="56560" Column="P_RateVariance_Acct">50005</Data>
+        <Data AD_Column_ID="56561" Column="P_MixVariance_Acct">50006</Data>
+        <Data AD_Column_ID="56562" Column="P_FloorStock_Acct">50002</Data>
+        <Data AD_Column_ID="56559" Column="P_UsageVariance_Acct">50004</Data>
+        <Data AD_Column_ID="2562" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3418" Column="P_Revenue_Acct">229</Data>
+        <Data AD_Column_ID="6120" Column="P_TradeDiscountGrant_Acct">284</Data>
+        <Data AD_Column_ID="84964" Column="UUID">8e935846-5563-11e9-8eba-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="580" StepType="AD">
+      <PO AD_Table_ID="327" Action="I" Record_ID="101" Table="M_Product_Costing">
+        <Data AD_Column_ID="3629" Column="Created">2019-04-02 12:22:50.509</Data>
+        <Data AD_Column_ID="3633" Column="CostStandard" isNewNull="true"/>
+        <Data AD_Column_ID="3628" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3631" Column="Updated">2019-04-02 12:22:50.509</Data>
+        <Data AD_Column_ID="6708" Column="PriceLastPO" isNewNull="true"/>
+        <Data AD_Column_ID="6711" Column="TotalInvAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3634" Column="CostAverage" isNewNull="true"/>
+        <Data AD_Column_ID="6703" Column="CostStandardPOAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6704" Column="CostStandardCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="6709" Column="PriceLastInv" isNewNull="true"/>
+        <Data AD_Column_ID="6710" Column="TotalInvQty" isNewNull="true"/>
+        <Data AD_Column_ID="6702" Column="CostStandardPOQty" isNewNull="true"/>
+        <Data AD_Column_ID="6705" Column="CostStandardCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6706" Column="CostAverageCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="5125" Column="CurrentCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="5126" Column="FutureCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="6707" Column="CostAverageCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3626" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3627" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3632" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3630" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3625" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="3624" Column="M_Product_ID">50043</Data>
+        <Data AD_Column_ID="84970" Column="UUID">8f42387a-5563-11e9-8edd-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="590" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:22:51.421</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:22:51.421</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">100</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50043</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">8fcd8a92-5563-11e9-8ef7-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="600" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-02 12:22:52.428</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-02 12:22:52.428</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">50000</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50043</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">906734c6-5563-11e9-8f12-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="610" StepType="AD">
+      <PO AD_Table_ID="453" Action="I" Record_ID="50043" Table="AD_TreeNodePR">
+        <Data AD_Column_ID="84443" Column="UUID">911e2b5e-5563-11e9-8f2d-00ff97344bad</Data>
+        <Data AD_Column_ID="6170" Column="Updated">2019-04-02 12:22:53.628</Data>
+        <Data AD_Column_ID="6167" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6168" Column="Created">2019-04-02 12:22:53.628</Data>
+        <Data AD_Column_ID="6164" Column="Node_ID">50043</Data>
+        <Data AD_Column_ID="6174" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6172" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6165" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="6166" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6163" Column="AD_Tree_ID">102</Data>
+        <Data AD_Column_ID="6171" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6169" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="620" StepType="AD">
+      <PO AD_Table_ID="53018" Action="I" Record_ID="50007" Table="PP_Product_BOM">
+        <Data AD_Column_ID="53343" Column="BOMUse">M</Data>
+        <Data AD_Column_ID="85060" Column="UUID">9757bc60-5563-11e9-8e7e-00ff97344bad</Data>
+        <Data AD_Column_ID="53335" Column="Processing">false</Data>
+        <Data AD_Column_ID="53323" Column="DocumentNo">50000</Data>
+        <Data AD_Column_ID="53336" Column="Updated">2019-04-02 12:23:03.783</Data>
+        <Data AD_Column_ID="53327" Column="Created">2019-04-02 12:23:03.783</Data>
+        <Data AD_Column_ID="53330" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53331" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53342" Column="BOMType">A</Data>
+        <Data AD_Column_ID="53338" Column="ValidFrom">2019-04-02 00:00:00.0</Data>
+        <Data AD_Column_ID="53339" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53329" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53321" Column="Value">Kit-Starter</Data>
+        <Data AD_Column_ID="53322" Column="Name">Plant Starter Kit</Data>
+        <Data AD_Column_ID="81405" Column="IsDefault">true</Data>
+        <Data AD_Column_ID="53324" Column="Revision" isNewNull="true"/>
+        <Data AD_Column_ID="53325" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="53326" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="53332" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53334" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53341" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53344" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53337" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="53340" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53328" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53333" Column="M_Product_ID">50043</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="630" StepType="AD">
+      <PO AD_Table_ID="53191" Action="I" Record_ID="0" Table="PP_Product_BOM_Trl">
+        <Data AD_Column_ID="57221" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57217" Column="Created">2019-04-02 12:23:05.167</Data>
+        <Data AD_Column_ID="57225" Column="Updated">2019-04-02 12:23:05.167</Data>
+        <Data AD_Column_ID="57219" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57220" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57222" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57223" Column="Name">Plant Starter Kit</Data>
+        <Data AD_Column_ID="57214" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57216" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57215" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="57218" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57224" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="57226" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85063" Column="UUID">97ff4976-5563-11e9-8e9a-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="640" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50043" Table="M_Product">
+        <Data AD_Column_ID="4708" Column="IsBOM" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="650" StepType="AD">
+      <PO AD_Table_ID="53018" Action="U" Record_ID="50007" Table="PP_Product_BOM">
+        <Data AD_Column_ID="53343" Column="BOMUse" oldValue="M">A</Data>
+        <Data AD_Column_ID="53342" Column="BOMType" oldValue="A">C</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="660" StepType="AD">
+      <PO AD_Table_ID="53019" Action="I" Record_ID="50018" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53351" Column="Created">2019-04-02 12:24:23.923</Data>
+        <Data AD_Column_ID="53357" Column="IsCritical">false</Data>
+        <Data AD_Column_ID="53370" Column="Updated">2019-04-02 12:24:23.923</Data>
+        <Data AD_Column_ID="53356" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53372" Column="ValidFrom">2019-04-02 00:00:00.0</Data>
+        <Data AD_Column_ID="53350" Column="ComponentType">OP</Data>
+        <Data AD_Column_ID="53345" Column="Feature">Seed Tray</Data>
+        <Data AD_Column_ID="53347" Column="Assay">0</Data>
+        <Data AD_Column_ID="53353" Column="Description">A seed starter tray with 16 small pots</Data>
+        <Data AD_Column_ID="53355" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53348" Column="BackflushGroup" isNewNull="true"/>
+        <Data AD_Column_ID="53368" Column="QtyBatch">0</Data>
+        <Data AD_Column_ID="53354" Column="Forecast">0</Data>
+        <Data AD_Column_ID="53360" Column="LeadTimeOffset">0</Data>
+        <Data AD_Column_ID="53358" Column="IsQtyPercentage">false</Data>
+        <Data AD_Column_ID="53363" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53359" Column="IssueMethod">1</Data>
+        <Data AD_Column_ID="53374" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53367" Column="QtyBOM">0</Data>
+        <Data AD_Column_ID="58595" Column="CostAllocationPerc">0</Data>
+        <Data AD_Column_ID="53369" Column="Scrap">0</Data>
+        <Data AD_Column_ID="53346" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53365" Column="PP_Product_BOMLine_ID">50018</Data>
+        <Data AD_Column_ID="53361" Column="Line">10</Data>
+        <Data AD_Column_ID="53373" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53364" Column="M_Product_ID">50038</Data>
+        <Data AD_Column_ID="53366" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53362" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="53349" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53371" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85061" Column="UUID">c71ad860-5563-11e9-ad21-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="670" StepType="AD">
+      <PO AD_Table_ID="53193" Action="I" Record_ID="50018" Table="PP_Product_BOMLine_Trl">
+        <Data AD_Column_ID="57233" Column="Created">2019-04-02 12:24:25.229</Data>
+        <Data AD_Column_ID="57237" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57241" Column="Updated">2019-04-02 12:24:25.229</Data>
+        <Data AD_Column_ID="57235" Column="Description">A seed starter tray with 16 small pots</Data>
+        <Data AD_Column_ID="57236" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57238" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57230" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57232" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57234" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57240" Column="PP_Product_BOMLine_ID">50018</Data>
+        <Data AD_Column_ID="57242" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57231" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="85062" Column="UUID">c7b78fd4-5563-11e9-ad43-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="680" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50038" Table="M_Product">
+        <Data AD_Column_ID="53408" Column="LowLevel" oldValue="0">1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="690" StepType="AD">
+      <PO AD_Table_ID="53019" Action="I" Record_ID="50019" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53351" Column="Created">2019-04-02 12:24:47.671</Data>
+        <Data AD_Column_ID="53357" Column="IsCritical">false</Data>
+        <Data AD_Column_ID="53370" Column="Updated">2019-04-02 12:24:47.671</Data>
+        <Data AD_Column_ID="53356" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53372" Column="ValidFrom">2019-04-02 00:00:00.0</Data>
+        <Data AD_Column_ID="53350" Column="ComponentType">OP</Data>
+        <Data AD_Column_ID="53345" Column="Feature">Seed Tray</Data>
+        <Data AD_Column_ID="53347" Column="Assay">0</Data>
+        <Data AD_Column_ID="53353" Column="Description">A seed starter tray with 36 small pots</Data>
+        <Data AD_Column_ID="53355" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53348" Column="BackflushGroup" isNewNull="true"/>
+        <Data AD_Column_ID="53368" Column="QtyBatch">0</Data>
+        <Data AD_Column_ID="53354" Column="Forecast">0</Data>
+        <Data AD_Column_ID="53360" Column="LeadTimeOffset">0</Data>
+        <Data AD_Column_ID="53358" Column="IsQtyPercentage">false</Data>
+        <Data AD_Column_ID="53363" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53359" Column="IssueMethod">1</Data>
+        <Data AD_Column_ID="53374" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53367" Column="QtyBOM">0</Data>
+        <Data AD_Column_ID="58595" Column="CostAllocationPerc">0</Data>
+        <Data AD_Column_ID="53369" Column="Scrap">0</Data>
+        <Data AD_Column_ID="53346" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53365" Column="PP_Product_BOMLine_ID">50019</Data>
+        <Data AD_Column_ID="53361" Column="Line">20</Data>
+        <Data AD_Column_ID="53373" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53364" Column="M_Product_ID">50039</Data>
+        <Data AD_Column_ID="53366" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53362" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="53349" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53371" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85061" Column="UUID">d53d8578-5563-11e9-ad54-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="700" StepType="AD">
+      <PO AD_Table_ID="53193" Action="I" Record_ID="50019" Table="PP_Product_BOMLine_Trl">
+        <Data AD_Column_ID="57233" Column="Created">2019-04-02 12:24:49.017</Data>
+        <Data AD_Column_ID="57237" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57241" Column="Updated">2019-04-02 12:24:49.017</Data>
+        <Data AD_Column_ID="57235" Column="Description">A seed starter tray with 36 small pots</Data>
+        <Data AD_Column_ID="57236" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57238" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57230" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57232" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57234" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57240" Column="PP_Product_BOMLine_ID">50019</Data>
+        <Data AD_Column_ID="57242" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57231" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="85062" Column="UUID">d5e4eb7e-5563-11e9-ad76-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="710" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50039" Table="M_Product">
+        <Data AD_Column_ID="53408" Column="LowLevel" oldValue="0">1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="720" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50019" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53350" Column="ComponentType" oldValue="OP">VA</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="730" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50018" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53350" Column="ComponentType" oldValue="OP">VA</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="740" StepType="AD">
+      <PO AD_Table_ID="53019" Action="I" Record_ID="50020" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53351" Column="Created">2019-04-02 12:25:44.385</Data>
+        <Data AD_Column_ID="53357" Column="IsCritical">false</Data>
+        <Data AD_Column_ID="53370" Column="Updated">2019-04-02 12:25:44.385</Data>
+        <Data AD_Column_ID="53356" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53372" Column="ValidFrom">2019-04-02 00:00:00.0</Data>
+        <Data AD_Column_ID="53350" Column="ComponentType">OP</Data>
+        <Data AD_Column_ID="53345" Column="Feature">Soil</Data>
+        <Data AD_Column_ID="53347" Column="Assay">0</Data>
+        <Data AD_Column_ID="53353" Column="Description">10# Bag of Mulch</Data>
+        <Data AD_Column_ID="53355" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53348" Column="BackflushGroup" isNewNull="true"/>
+        <Data AD_Column_ID="53368" Column="QtyBatch">0</Data>
+        <Data AD_Column_ID="53354" Column="Forecast">0</Data>
+        <Data AD_Column_ID="53360" Column="LeadTimeOffset">0</Data>
+        <Data AD_Column_ID="53358" Column="IsQtyPercentage">false</Data>
+        <Data AD_Column_ID="53363" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53359" Column="IssueMethod">1</Data>
+        <Data AD_Column_ID="53374" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53367" Column="QtyBOM">0</Data>
+        <Data AD_Column_ID="58595" Column="CostAllocationPerc">0</Data>
+        <Data AD_Column_ID="53369" Column="Scrap">0</Data>
+        <Data AD_Column_ID="53346" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53365" Column="PP_Product_BOMLine_ID">50020</Data>
+        <Data AD_Column_ID="53361" Column="Line">30</Data>
+        <Data AD_Column_ID="53373" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53364" Column="M_Product_ID">137</Data>
+        <Data AD_Column_ID="53366" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53362" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="53349" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53371" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85061" Column="UUID">f70e7aea-5563-11e9-ad87-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="750" StepType="AD">
+      <PO AD_Table_ID="53193" Action="I" Record_ID="50020" Table="PP_Product_BOMLine_Trl">
+        <Data AD_Column_ID="57233" Column="Created">2019-04-02 12:25:45.783</Data>
+        <Data AD_Column_ID="57237" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57241" Column="Updated">2019-04-02 12:25:45.783</Data>
+        <Data AD_Column_ID="57235" Column="Description">10# Bag of Mulch</Data>
+        <Data AD_Column_ID="57236" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57238" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57230" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57232" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57234" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57240" Column="PP_Product_BOMLine_ID">50020</Data>
+        <Data AD_Column_ID="57242" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57231" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="85062" Column="UUID">f7bb1124-5563-11e9-ada9-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="760" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="137" Table="M_Product">
+        <Data AD_Column_ID="53408" Column="LowLevel" oldValue="0">1</Data>
+        <Data AD_Column_ID="84959" Column="UUID" isOldNull="true">f846633c-5563-11e9-adb8-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="770" StepType="AD">
+      <PO AD_Table_ID="53019" Action="I" Record_ID="50021" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53351" Column="Created">2019-04-02 12:26:06.487</Data>
+        <Data AD_Column_ID="53357" Column="IsCritical">false</Data>
+        <Data AD_Column_ID="53370" Column="Updated">2019-04-02 12:26:06.487</Data>
+        <Data AD_Column_ID="53356" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53372" Column="ValidFrom">2019-04-02 00:00:00.0</Data>
+        <Data AD_Column_ID="53350" Column="ComponentType">OP</Data>
+        <Data AD_Column_ID="53345" Column="Feature">Soil</Data>
+        <Data AD_Column_ID="53347" Column="Assay">0</Data>
+        <Data AD_Column_ID="53353" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="53355" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53348" Column="BackflushGroup" isNewNull="true"/>
+        <Data AD_Column_ID="53368" Column="QtyBatch">0</Data>
+        <Data AD_Column_ID="53354" Column="Forecast">0</Data>
+        <Data AD_Column_ID="53360" Column="LeadTimeOffset">0</Data>
+        <Data AD_Column_ID="53358" Column="IsQtyPercentage">false</Data>
+        <Data AD_Column_ID="53363" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53359" Column="IssueMethod">1</Data>
+        <Data AD_Column_ID="53374" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53367" Column="QtyBOM">0</Data>
+        <Data AD_Column_ID="58595" Column="CostAllocationPerc">0</Data>
+        <Data AD_Column_ID="53369" Column="Scrap">0</Data>
+        <Data AD_Column_ID="53346" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53365" Column="PP_Product_BOMLine_ID">50021</Data>
+        <Data AD_Column_ID="53361" Column="Line">40</Data>
+        <Data AD_Column_ID="53373" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53364" Column="M_Product_ID">50041</Data>
+        <Data AD_Column_ID="53366" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53362" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="53349" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53371" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85061" Column="UUID">043c1614-5564-11e9-adbc-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="780" StepType="AD">
+      <PO AD_Table_ID="53193" Action="I" Record_ID="50021" Table="PP_Product_BOMLine_Trl">
+        <Data AD_Column_ID="57233" Column="Created">2019-04-02 12:26:08.192</Data>
+        <Data AD_Column_ID="57237" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57241" Column="Updated">2019-04-02 12:26:08.192</Data>
+        <Data AD_Column_ID="57235" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57236" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57238" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57230" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57232" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57234" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57240" Column="PP_Product_BOMLine_ID">50021</Data>
+        <Data AD_Column_ID="57242" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57231" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="85062" Column="UUID">0516258e-5564-11e9-adde-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="790" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50041" Table="M_Product">
+        <Data AD_Column_ID="53408" Column="LowLevel" oldValue="0">1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="800" StepType="AD">
+      <PO AD_Table_ID="53019" Action="I" Record_ID="50022" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53351" Column="Created">2019-04-02 12:26:22.312</Data>
+        <Data AD_Column_ID="53357" Column="IsCritical">false</Data>
+        <Data AD_Column_ID="53370" Column="Updated">2019-04-02 12:26:22.312</Data>
+        <Data AD_Column_ID="53356" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53372" Column="ValidFrom">2019-04-02 00:00:00.0</Data>
+        <Data AD_Column_ID="53350" Column="ComponentType">OP</Data>
+        <Data AD_Column_ID="53345" Column="Feature">Soil</Data>
+        <Data AD_Column_ID="53347" Column="Assay">0</Data>
+        <Data AD_Column_ID="53353" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="53355" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53348" Column="BackflushGroup" isNewNull="true"/>
+        <Data AD_Column_ID="53368" Column="QtyBatch">0</Data>
+        <Data AD_Column_ID="53354" Column="Forecast">0</Data>
+        <Data AD_Column_ID="53360" Column="LeadTimeOffset">0</Data>
+        <Data AD_Column_ID="53358" Column="IsQtyPercentage">false</Data>
+        <Data AD_Column_ID="53363" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53359" Column="IssueMethod">1</Data>
+        <Data AD_Column_ID="53374" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53367" Column="QtyBOM">0</Data>
+        <Data AD_Column_ID="58595" Column="CostAllocationPerc">0</Data>
+        <Data AD_Column_ID="53369" Column="Scrap">0</Data>
+        <Data AD_Column_ID="53346" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53365" Column="PP_Product_BOMLine_ID">50022</Data>
+        <Data AD_Column_ID="53361" Column="Line">50</Data>
+        <Data AD_Column_ID="53373" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53364" Column="M_Product_ID">50042</Data>
+        <Data AD_Column_ID="53366" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53362" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="53349" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53371" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85061" Column="UUID">0db1f27c-5564-11e9-adef-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="810" StepType="AD">
+      <PO AD_Table_ID="53193" Action="I" Record_ID="50022" Table="PP_Product_BOMLine_Trl">
+        <Data AD_Column_ID="57233" Column="Created">2019-04-02 12:26:23.928</Data>
+        <Data AD_Column_ID="57237" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57241" Column="Updated">2019-04-02 12:26:23.928</Data>
+        <Data AD_Column_ID="57235" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57236" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57238" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57230" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57232" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57234" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57240" Column="PP_Product_BOMLine_ID">50022</Data>
+        <Data AD_Column_ID="57242" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57231" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="85062" Column="UUID">0e774130-5564-11e9-ae11-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="820" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50042" Table="M_Product">
+        <Data AD_Column_ID="53408" Column="LowLevel" oldValue="0">1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="830" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50039" Table="M_Product">
+        <Data AD_Column_ID="1410" Column="Name" oldValue="Seedling Tray - 36 bins">Seedling Tray - 32 bins</Data>
+        <Data AD_Column_ID="1411" Column="Description" oldValue="A seed starter tray with 36 small pots">A seed starter tray with 32 small pots</Data>
+        <Data AD_Column_ID="2011" Column="Value" oldValue="SeedTray-36">SeedTray-32</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="840" StepType="AD">
+      <PO AD_Table_ID="312" Action="U" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="13008" Column="Description" oldValue="A seed starter tray with 36 small pots">A seed starter tray with 32 small pots</Data>
+        <Data AD_Column_ID="3330" Column="Name" oldValue="Seedling Tray - 36 bins">Seedling Tray - 32 bins</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="3322" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID" oldValue="50039">50039</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="850" StepType="AD">
+      <PO AD_Table_ID="251" Action="I" Record_ID="50039" Table="M_ProductPrice">
+        <Data AD_Column_ID="2059" Column="Created">2019-04-08 09:47:39.103</Data>
+        <Data AD_Column_ID="2058" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2061" Column="Updated">2019-04-08 09:47:39.103</Data>
+        <Data AD_Column_ID="2064" Column="M_Product_ID">50039</Data>
+        <Data AD_Column_ID="3028" Column="PriceStd">5.500000000000</Data>
+        <Data AD_Column_ID="3029" Column="PriceLimit">5.500000000000</Data>
+        <Data AD_Column_ID="3027" Column="PriceList">5.500000000000</Data>
+        <Data AD_Column_ID="2056" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2057" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2062" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2760" Column="M_PriceList_Version_ID">104</Data>
+        <Data AD_Column_ID="2060" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84962" Column="UUID">dfb6f926-5a04-11e9-bcd7-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="860" StepType="AD">
+      <PO AD_Table_ID="251" Action="I" Record_ID="50038" Table="M_ProductPrice">
+        <Data AD_Column_ID="2059" Column="Created">2019-04-08 09:48:07.152</Data>
+        <Data AD_Column_ID="2058" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2061" Column="Updated">2019-04-08 09:48:07.152</Data>
+        <Data AD_Column_ID="2064" Column="M_Product_ID">50038</Data>
+        <Data AD_Column_ID="3028" Column="PriceStd">3.000000000000</Data>
+        <Data AD_Column_ID="3029" Column="PriceLimit">3.000000000000</Data>
+        <Data AD_Column_ID="3027" Column="PriceList">3.000000000000</Data>
+        <Data AD_Column_ID="2056" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2057" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2062" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2760" Column="M_PriceList_Version_ID">104</Data>
+        <Data AD_Column_ID="2060" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84962" Column="UUID">f06c7a34-5a04-11e9-a064-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="870" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50041" Table="M_Product">
+        <Data AD_Column_ID="1411" Column="Description" isOldNull="true">Peat potting material</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="880" StepType="AD">
+      <PO AD_Table_ID="312" Action="U" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="13008" Column="Description" isOldNull="true">Peat potting material</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID" oldValue="50041">50041</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="890" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50041" Table="M_Product">
+        <Data AD_Column_ID="1411" Column="Description" oldValue="Peat potting material">Peat potting material, 1 Kg bag.</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="900" StepType="AD">
+      <PO AD_Table_ID="312" Action="U" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="13008" Column="Description" oldValue="Peat potting material">Peat potting material, 1 Kg bag.</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true" isOldNull="true"/>
+        <Data AD_Column_ID="3322" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID" oldValue="50041">50041</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="910" StepType="AD">
+      <PO AD_Table_ID="251" Action="I" Record_ID="50041" Table="M_ProductPrice">
+        <Data AD_Column_ID="2059" Column="Created">2019-04-08 09:49:52.083</Data>
+        <Data AD_Column_ID="2058" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2061" Column="Updated">2019-04-08 09:49:52.083</Data>
+        <Data AD_Column_ID="2064" Column="M_Product_ID">50041</Data>
+        <Data AD_Column_ID="3028" Column="PriceStd">4.500000000000</Data>
+        <Data AD_Column_ID="3029" Column="PriceLimit">4.500000000000</Data>
+        <Data AD_Column_ID="3027" Column="PriceList">4.500000000000</Data>
+        <Data AD_Column_ID="2056" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2057" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2062" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2760" Column="M_PriceList_Version_ID">104</Data>
+        <Data AD_Column_ID="2060" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84962" Column="UUID">2ef7b4a8-5a05-11e9-a020-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="920" StepType="AD">
+      <PO AD_Table_ID="251" Action="I" Record_ID="50042" Table="M_ProductPrice">
+        <Data AD_Column_ID="2059" Column="Created">2019-04-08 09:50:45.458</Data>
+        <Data AD_Column_ID="2058" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2061" Column="Updated">2019-04-08 09:50:45.458</Data>
+        <Data AD_Column_ID="2064" Column="M_Product_ID">50042</Data>
+        <Data AD_Column_ID="3028" Column="PriceStd">3.500000000000</Data>
+        <Data AD_Column_ID="3029" Column="PriceLimit">3.500000000000</Data>
+        <Data AD_Column_ID="3027" Column="PriceList">3.500000000000</Data>
+        <Data AD_Column_ID="2056" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2057" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2062" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2760" Column="M_PriceList_Version_ID">104</Data>
+        <Data AD_Column_ID="2060" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84962" Column="UUID">4ec830dc-5a05-11e9-a02f-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="930" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53618" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-04-14 10:25:19.569</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Select Bill Of Materials</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-04-14 10:25:19.569</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">BOMDropForm_SelectBOM</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53618</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID">21d73cce-5ec1-11e9-98c5-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="940" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-04-14 10:25:23.986</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-04-14 10:25:23.986</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Select Bill Of Materials</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53618</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID">242972da-5ec1-11e9-98d6-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="950" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53618">53618</Data>
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="Select Bill Of Materials">Seleccionar lista de materiales</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="960" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53619" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-04-14 10:33:38.302</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Select Products</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-04-14 10:33:38.302</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">BOMDropForm_SelectProducts</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53619</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID">4afc7fd2-5ec2-11e9-98e5-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="970" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-04-14 10:33:39.76</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-04-14 10:33:39.76</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Select Products</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53619</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID">4baa4e8c-5ec2-11e9-98f6-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="980" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="Select Products">Seleccionar productos</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53619">53619</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="990" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53620" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-04-14 10:34:47.225</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Click to open</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-04-14 10:34:47.225</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">BOMDropForm_ClickToOpen</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53620</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID">7413e658-5ec2-11e9-b495-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1000" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-04-14 10:34:48.57</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-04-14 10:34:48.57</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Click to open</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53620</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID">74adb79c-5ec2-11e9-b4a6-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1010" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="Click to open">Haga clic para abrir</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53620">53620</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1020" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53621" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-04-14 10:36:03.154</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Nothing selected</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-04-14 10:36:03.154</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">BOMDropController_NothingSelected</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53621</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID">a14fb1ba-5ec2-11e9-8590-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1030" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-04-14 10:36:04.357</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-04-14 10:36:04.357</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Nothing selected</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53621</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID">a1d9f258-5ec2-11e9-85a1-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1040" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="Nothing selected">Nada seleccionado</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53621">53621</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1050" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53622" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-04-14 10:37:44.593</Data>
+        <Data AD_Column_ID="198" Column="MsgText">item selected</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-04-14 10:37:44.593</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">BOMDropController_ItemSelectedSingular</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53622</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID">de2b80fa-5ec2-11e9-990f-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1060" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-04-14 10:37:47.008</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-04-14 10:37:47.008</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">item selected</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53622</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID">df0912f8-5ec2-11e9-9920-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1070" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="item selected">elemento seleccionado</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53622">53622</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1080" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53623" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-04-14 10:38:49.945</Data>
+        <Data AD_Column_ID="198" Column="MsgText">items selected</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-04-14 10:38:49.945</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">BOMDropController_ItemSelectedPlural</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53623</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID">04b68dbe-5ec3-11e9-b4b5-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1090" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-04-14 10:38:51.319</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-04-14 10:38:51.319</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">items selected</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53623</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID">055e68f4-5ec3-11e9-b4c6-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1100" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="items selected">elementos seleccionados</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53623">53623</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1110" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53624" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-04-14 10:42:13.833</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Explode BOM</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-04-14 10:42:13.833</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">BOMDropController_ExplodeBOM</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53624</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID">7e445c88-5ec3-11e9-b4da-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1120" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-04-14 10:42:15.176</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-04-14 10:42:15.176</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Explode BOM</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53624</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID">7ee077bc-5ec3-11e9-b4eb-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1130" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="Explode BOM">Explotar lista de materiales</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53624">53624</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1140" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53625" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-04-14 10:46:17.497</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Explode BOM</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-04-14 10:46:17.497</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">BOMDropController_ExplodeBOMTooltip</Data>
+        <Data AD_Column_ID="199" Column="MsgTip">Explode (expand) the Bill of Materials to show lower-level items.</Data>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">D</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53625</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84346" Column="UUID">0f817172-5ec4-11e9-9e4b-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1150" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-04-14 10:46:18.881</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-04-14 10:46:18.881</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Explode BOM</Data>
+        <Data AD_Column_ID="343" Column="MsgTip">Explode (expand) the Bill of Materials to show lower-level items.</Data>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53625</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84347" Column="UUID">1022bcda-5ec4-11e9-9e5c-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1160" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="343" Column="MsgTip" oldValue="Explode (expand) the Bill of Materials to show lower-level items.">Explote (expanda) la Lista de materiales para mostrar los elementos de nivel m&amp;#xE1;s bajo. Esto solo es relevante si la lista de materiales seleccionada tiene varios niveles.</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="Explode BOM">Explotar lista de materiales</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53625">53625</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1170" StepType="AD">
+      <PO AD_Table_ID="109" Action="U" Record_ID="53625" Table="AD_Message">
+        <Data AD_Column_ID="199" Column="MsgTip" oldValue="Explode (expand) the Bill of Materials to show lower-level items.">Explode (expand) the Bill of Materials to show the lowest-level items. This is only relevant if the selected BOM has multiple levels.</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1180" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="0" Table="AD_Message_Trl">
+        <Data AD_Column_ID="344" Column="IsTranslated" oldValue="true">false</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53625">53625</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1190" StepType="AD">
+      <PO AD_Table_ID="101" Action="I" Record_ID="92953" Table="AD_Column">
+        <Data AD_Column_ID="112" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="548" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90939" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="549" Column="Created">2019-04-15 19:09:18.526</Data>
+        <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="551" Column="Updated">2019-04-15 19:09:18.526</Data>
+        <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="109" Column="AD_Column_ID">92953</Data>
+        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="111" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="120" Column="IsParent">false</Data>
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
+        <Data AD_Column_ID="6483" Column="IsSyncDatabase">N</Data>
+        <Data AD_Column_ID="119" Column="IsKey">false</Data>
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="56352" Column="FormatPattern" isNewNull="true"/>
+        <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
+        <Data AD_Column_ID="110" Column="Version">0</Data>
+        <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
+        <Data AD_Column_ID="116" Column="ColumnName">BOMDrop</Data>
+        <Data AD_Column_ID="113" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="3360" Column="IsUpdateable">true</Data>
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="11617" Column="IsAlwaysUpdateable">false</Data>
+        <Data AD_Column_ID="128" Column="IsEncrypted">N</Data>
+        <Data AD_Column_ID="54358" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="56187" Column="IsAllowLogging">true</Data>
+        <Data AD_Column_ID="56149" Column="IsAutocomplete">false</Data>
+        <Data AD_Column_ID="68024" Column="IsRange">false</Data>
+        <Data AD_Column_ID="62199" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="127" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="6482" Column="EntityType">D</Data>
+        <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">318</Data>
+        <Data AD_Column_ID="550" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="2608" Column="AD_Element_ID">60953</Data>
+        <Data AD_Column_ID="227" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="115" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="118" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="226" Column="AD_Reference_ID">28</Data>
+        <Data AD_Column_ID="552" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84306" Column="UUID">7f483a30-5fd3-11e9-9323-00ff97344bad</Data>
+        <Data AD_Column_ID="3369" Column="AD_Process_ID">54214</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1200" StepType="AD">
+      <PO AD_Table_ID="752" Action="I" Record_ID="92953" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12960" Column="Created">2019-04-15 19:09:20.832</Data>
+        <Data AD_Column_ID="12959" Column="IsActive">true</Data>
+        <Data AD_Column_ID="12952" Column="Updated">2019-04-15 19:09:20.832</Data>
+        <Data AD_Column_ID="12955" Column="AD_Column_ID">92953</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="12957" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="12958" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="12956" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84310" Column="UUID">8065471e-5fd3-11e9-9359-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1210" StepType="AD">
+      <PO AD_Table_ID="752" Action="U" Record_ID="92953" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12955" Column="AD_Column_ID" oldValue="92953">92953</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="12957" Column="Name" oldValue="BOM Drop">Expansi&amp;oacute;n LDM</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1220" StepType="AD">
+      <PO AD_Table_ID="101" Action="I" Record_ID="92954" Table="AD_Column">
+        <Data AD_Column_ID="112" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="548" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90939" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="549" Column="Created">2019-04-15 19:14:06.646</Data>
+        <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="551" Column="Updated">2019-04-15 19:14:06.646</Data>
+        <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="109" Column="AD_Column_ID">92954</Data>
+        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="111" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="120" Column="IsParent">false</Data>
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
+        <Data AD_Column_ID="6483" Column="IsSyncDatabase">N</Data>
+        <Data AD_Column_ID="119" Column="IsKey">false</Data>
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="56352" Column="FormatPattern" isNewNull="true"/>
+        <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
+        <Data AD_Column_ID="110" Column="Version">0</Data>
+        <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
+        <Data AD_Column_ID="116" Column="ColumnName">BOMDrop</Data>
+        <Data AD_Column_ID="113" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="3360" Column="IsUpdateable">true</Data>
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="11617" Column="IsAlwaysUpdateable">false</Data>
+        <Data AD_Column_ID="128" Column="IsEncrypted">N</Data>
+        <Data AD_Column_ID="54358" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="56187" Column="IsAllowLogging">true</Data>
+        <Data AD_Column_ID="56149" Column="IsAutocomplete">false</Data>
+        <Data AD_Column_ID="68024" Column="IsRange">false</Data>
+        <Data AD_Column_ID="62199" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="127" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="6482" Column="EntityType">D</Data>
+        <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">203</Data>
+        <Data AD_Column_ID="550" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="2608" Column="AD_Element_ID">60953</Data>
+        <Data AD_Column_ID="227" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="115" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="118" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="226" Column="AD_Reference_ID">28</Data>
+        <Data AD_Column_ID="552" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="84306" Column="UUID">2aee8f60-5fd4-11e9-9367-00ff97344bad</Data>
+        <Data AD_Column_ID="3369" Column="AD_Process_ID">54214</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1230" StepType="AD">
+      <PO AD_Table_ID="752" Action="I" Record_ID="92954" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12960" Column="Created">2019-04-15 19:14:08.435</Data>
+        <Data AD_Column_ID="12959" Column="IsActive">true</Data>
+        <Data AD_Column_ID="12952" Column="Updated">2019-04-15 19:14:08.435</Data>
+        <Data AD_Column_ID="12955" Column="AD_Column_ID">92954</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="12957" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="12958" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="12956" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84310" Column="UUID">2bd178a2-5fd4-11e9-939d-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1240" StepType="AD">
+      <PO AD_Table_ID="752" Action="U" Record_ID="92954" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12955" Column="AD_Column_ID" oldValue="92954">92954</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated" oldValue="false">true</Data>
+        <Data AD_Column_ID="12957" Column="Name" oldValue="BOM Drop">Expansi&amp;oacute;n LDM</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1250" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93650" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:16:28.474</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:16:28.474</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93650</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">92893</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">1</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">294</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">7f79088a-5fd4-11e9-9657-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1260" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93650" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:16:30.185</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:16:30.185</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="286" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="288" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93650</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">804ed23a-5fd4-11e9-9686-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1270" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93651" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:16:31.188</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:16:31.188</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93651</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">84683</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">36</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">294</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">8112c154-5fd4-11e9-9696-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1280" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93651" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:16:32.695</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:16:32.695</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="286" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="288" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93651</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">81cdfdc0-5fd4-11e9-96c5-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1290" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93652" Table="AD_Field">
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="168" Column="Name">Order Source</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:16:33.772</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:16:33.773</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93652</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">58409</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="180" Column="DisplayLength">10</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">294</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">833274fc-5fd4-11e9-96d5-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1300" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93652" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:16:36.37</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:16:36.37</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="286" Column="Name">Order Source</Data>
+        <Data AD_Column_ID="288" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93652</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">83fea194-5fd4-11e9-9704-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1310" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93653" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">Processed On</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:16:37.346</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:16:37.346</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">The date+time (expressed in decimal format) when the document has been processed</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">The ProcessedOn Date+Time save the exact moment (nanoseconds precision if allowed by the DB) when a document has been processed.</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93653</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">59038</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">20</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">294</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">84c3c938-5fd4-11e9-9714-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1320" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93653" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:16:39.067</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:16:39.067</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">The date+time (expressed in decimal format) when the document has been processed</Data>
+        <Data AD_Column_ID="286" Column="Name">Processed On</Data>
+        <Data AD_Column_ID="288" Column="Help">The ProcessedOn Date+Time save the exact moment (nanoseconds precision if allowed by the DB) when a document has been processed.</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93653</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">859a2f32-5fd4-11e9-9743-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1330" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93654" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">Sales Opportunity</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:16:39.88</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:16:39.88</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93654</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">62180</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">10</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">294</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">8659ff92-5fd4-11e9-9753-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1340" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93654" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:16:41.509</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:16:41.509</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="286" Column="Name">Sales Opportunity</Data>
+        <Data AD_Column_ID="288" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93654</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">870eac30-5fd4-11e9-9782-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1350" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93652" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="0">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1360" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93653" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="0">20</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1370" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93654" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="0">30</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1380" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3422" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="10">40</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1390" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3453" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="20">50</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1400" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3424" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="30">60</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1410" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3455" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="40">70</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1420" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3429" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="50">80</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1430" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3428" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="60">90</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1440" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3435" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="70">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1450" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3436" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="80">110</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1460" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3419" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="90">120</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1470" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6505" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="100">130</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1480" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3458" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="110">140</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1490" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6507" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="120">150</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1500" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3452" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="130">160</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1510" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6504" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="140">170</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1520" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3451" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="150">180</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1530" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="10123" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="160">190</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1540" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="55413" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="170">200</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1550" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="55414" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="180">210</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1560" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="55415" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="190">220</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1570" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3444" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="200">230</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1580" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3447" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="210">240</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1590" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3464" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="220">250</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1600" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3443" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="230">260</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1610" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3448" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="240">270</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1620" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3420" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="250">280</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1630" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3441" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="260">290</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1640" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="8652" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="270">300</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1650" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3438" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="280">310</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1660" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3467" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="290">320</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1670" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3456" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="300">330</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1680" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3454" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="310">340</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1690" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3466" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="320">350</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1700" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3439" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="330">360</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1710" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3459" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="340">370</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1720" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3457" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="350">380</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1730" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3446" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="360">390</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1740" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="7039" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="370">400</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1750" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="7824" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="380">410</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1760" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="7823" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="390">420</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1770" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="58210" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="400">430</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1780" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="58211" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="410">440</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1790" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3425" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="420">450</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1800" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3427" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="430">460</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1810" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3449" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="440">470</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1820" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3450" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="450">480</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1830" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6506" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="460">490</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1840" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93650" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="0">500</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1850" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3426" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="470">510</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1860" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3671" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="480">520</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1870" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93650" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="500">490</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1880" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6506" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="490">500</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1890" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93655" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:19:59.768</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:19:59.768</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93655</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">92953</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">1</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">263</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">fd649c78-5fd4-11e9-940a-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1900" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93655" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:20:01.17</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:20:01.17</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="286" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="288" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93655</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">fe10bd78-5fd4-11e9-9439-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1910" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93655" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="0">380</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1920" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6564" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="380">390</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1930" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="2777" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="390">400</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1940" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3663" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="400">410</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1950" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3899" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="410">420</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1960" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="13700" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="420">430</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1970" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="53257" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="430">440</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1980" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="53258" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="440">450</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1990" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6564" Table="AD_Field">
+        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2000" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="2777" Table="AD_Field">
+        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2010" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3663" Table="AD_Field">
+        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2020" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93655" Table="AD_Field">
+        <Data AD_Column_ID="177" Column="DisplayLogic" isOldNull="true">@DocStatus@=DR | @DocStatus@=PR</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2030" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93656" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:24:33.767</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:24:33.767</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93656</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">92953</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">1</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">290</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">a0b6b618-5fd5-11e9-97b4-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2040" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93656" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:24:35.23</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:24:35.23</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="286" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="288" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93656</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">a16ac680-5fd5-11e9-97e3-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2050" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93657" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:24:35.977</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:24:35.977</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93657</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">84667</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">36</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">290</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">a20fbb72-5fd5-11e9-97f3-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2060" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93657" Table="AD_Field_Trl">
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:24:37.471</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:24:37.471</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="286" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="288" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93657</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">a2c0be90-5fd5-11e9-9822-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2070" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93658" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">POS Terminal</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:24:38.243</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:24:38.243</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Point of Sales Terminal</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">The POS Terminal defines the defaults and functions available for the POS Form</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93658</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">79168</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">10</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">290</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">a3608358-5fd5-11e9-9832-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2080" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93658" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:24:39.833</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:24:39.833</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Point of Sales Terminal</Data>
+        <Data AD_Column_ID="286" Column="Name">POS Terminal</Data>
+        <Data AD_Column_ID="288" Column="Help">The POS Terminal defines the defaults and functions available for the POS Form</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93658</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">a4292d76-5fd5-11e9-9861-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2090" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93659" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">Processed On</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:24:40.705</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:24:40.705</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">The date+time (expressed in decimal format) when the document has been processed</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">The ProcessedOn Date+Time save the exact moment (nanoseconds precision if allowed by the DB) when a document has been processed.</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93659</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">59037</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">20</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">290</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">a4d80daa-5fd5-11e9-9871-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2100" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93659" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:24:42.15</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:24:42.15</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">The date+time (expressed in decimal format) when the document has been processed</Data>
+        <Data AD_Column_ID="286" Column="Name">Processed On</Data>
+        <Data AD_Column_ID="288" Column="Help">The ProcessedOn Date+Time save the exact moment (nanoseconds precision if allowed by the DB) when a document has been processed.</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93659</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">a58abe6e-5fd5-11e9-98a0-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2110" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93658" Table="AD_Field">
+        <Data AD_Column_ID="176" Column="IsDisplayed" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2120" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93659" Table="AD_Field">
+        <Data AD_Column_ID="176" Column="IsDisplayed" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2130" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93656" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="0">390</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2140" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6532" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="390">400</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2150" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="200048" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="400">410</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2160" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3334" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="400">420</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2170" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3670" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="410">430</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2180" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="3900" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="420">440</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2190" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="6532" Table="AD_Field">
+        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2200" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93656" Table="AD_Field">
+        <Data AD_Column_ID="177" Column="DisplayLogic" isOldNull="true">@DocStatus@=DR | @DocStatus@=PR</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2210" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="93660" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2019-04-15 19:28:05.836</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2019-04-15 19:28:05.836</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth" isNewNull="true"/>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">93660</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">EE09</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">92954</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">1</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">54375</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">1f1de47c-5fd6-11e9-98ca-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2220" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="93660" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2019-04-15 19:28:07.265</Data>
+        <Data AD_Column_ID="674" Column="Updated">2019-04-15 19:28:07.265</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Drop (expand) Bill of Materials into an Order, Invoice, etc.</Data>
+        <Data AD_Column_ID="286" Column="Name">BOM Drop</Data>
+        <Data AD_Column_ID="288" Column="Help">Drop the extended Bill of Materials into an Order, Invoice, etc.  The documents need to be in a Drafted stage.  Make sure that the items included in the BOM are on the price list of the Order, Invoice, etc. as otherwise the price will be zero!</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">93660</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">1fccc4a6-5fd6-11e9-98f9-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2230" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93660" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="0">540</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2240" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="83248" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="540">550</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2250" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="83249" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="550">560</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2260" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="93660" Table="AD_Field">
+        <Data AD_Column_ID="177" Column="DisplayLogic" isOldNull="true">@DocStatus@=DR | @DocStatus@=PR</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2270" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="83248" Table="AD_Field">
+        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2280" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="83249" Table="AD_Field">
+        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2290" StepType="AD">
+      <PO AD_Table_ID="208" Action="I" Record_ID="50044" Table="M_Product">
+        <Data AD_Column_ID="1767" Column="Weight">0</Data>
+        <Data AD_Column_ID="1405" Column="IsActive">true</Data>
+        <Data AD_Column_ID="1406" Column="Created">2019-04-15 19:33:38.937</Data>
+        <Data AD_Column_ID="3014" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="1408" Column="Updated">2019-04-15 19:33:38.937</Data>
+        <Data AD_Column_ID="2704" Column="DiscontinuedAt" isNewNull="true"/>
+        <Data AD_Column_ID="85500" Column="C_TaxType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7963" Column="DescriptionURL" isNewNull="true"/>
+        <Data AD_Column_ID="10261" Column="IsSelfService">true</Data>
+        <Data AD_Column_ID="4712" Column="Processing">false</Data>
+        <Data AD_Column_ID="14505" Column="IsExcludeAutoDelivery">false</Data>
+        <Data AD_Column_ID="61997" Column="IsManufactured">false</Data>
+        <Data AD_Column_ID="61996" Column="IsKanban">false</Data>
+        <Data AD_Column_ID="2305" Column="SKU" isNewNull="true"/>
+        <Data AD_Column_ID="7973" Column="VersionNo" isNewNull="true"/>
+        <Data AD_Column_ID="3015" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1413" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="1411" Column="Description">Part of the Seed Starter Kit</Data>
+        <Data AD_Column_ID="1766" Column="Volume">0</Data>
+        <Data AD_Column_ID="1410" Column="Name">Grow Light and Stand</Data>
+        <Data AD_Column_ID="61995" Column="M_PartType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2308" Column="ShelfHeight">0</Data>
+        <Data AD_Column_ID="2304" Column="UPC" isNewNull="true"/>
+        <Data AD_Column_ID="4709" Column="IsInvoicePrintDetails">false</Data>
+        <Data AD_Column_ID="4711" Column="IsVerified">false</Data>
+        <Data AD_Column_ID="7962" Column="ImageURL" isNewNull="true"/>
+        <Data AD_Column_ID="7795" Column="ProductType">I</Data>
+        <Data AD_Column_ID="10260" Column="IsWebStoreFeatured">false</Data>
+        <Data AD_Column_ID="4708" Column="IsBOM">false</Data>
+        <Data AD_Column_ID="68433" Column="IsPhantom">false</Data>
+        <Data AD_Column_ID="68432" Column="IsToFormule">false</Data>
+        <Data AD_Column_ID="52062" Column="Group2" isNewNull="true"/>
+        <Data AD_Column_ID="52061" Column="Group1" isNewNull="true"/>
+        <Data AD_Column_ID="1761" Column="IsStocked">true</Data>
+        <Data AD_Column_ID="1762" Column="IsPurchased">true</Data>
+        <Data AD_Column_ID="2011" Column="Value">GrowLight</Data>
+        <Data AD_Column_ID="1763" Column="IsSold">true</Data>
+        <Data AD_Column_ID="2703" Column="Discontinued">false</Data>
+        <Data AD_Column_ID="2310" Column="UnitsPerPallet">0</Data>
+        <Data AD_Column_ID="4710" Column="IsPickListPrintDetails">false</Data>
+        <Data AD_Column_ID="12147" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="59231" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="68430" Column="DiscontinuedBy" isNewNull="true"/>
+        <Data AD_Column_ID="68431" Column="DownloadURL" isNewNull="true"/>
+        <Data AD_Column_ID="3016" Column="Classification" isNewNull="true"/>
+        <Data AD_Column_ID="1402" Column="M_Product_ID">50044</Data>
+        <Data AD_Column_ID="1403" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1404" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2307" Column="ShelfWidth">0</Data>
+        <Data AD_Column_ID="2019" Column="C_TaxCategory_ID">107</Data>
+        <Data AD_Column_ID="1409" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1407" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3391" Column="SalesRep_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7974" Column="GuaranteeDays">0</Data>
+        <Data AD_Column_ID="2309" Column="ShelfDepth">0</Data>
+        <Data AD_Column_ID="8417" Column="M_AttributeSet_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9889" Column="GuaranteeDaysMin">0</Data>
+        <Data AD_Column_ID="10919" Column="C_SubscriptionType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7972" Column="R_MailText_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53408" Column="LowLevel">0</Data>
+        <Data AD_Column_ID="67105" Column="M_Product_Group_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67106" Column="M_Product_Classification_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2012" Column="M_Product_Category_ID">105</Data>
+        <Data AD_Column_ID="9420" Column="M_Locator_ID">50006</Data>
+        <Data AD_Column_ID="6771" Column="S_ExpenseType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6773" Column="S_Resource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3909" Column="C_RevenueRecognition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8418" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1760" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="9329" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52116" Column="UnitsPerPack">0</Data>
+        <Data AD_Column_ID="67104" Column="M_Product_Class_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84959" Column="UUID">e5ac219e-5fd6-11e9-ab47-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2300" StepType="AD">
+      <PO AD_Table_ID="312" Action="I" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="3326" Column="Created">2019-04-15 19:33:41.512</Data>
+        <Data AD_Column_ID="3325" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3328" Column="Updated">2019-04-15 19:33:41.512</Data>
+        <Data AD_Column_ID="13008" Column="Description">Part of the Seed Starter Kit</Data>
+        <Data AD_Column_ID="3330" Column="Name">Grow Light and Stand</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="3323" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3324" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3327" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3329" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID">50044</Data>
+        <Data AD_Column_ID="84974" Column="UUID">e706d4b2-5fd6-11e9-ab92-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2310" StepType="AD">
+      <PO AD_Table_ID="273" Action="I" Record_ID="50044" Table="M_Product_Acct">
+        <Data AD_Column_ID="2561" Column="Created">2019-04-15 19:33:42.709</Data>
+        <Data AD_Column_ID="2563" Column="Updated">2019-04-15 19:33:42.709</Data>
+        <Data AD_Column_ID="2560" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3421" Column="P_COGS_Acct">233</Data>
+        <Data AD_Column_ID="56558" Column="P_MethodChangeVariance_Acct">50003</Data>
+        <Data AD_Column_ID="56566" Column="P_OutsideProcessing_Acct">50010</Data>
+        <Data AD_Column_ID="56565" Column="P_Burden_Acct">50008</Data>
+        <Data AD_Column_ID="56571" Column="P_Overhead_Acct">50011</Data>
+        <Data AD_Column_ID="56572" Column="P_Scrap_Acct">50012</Data>
+        <Data AD_Column_ID="14431" Column="P_InventoryClearing_Acct">299</Data>
+        <Data AD_Column_ID="59073" Column="P_AverageCostVariance_Acct">50013</Data>
+        <Data AD_Column_ID="14432" Column="P_CostAdjustment_Acct">298</Data>
+        <Data AD_Column_ID="2559" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2558" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2565" Column="M_Product_ID">50044</Data>
+        <Data AD_Column_ID="2556" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="56557" Column="P_WIP_Acct">50001</Data>
+        <Data AD_Column_ID="2564" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="5109" Column="P_PurchasePriceVariance_Acct">232</Data>
+        <Data AD_Column_ID="3420" Column="P_Asset_Acct">231</Data>
+        <Data AD_Column_ID="3419" Column="P_Expense_Acct">230</Data>
+        <Data AD_Column_ID="6119" Column="P_TradeDiscountRec_Acct">283</Data>
+        <Data AD_Column_ID="6118" Column="P_InvoicePriceVariance_Acct">282</Data>
+        <Data AD_Column_ID="56563" Column="P_CostOfProduction_Acct">50009</Data>
+        <Data AD_Column_ID="56564" Column="P_Labor_Acct">50007</Data>
+        <Data AD_Column_ID="56560" Column="P_RateVariance_Acct">50005</Data>
+        <Data AD_Column_ID="56561" Column="P_MixVariance_Acct">50006</Data>
+        <Data AD_Column_ID="56562" Column="P_FloorStock_Acct">50002</Data>
+        <Data AD_Column_ID="56559" Column="P_UsageVariance_Acct">50004</Data>
+        <Data AD_Column_ID="2562" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3418" Column="P_Revenue_Acct">229</Data>
+        <Data AD_Column_ID="6120" Column="P_TradeDiscountGrant_Acct">284</Data>
+        <Data AD_Column_ID="84964" Column="UUID">e7bd7d34-5fd6-11e9-aba2-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2320" StepType="AD">
+      <PO AD_Table_ID="327" Action="I" Record_ID="101" Table="M_Product_Costing">
+        <Data AD_Column_ID="3629" Column="Created">2019-04-15 19:33:43.88</Data>
+        <Data AD_Column_ID="3633" Column="CostStandard" isNewNull="true"/>
+        <Data AD_Column_ID="3628" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3631" Column="Updated">2019-04-15 19:33:43.88</Data>
+        <Data AD_Column_ID="6708" Column="PriceLastPO" isNewNull="true"/>
+        <Data AD_Column_ID="6711" Column="TotalInvAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3634" Column="CostAverage" isNewNull="true"/>
+        <Data AD_Column_ID="6703" Column="CostStandardPOAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6704" Column="CostStandardCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="6709" Column="PriceLastInv" isNewNull="true"/>
+        <Data AD_Column_ID="6710" Column="TotalInvQty" isNewNull="true"/>
+        <Data AD_Column_ID="6702" Column="CostStandardPOQty" isNewNull="true"/>
+        <Data AD_Column_ID="6705" Column="CostStandardCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6706" Column="CostAverageCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="5125" Column="CurrentCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="5126" Column="FutureCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="6707" Column="CostAverageCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3626" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3627" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3632" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3630" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3625" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="3624" Column="M_Product_ID">50044</Data>
+        <Data AD_Column_ID="84970" Column="UUID">e8702e02-5fd6-11e9-abc5-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2330" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-15 19:33:44.8</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-15 19:33:44.8</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">100</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50044</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">e8fcb89a-5fd6-11e9-abdf-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2340" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-15 19:33:45.792</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-15 19:33:45.792</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">50000</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50044</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">e99418d4-5fd6-11e9-abfa-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2350" StepType="AD">
+      <PO AD_Table_ID="453" Action="I" Record_ID="50044" Table="AD_TreeNodePR">
+        <Data AD_Column_ID="84443" Column="UUID">ea369cc6-5fd6-11e9-ac15-00ff97344bad</Data>
+        <Data AD_Column_ID="6170" Column="Updated">2019-04-15 19:33:46.858</Data>
+        <Data AD_Column_ID="6167" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6168" Column="Created">2019-04-15 19:33:46.858</Data>
+        <Data AD_Column_ID="6164" Column="Node_ID">50044</Data>
+        <Data AD_Column_ID="6174" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6172" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6165" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="6166" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6163" Column="AD_Tree_ID">102</Data>
+        <Data AD_Column_ID="6171" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6169" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2360" StepType="AD">
+      <PO AD_Table_ID="251" Action="I" Record_ID="50044" Table="M_ProductPrice">
+        <Data AD_Column_ID="2059" Column="Created">2019-04-15 19:38:42.225</Data>
+        <Data AD_Column_ID="2058" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2061" Column="Updated">2019-04-15 19:38:42.225</Data>
+        <Data AD_Column_ID="2064" Column="M_Product_ID">50044</Data>
+        <Data AD_Column_ID="3028" Column="PriceStd">25.000000000000</Data>
+        <Data AD_Column_ID="3029" Column="PriceLimit">22.000000000000</Data>
+        <Data AD_Column_ID="3027" Column="PriceList">28.000000000000</Data>
+        <Data AD_Column_ID="2056" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2057" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2062" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2760" Column="M_PriceList_Version_ID">104</Data>
+        <Data AD_Column_ID="2060" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84962" Column="UUID">9a442d22-5fd7-11e9-a328-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2370" StepType="AD">
+      <PO AD_Table_ID="53019" Action="I" Record_ID="50023" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53351" Column="Created">2019-04-15 19:40:56.711</Data>
+        <Data AD_Column_ID="53357" Column="IsCritical">false</Data>
+        <Data AD_Column_ID="53370" Column="Updated">2019-04-15 19:40:56.711</Data>
+        <Data AD_Column_ID="53356" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53372" Column="ValidFrom">2019-04-02 00:00:00.0</Data>
+        <Data AD_Column_ID="53350" Column="ComponentType">CO</Data>
+        <Data AD_Column_ID="53345" Column="Feature" isNewNull="true"/>
+        <Data AD_Column_ID="53347" Column="Assay">0</Data>
+        <Data AD_Column_ID="53353" Column="Description">Part of the Seed Starter Kit</Data>
+        <Data AD_Column_ID="53355" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53348" Column="BackflushGroup" isNewNull="true"/>
+        <Data AD_Column_ID="53368" Column="QtyBatch">0</Data>
+        <Data AD_Column_ID="53354" Column="Forecast">0</Data>
+        <Data AD_Column_ID="53360" Column="LeadTimeOffset">0</Data>
+        <Data AD_Column_ID="53358" Column="IsQtyPercentage">false</Data>
+        <Data AD_Column_ID="53363" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53359" Column="IssueMethod">1</Data>
+        <Data AD_Column_ID="53374" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53367" Column="QtyBOM">1.000000000000</Data>
+        <Data AD_Column_ID="58595" Column="CostAllocationPerc">0</Data>
+        <Data AD_Column_ID="53369" Column="Scrap">0</Data>
+        <Data AD_Column_ID="53346" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53365" Column="PP_Product_BOMLine_ID">50023</Data>
+        <Data AD_Column_ID="53361" Column="Line">5</Data>
+        <Data AD_Column_ID="53373" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53364" Column="M_Product_ID">50044</Data>
+        <Data AD_Column_ID="53366" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53362" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="53349" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53371" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85061" Column="UUID">ea97a38a-5fd7-11e9-a337-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2380" StepType="AD">
+      <PO AD_Table_ID="53193" Action="I" Record_ID="50023" Table="PP_Product_BOMLine_Trl">
+        <Data AD_Column_ID="57233" Column="Created">2019-04-15 19:40:58.117</Data>
+        <Data AD_Column_ID="57237" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57241" Column="Updated">2019-04-15 19:40:58.117</Data>
+        <Data AD_Column_ID="57235" Column="Description">Part of the Seed Starter Kit</Data>
+        <Data AD_Column_ID="57236" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57238" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57230" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57232" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57234" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57240" Column="PP_Product_BOMLine_ID">50023</Data>
+        <Data AD_Column_ID="57242" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57231" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="85062" Column="UUID">eb43c494-5fd7-11e9-a359-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2390" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50044" Table="M_Product">
+        <Data AD_Column_ID="53408" Column="LowLevel" oldValue="0">1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2400" StepType="AD">
+      <PO AD_Table_ID="208" Action="I" Record_ID="50045" Table="M_Product">
+        <Data AD_Column_ID="1767" Column="Weight">0</Data>
+        <Data AD_Column_ID="1405" Column="IsActive">true</Data>
+        <Data AD_Column_ID="1406" Column="Created">2019-04-15 19:44:44.473</Data>
+        <Data AD_Column_ID="3014" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="1408" Column="Updated">2019-04-15 19:44:44.473</Data>
+        <Data AD_Column_ID="2704" Column="DiscontinuedAt" isNewNull="true"/>
+        <Data AD_Column_ID="85500" Column="C_TaxType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7963" Column="DescriptionURL" isNewNull="true"/>
+        <Data AD_Column_ID="10261" Column="IsSelfService">true</Data>
+        <Data AD_Column_ID="4712" Column="Processing">false</Data>
+        <Data AD_Column_ID="14505" Column="IsExcludeAutoDelivery">false</Data>
+        <Data AD_Column_ID="61997" Column="IsManufactured">false</Data>
+        <Data AD_Column_ID="61996" Column="IsKanban">false</Data>
+        <Data AD_Column_ID="2305" Column="SKU" isNewNull="true"/>
+        <Data AD_Column_ID="7973" Column="VersionNo" isNewNull="true"/>
+        <Data AD_Column_ID="3015" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1413" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="1411" Column="Description">Shasta Daisy seed packet</Data>
+        <Data AD_Column_ID="1766" Column="Volume">0</Data>
+        <Data AD_Column_ID="1410" Column="Name">Seed Pack Daisy</Data>
+        <Data AD_Column_ID="61995" Column="M_PartType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2308" Column="ShelfHeight">0</Data>
+        <Data AD_Column_ID="2304" Column="UPC" isNewNull="true"/>
+        <Data AD_Column_ID="4709" Column="IsInvoicePrintDetails">false</Data>
+        <Data AD_Column_ID="4711" Column="IsVerified">false</Data>
+        <Data AD_Column_ID="7962" Column="ImageURL" isNewNull="true"/>
+        <Data AD_Column_ID="7795" Column="ProductType">I</Data>
+        <Data AD_Column_ID="10260" Column="IsWebStoreFeatured">false</Data>
+        <Data AD_Column_ID="4708" Column="IsBOM">false</Data>
+        <Data AD_Column_ID="68433" Column="IsPhantom">false</Data>
+        <Data AD_Column_ID="68432" Column="IsToFormule">false</Data>
+        <Data AD_Column_ID="52062" Column="Group2" isNewNull="true"/>
+        <Data AD_Column_ID="52061" Column="Group1" isNewNull="true"/>
+        <Data AD_Column_ID="1761" Column="IsStocked">true</Data>
+        <Data AD_Column_ID="1762" Column="IsPurchased">true</Data>
+        <Data AD_Column_ID="2011" Column="Value">Seed-Daisy</Data>
+        <Data AD_Column_ID="1763" Column="IsSold">true</Data>
+        <Data AD_Column_ID="2703" Column="Discontinued">false</Data>
+        <Data AD_Column_ID="2310" Column="UnitsPerPallet">0</Data>
+        <Data AD_Column_ID="4710" Column="IsPickListPrintDetails">false</Data>
+        <Data AD_Column_ID="12147" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="59231" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="68430" Column="DiscontinuedBy" isNewNull="true"/>
+        <Data AD_Column_ID="68431" Column="DownloadURL" isNewNull="true"/>
+        <Data AD_Column_ID="3016" Column="Classification" isNewNull="true"/>
+        <Data AD_Column_ID="1402" Column="M_Product_ID">50045</Data>
+        <Data AD_Column_ID="1403" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1404" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2307" Column="ShelfWidth">0</Data>
+        <Data AD_Column_ID="2019" Column="C_TaxCategory_ID">107</Data>
+        <Data AD_Column_ID="1409" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1407" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3391" Column="SalesRep_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7974" Column="GuaranteeDays">0</Data>
+        <Data AD_Column_ID="2309" Column="ShelfDepth">0</Data>
+        <Data AD_Column_ID="8417" Column="M_AttributeSet_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9889" Column="GuaranteeDaysMin">0</Data>
+        <Data AD_Column_ID="10919" Column="C_SubscriptionType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7972" Column="R_MailText_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53408" Column="LowLevel">0</Data>
+        <Data AD_Column_ID="67105" Column="M_Product_Group_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67106" Column="M_Product_Classification_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2012" Column="M_Product_Category_ID">105</Data>
+        <Data AD_Column_ID="9420" Column="M_Locator_ID">50006</Data>
+        <Data AD_Column_ID="6771" Column="S_ExpenseType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6773" Column="S_Resource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3909" Column="C_RevenueRecognition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8418" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1760" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="9329" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52116" Column="UnitsPerPack">0</Data>
+        <Data AD_Column_ID="67104" Column="M_Product_Class_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84959" Column="UUID">725bf5d2-5fd8-11e9-b916-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2410" StepType="AD">
+      <PO AD_Table_ID="312" Action="I" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="3326" Column="Created">2019-04-15 19:44:46.157</Data>
+        <Data AD_Column_ID="3325" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3328" Column="Updated">2019-04-15 19:44:46.157</Data>
+        <Data AD_Column_ID="13008" Column="Description">Shasta Daisy seed packet</Data>
+        <Data AD_Column_ID="3330" Column="Name">Seed Pack Daisy</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="3323" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3324" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3327" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3329" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID">50045</Data>
+        <Data AD_Column_ID="84974" Column="UUID">732f9ca2-5fd8-11e9-b961-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2420" StepType="AD">
+      <PO AD_Table_ID="273" Action="I" Record_ID="50045" Table="M_Product_Acct">
+        <Data AD_Column_ID="2561" Column="Created">2019-04-15 19:44:47.546</Data>
+        <Data AD_Column_ID="2563" Column="Updated">2019-04-15 19:44:47.546</Data>
+        <Data AD_Column_ID="2560" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3421" Column="P_COGS_Acct">233</Data>
+        <Data AD_Column_ID="56558" Column="P_MethodChangeVariance_Acct">50003</Data>
+        <Data AD_Column_ID="56566" Column="P_OutsideProcessing_Acct">50010</Data>
+        <Data AD_Column_ID="56565" Column="P_Burden_Acct">50008</Data>
+        <Data AD_Column_ID="56571" Column="P_Overhead_Acct">50011</Data>
+        <Data AD_Column_ID="56572" Column="P_Scrap_Acct">50012</Data>
+        <Data AD_Column_ID="14431" Column="P_InventoryClearing_Acct">299</Data>
+        <Data AD_Column_ID="59073" Column="P_AverageCostVariance_Acct">50013</Data>
+        <Data AD_Column_ID="14432" Column="P_CostAdjustment_Acct">298</Data>
+        <Data AD_Column_ID="2559" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2558" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2565" Column="M_Product_ID">50045</Data>
+        <Data AD_Column_ID="2556" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="56557" Column="P_WIP_Acct">50001</Data>
+        <Data AD_Column_ID="2564" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="5109" Column="P_PurchasePriceVariance_Acct">232</Data>
+        <Data AD_Column_ID="3420" Column="P_Asset_Acct">231</Data>
+        <Data AD_Column_ID="3419" Column="P_Expense_Acct">230</Data>
+        <Data AD_Column_ID="6119" Column="P_TradeDiscountRec_Acct">283</Data>
+        <Data AD_Column_ID="6118" Column="P_InvoicePriceVariance_Acct">282</Data>
+        <Data AD_Column_ID="56563" Column="P_CostOfProduction_Acct">50009</Data>
+        <Data AD_Column_ID="56564" Column="P_Labor_Acct">50007</Data>
+        <Data AD_Column_ID="56560" Column="P_RateVariance_Acct">50005</Data>
+        <Data AD_Column_ID="56561" Column="P_MixVariance_Acct">50006</Data>
+        <Data AD_Column_ID="56562" Column="P_FloorStock_Acct">50002</Data>
+        <Data AD_Column_ID="56559" Column="P_UsageVariance_Acct">50004</Data>
+        <Data AD_Column_ID="2562" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3418" Column="P_Revenue_Acct">229</Data>
+        <Data AD_Column_ID="6120" Column="P_TradeDiscountGrant_Acct">284</Data>
+        <Data AD_Column_ID="84964" Column="UUID">74039188-5fd8-11e9-b971-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2430" StepType="AD">
+      <PO AD_Table_ID="327" Action="I" Record_ID="101" Table="M_Product_Costing">
+        <Data AD_Column_ID="3629" Column="Created">2019-04-15 19:44:48.559</Data>
+        <Data AD_Column_ID="3633" Column="CostStandard" isNewNull="true"/>
+        <Data AD_Column_ID="3628" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3631" Column="Updated">2019-04-15 19:44:48.559</Data>
+        <Data AD_Column_ID="6708" Column="PriceLastPO" isNewNull="true"/>
+        <Data AD_Column_ID="6711" Column="TotalInvAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3634" Column="CostAverage" isNewNull="true"/>
+        <Data AD_Column_ID="6703" Column="CostStandardPOAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6704" Column="CostStandardCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="6709" Column="PriceLastInv" isNewNull="true"/>
+        <Data AD_Column_ID="6710" Column="TotalInvQty" isNewNull="true"/>
+        <Data AD_Column_ID="6702" Column="CostStandardPOQty" isNewNull="true"/>
+        <Data AD_Column_ID="6705" Column="CostStandardCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6706" Column="CostAverageCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="5125" Column="CurrentCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="5126" Column="FutureCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="6707" Column="CostAverageCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3626" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3627" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3632" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3630" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3625" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="3624" Column="M_Product_ID">50045</Data>
+        <Data AD_Column_ID="84970" Column="UUID">749dff0c-5fd8-11e9-b994-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2440" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-15 19:44:49.478</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-15 19:44:49.478</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">100</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50045</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">752a89ae-5fd8-11e9-b9ae-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2450" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-15 19:44:50.421</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-15 19:44:50.421</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">50000</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50045</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">75ba6fba-5fd8-11e9-b9c9-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2460" StepType="AD">
+      <PO AD_Table_ID="453" Action="I" Record_ID="50045" Table="AD_TreeNodePR">
+        <Data AD_Column_ID="84443" Column="UUID">763f3204-5fd8-11e9-b9e4-00ff97344bad</Data>
+        <Data AD_Column_ID="6170" Column="Updated">2019-04-15 19:44:51.293</Data>
+        <Data AD_Column_ID="6167" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6168" Column="Created">2019-04-15 19:44:51.293</Data>
+        <Data AD_Column_ID="6164" Column="Node_ID">50045</Data>
+        <Data AD_Column_ID="6174" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6172" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6165" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="6166" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6163" Column="AD_Tree_ID">102</Data>
+        <Data AD_Column_ID="6171" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6169" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2470" StepType="AD">
+      <PO AD_Table_ID="251" Action="I" Record_ID="50045" Table="M_ProductPrice">
+        <Data AD_Column_ID="2059" Column="Created">2019-04-15 19:45:11.804</Data>
+        <Data AD_Column_ID="2058" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2061" Column="Updated">2019-04-15 19:45:11.804</Data>
+        <Data AD_Column_ID="2064" Column="M_Product_ID">50045</Data>
+        <Data AD_Column_ID="3028" Column="PriceStd">1.000000000000</Data>
+        <Data AD_Column_ID="3029" Column="PriceLimit">0.750000000000</Data>
+        <Data AD_Column_ID="3027" Column="PriceList">1.000000000000</Data>
+        <Data AD_Column_ID="2056" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2057" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2062" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2760" Column="M_PriceList_Version_ID">104</Data>
+        <Data AD_Column_ID="2060" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84962" Column="UUID">82799000-5fd8-11e9-ac25-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2480" StepType="AD">
+      <PO AD_Table_ID="208" Action="I" Record_ID="50046" Table="M_Product">
+        <Data AD_Column_ID="1767" Column="Weight">0</Data>
+        <Data AD_Column_ID="1405" Column="IsActive">true</Data>
+        <Data AD_Column_ID="1406" Column="Created">2019-04-15 19:46:09.21</Data>
+        <Data AD_Column_ID="3014" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="1408" Column="Updated">2019-04-15 19:46:09.21</Data>
+        <Data AD_Column_ID="2704" Column="DiscontinuedAt" isNewNull="true"/>
+        <Data AD_Column_ID="85500" Column="C_TaxType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7963" Column="DescriptionURL" isNewNull="true"/>
+        <Data AD_Column_ID="10261" Column="IsSelfService">true</Data>
+        <Data AD_Column_ID="4712" Column="Processing">false</Data>
+        <Data AD_Column_ID="14505" Column="IsExcludeAutoDelivery">false</Data>
+        <Data AD_Column_ID="61997" Column="IsManufactured">false</Data>
+        <Data AD_Column_ID="61996" Column="IsKanban">false</Data>
+        <Data AD_Column_ID="2305" Column="SKU" isNewNull="true"/>
+        <Data AD_Column_ID="7973" Column="VersionNo" isNewNull="true"/>
+        <Data AD_Column_ID="3015" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1413" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="1411" Column="Description">A seed packet for Baby Breath flowers</Data>
+        <Data AD_Column_ID="1766" Column="Volume">0</Data>
+        <Data AD_Column_ID="1410" Column="Name">Seed Packet Baby Breath</Data>
+        <Data AD_Column_ID="61995" Column="M_PartType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2308" Column="ShelfHeight">0</Data>
+        <Data AD_Column_ID="2304" Column="UPC" isNewNull="true"/>
+        <Data AD_Column_ID="4709" Column="IsInvoicePrintDetails">false</Data>
+        <Data AD_Column_ID="4711" Column="IsVerified">false</Data>
+        <Data AD_Column_ID="7962" Column="ImageURL" isNewNull="true"/>
+        <Data AD_Column_ID="7795" Column="ProductType">I</Data>
+        <Data AD_Column_ID="10260" Column="IsWebStoreFeatured">false</Data>
+        <Data AD_Column_ID="4708" Column="IsBOM">false</Data>
+        <Data AD_Column_ID="68433" Column="IsPhantom">false</Data>
+        <Data AD_Column_ID="68432" Column="IsToFormule">false</Data>
+        <Data AD_Column_ID="52062" Column="Group2" isNewNull="true"/>
+        <Data AD_Column_ID="52061" Column="Group1" isNewNull="true"/>
+        <Data AD_Column_ID="1761" Column="IsStocked">true</Data>
+        <Data AD_Column_ID="1762" Column="IsPurchased">true</Data>
+        <Data AD_Column_ID="2011" Column="Value">Seed-BabyBreath</Data>
+        <Data AD_Column_ID="1763" Column="IsSold">true</Data>
+        <Data AD_Column_ID="2703" Column="Discontinued">false</Data>
+        <Data AD_Column_ID="2310" Column="UnitsPerPallet">0</Data>
+        <Data AD_Column_ID="4710" Column="IsPickListPrintDetails">false</Data>
+        <Data AD_Column_ID="12147" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="59231" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="68430" Column="DiscontinuedBy" isNewNull="true"/>
+        <Data AD_Column_ID="68431" Column="DownloadURL" isNewNull="true"/>
+        <Data AD_Column_ID="3016" Column="Classification" isNewNull="true"/>
+        <Data AD_Column_ID="1402" Column="M_Product_ID">50046</Data>
+        <Data AD_Column_ID="1403" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1404" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2307" Column="ShelfWidth">0</Data>
+        <Data AD_Column_ID="2019" Column="C_TaxCategory_ID">107</Data>
+        <Data AD_Column_ID="1409" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1407" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3391" Column="SalesRep_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7974" Column="GuaranteeDays">0</Data>
+        <Data AD_Column_ID="2309" Column="ShelfDepth">0</Data>
+        <Data AD_Column_ID="8417" Column="M_AttributeSet_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9889" Column="GuaranteeDaysMin">0</Data>
+        <Data AD_Column_ID="10919" Column="C_SubscriptionType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7972" Column="R_MailText_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53408" Column="LowLevel">0</Data>
+        <Data AD_Column_ID="67105" Column="M_Product_Group_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67106" Column="M_Product_Classification_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2012" Column="M_Product_Category_ID">105</Data>
+        <Data AD_Column_ID="9420" Column="M_Locator_ID">50006</Data>
+        <Data AD_Column_ID="6771" Column="S_ExpenseType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6773" Column="S_Resource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3909" Column="C_RevenueRecognition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8418" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1760" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="9329" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52116" Column="UnitsPerPack">0</Data>
+        <Data AD_Column_ID="67104" Column="M_Product_Class_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84959" Column="UUID">a4d9f64e-5fd8-11e9-b9f2-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2490" StepType="AD">
+      <PO AD_Table_ID="312" Action="I" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="3326" Column="Created">2019-04-15 19:46:10.9</Data>
+        <Data AD_Column_ID="3325" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3328" Column="Updated">2019-04-15 19:46:10.9</Data>
+        <Data AD_Column_ID="13008" Column="Description">A seed packet for Baby Breath flowers</Data>
+        <Data AD_Column_ID="3330" Column="Name">Seed Packet Baby Breath</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="3323" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3324" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3327" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3329" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID">50046</Data>
+        <Data AD_Column_ID="84974" Column="UUID">a5b25818-5fd8-11e9-ba3d-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2500" StepType="AD">
+      <PO AD_Table_ID="273" Action="I" Record_ID="50046" Table="M_Product_Acct">
+        <Data AD_Column_ID="2561" Column="Created">2019-04-15 19:46:11.84</Data>
+        <Data AD_Column_ID="2563" Column="Updated">2019-04-15 19:46:11.84</Data>
+        <Data AD_Column_ID="2560" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3421" Column="P_COGS_Acct">233</Data>
+        <Data AD_Column_ID="56558" Column="P_MethodChangeVariance_Acct">50003</Data>
+        <Data AD_Column_ID="56566" Column="P_OutsideProcessing_Acct">50010</Data>
+        <Data AD_Column_ID="56565" Column="P_Burden_Acct">50008</Data>
+        <Data AD_Column_ID="56571" Column="P_Overhead_Acct">50011</Data>
+        <Data AD_Column_ID="56572" Column="P_Scrap_Acct">50012</Data>
+        <Data AD_Column_ID="14431" Column="P_InventoryClearing_Acct">299</Data>
+        <Data AD_Column_ID="59073" Column="P_AverageCostVariance_Acct">50013</Data>
+        <Data AD_Column_ID="14432" Column="P_CostAdjustment_Acct">298</Data>
+        <Data AD_Column_ID="2559" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2558" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2565" Column="M_Product_ID">50046</Data>
+        <Data AD_Column_ID="2556" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="56557" Column="P_WIP_Acct">50001</Data>
+        <Data AD_Column_ID="2564" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="5109" Column="P_PurchasePriceVariance_Acct">232</Data>
+        <Data AD_Column_ID="3420" Column="P_Asset_Acct">231</Data>
+        <Data AD_Column_ID="3419" Column="P_Expense_Acct">230</Data>
+        <Data AD_Column_ID="6119" Column="P_TradeDiscountRec_Acct">283</Data>
+        <Data AD_Column_ID="6118" Column="P_InvoicePriceVariance_Acct">282</Data>
+        <Data AD_Column_ID="56563" Column="P_CostOfProduction_Acct">50009</Data>
+        <Data AD_Column_ID="56564" Column="P_Labor_Acct">50007</Data>
+        <Data AD_Column_ID="56560" Column="P_RateVariance_Acct">50005</Data>
+        <Data AD_Column_ID="56561" Column="P_MixVariance_Acct">50006</Data>
+        <Data AD_Column_ID="56562" Column="P_FloorStock_Acct">50002</Data>
+        <Data AD_Column_ID="56559" Column="P_UsageVariance_Acct">50004</Data>
+        <Data AD_Column_ID="2562" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3418" Column="P_Revenue_Acct">229</Data>
+        <Data AD_Column_ID="6120" Column="P_TradeDiscountGrant_Acct">284</Data>
+        <Data AD_Column_ID="84964" Column="UUID">a641c8f4-5fd8-11e9-ba4d-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2510" StepType="AD">
+      <PO AD_Table_ID="327" Action="I" Record_ID="101" Table="M_Product_Costing">
+        <Data AD_Column_ID="3629" Column="Created">2019-04-15 19:46:12.947</Data>
+        <Data AD_Column_ID="3633" Column="CostStandard" isNewNull="true"/>
+        <Data AD_Column_ID="3628" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3631" Column="Updated">2019-04-15 19:46:12.947</Data>
+        <Data AD_Column_ID="6708" Column="PriceLastPO" isNewNull="true"/>
+        <Data AD_Column_ID="6711" Column="TotalInvAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3634" Column="CostAverage" isNewNull="true"/>
+        <Data AD_Column_ID="6703" Column="CostStandardPOAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6704" Column="CostStandardCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="6709" Column="PriceLastInv" isNewNull="true"/>
+        <Data AD_Column_ID="6710" Column="TotalInvQty" isNewNull="true"/>
+        <Data AD_Column_ID="6702" Column="CostStandardPOQty" isNewNull="true"/>
+        <Data AD_Column_ID="6705" Column="CostStandardCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6706" Column="CostAverageCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="5125" Column="CurrentCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="5126" Column="FutureCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="6707" Column="CostAverageCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3626" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3627" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3632" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3630" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3625" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="3624" Column="M_Product_ID">50046</Data>
+        <Data AD_Column_ID="84970" Column="UUID">a6eab59a-5fd8-11e9-ba70-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2520" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-15 19:46:14.202</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-15 19:46:14.202</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">100</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50046</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">a7aa85fa-5fd8-11e9-ba8a-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2530" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-15 19:46:15.21</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-15 19:46:15.21</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">50000</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50046</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">a8445734-5fd8-11e9-baa5-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2540" StepType="AD">
+      <PO AD_Table_ID="453" Action="I" Record_ID="50046" Table="AD_TreeNodePR">
+        <Data AD_Column_ID="84443" Column="UUID">a8d7237a-5fd8-11e9-bac0-00ff97344bad</Data>
+        <Data AD_Column_ID="6170" Column="Updated">2019-04-15 19:46:16.174</Data>
+        <Data AD_Column_ID="6167" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6168" Column="Created">2019-04-15 19:46:16.174</Data>
+        <Data AD_Column_ID="6164" Column="Node_ID">50046</Data>
+        <Data AD_Column_ID="6174" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6172" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6165" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="6166" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6163" Column="AD_Tree_ID">102</Data>
+        <Data AD_Column_ID="6171" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6169" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2550" StepType="AD">
+      <PO AD_Table_ID="251" Action="I" Record_ID="50046" Table="M_ProductPrice">
+        <Data AD_Column_ID="2059" Column="Created">2019-04-15 19:46:33.874</Data>
+        <Data AD_Column_ID="2058" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2061" Column="Updated">2019-04-15 19:46:33.874</Data>
+        <Data AD_Column_ID="2064" Column="M_Product_ID">50046</Data>
+        <Data AD_Column_ID="3028" Column="PriceStd">1.000000000000</Data>
+        <Data AD_Column_ID="3029" Column="PriceLimit">0.750000000000</Data>
+        <Data AD_Column_ID="3027" Column="PriceList">1.000000000000</Data>
+        <Data AD_Column_ID="2056" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2057" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2062" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2760" Column="M_PriceList_Version_ID">104</Data>
+        <Data AD_Column_ID="2060" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84962" Column="UUID">b364405c-5fd8-11e9-bacf-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2560" StepType="AD">
+      <PO AD_Table_ID="208" Action="I" Record_ID="50047" Table="M_Product">
+        <Data AD_Column_ID="1767" Column="Weight">0</Data>
+        <Data AD_Column_ID="1405" Column="IsActive">true</Data>
+        <Data AD_Column_ID="1406" Column="Created">2019-04-15 19:48:29.465</Data>
+        <Data AD_Column_ID="3014" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="1408" Column="Updated">2019-04-15 19:48:29.465</Data>
+        <Data AD_Column_ID="2704" Column="DiscontinuedAt" isNewNull="true"/>
+        <Data AD_Column_ID="85500" Column="C_TaxType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7963" Column="DescriptionURL" isNewNull="true"/>
+        <Data AD_Column_ID="10261" Column="IsSelfService">true</Data>
+        <Data AD_Column_ID="4712" Column="Processing">false</Data>
+        <Data AD_Column_ID="14505" Column="IsExcludeAutoDelivery">false</Data>
+        <Data AD_Column_ID="61997" Column="IsManufactured">false</Data>
+        <Data AD_Column_ID="61996" Column="IsKanban">false</Data>
+        <Data AD_Column_ID="2305" Column="SKU" isNewNull="true"/>
+        <Data AD_Column_ID="7973" Column="VersionNo" isNewNull="true"/>
+        <Data AD_Column_ID="3015" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1413" Column="IsSummary">false</Data>
+        <Data AD_Column_ID="1411" Column="Description">Forget Me Not flower Seed Packet</Data>
+        <Data AD_Column_ID="1766" Column="Volume">0</Data>
+        <Data AD_Column_ID="1410" Column="Name">Seed Packet Forget Me Not</Data>
+        <Data AD_Column_ID="61995" Column="M_PartType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2308" Column="ShelfHeight">0</Data>
+        <Data AD_Column_ID="2304" Column="UPC" isNewNull="true"/>
+        <Data AD_Column_ID="4709" Column="IsInvoicePrintDetails">false</Data>
+        <Data AD_Column_ID="4711" Column="IsVerified">false</Data>
+        <Data AD_Column_ID="7962" Column="ImageURL" isNewNull="true"/>
+        <Data AD_Column_ID="7795" Column="ProductType">I</Data>
+        <Data AD_Column_ID="10260" Column="IsWebStoreFeatured">false</Data>
+        <Data AD_Column_ID="4708" Column="IsBOM">false</Data>
+        <Data AD_Column_ID="68433" Column="IsPhantom">false</Data>
+        <Data AD_Column_ID="68432" Column="IsToFormule">false</Data>
+        <Data AD_Column_ID="52062" Column="Group2" isNewNull="true"/>
+        <Data AD_Column_ID="52061" Column="Group1" isNewNull="true"/>
+        <Data AD_Column_ID="1761" Column="IsStocked">true</Data>
+        <Data AD_Column_ID="1762" Column="IsPurchased">true</Data>
+        <Data AD_Column_ID="2011" Column="Value">Seed-ForgetMeNot</Data>
+        <Data AD_Column_ID="1763" Column="IsSold">true</Data>
+        <Data AD_Column_ID="2703" Column="Discontinued">false</Data>
+        <Data AD_Column_ID="2310" Column="UnitsPerPallet">0</Data>
+        <Data AD_Column_ID="4710" Column="IsPickListPrintDetails">false</Data>
+        <Data AD_Column_ID="12147" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="59231" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="68430" Column="DiscontinuedBy" isNewNull="true"/>
+        <Data AD_Column_ID="68431" Column="DownloadURL" isNewNull="true"/>
+        <Data AD_Column_ID="3016" Column="Classification" isNewNull="true"/>
+        <Data AD_Column_ID="1402" Column="M_Product_ID">50047</Data>
+        <Data AD_Column_ID="1403" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1404" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2307" Column="ShelfWidth">0</Data>
+        <Data AD_Column_ID="2019" Column="C_TaxCategory_ID">107</Data>
+        <Data AD_Column_ID="1409" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1407" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3391" Column="SalesRep_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7974" Column="GuaranteeDays">0</Data>
+        <Data AD_Column_ID="2309" Column="ShelfDepth">0</Data>
+        <Data AD_Column_ID="8417" Column="M_AttributeSet_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9889" Column="GuaranteeDaysMin">0</Data>
+        <Data AD_Column_ID="10919" Column="C_SubscriptionType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7972" Column="R_MailText_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53408" Column="LowLevel">0</Data>
+        <Data AD_Column_ID="67105" Column="M_Product_Group_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67106" Column="M_Product_Classification_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2012" Column="M_Product_Category_ID">105</Data>
+        <Data AD_Column_ID="9420" Column="M_Locator_ID">50006</Data>
+        <Data AD_Column_ID="6771" Column="S_ExpenseType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6773" Column="S_Resource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3909" Column="C_RevenueRecognition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8418" Column="M_AttributeSetInstance_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1760" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="9329" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52116" Column="UnitsPerPack">0</Data>
+        <Data AD_Column_ID="67104" Column="M_Product_Class_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84959" Column="UUID">f87acf58-5fd8-11e9-ac34-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2570" StepType="AD">
+      <PO AD_Table_ID="312" Action="I" Record_ID="0" Table="M_Product_Trl">
+        <Data AD_Column_ID="3326" Column="Created">2019-04-15 19:48:31.342</Data>
+        <Data AD_Column_ID="3325" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3328" Column="Updated">2019-04-15 19:48:31.342</Data>
+        <Data AD_Column_ID="13008" Column="Description">Forget Me Not flower Seed Packet</Data>
+        <Data AD_Column_ID="3330" Column="Name">Seed Packet Forget Me Not</Data>
+        <Data AD_Column_ID="3331" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3332" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="3323" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3324" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3327" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3322" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3329" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3321" Column="M_Product_ID">50047</Data>
+        <Data AD_Column_ID="84974" Column="UUID">f9684012-5fd8-11e9-ac7f-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2580" StepType="AD">
+      <PO AD_Table_ID="273" Action="I" Record_ID="50047" Table="M_Product_Acct">
+        <Data AD_Column_ID="2561" Column="Created">2019-04-15 19:48:32.648</Data>
+        <Data AD_Column_ID="2563" Column="Updated">2019-04-15 19:48:32.648</Data>
+        <Data AD_Column_ID="2560" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3421" Column="P_COGS_Acct">233</Data>
+        <Data AD_Column_ID="56558" Column="P_MethodChangeVariance_Acct">50003</Data>
+        <Data AD_Column_ID="56566" Column="P_OutsideProcessing_Acct">50010</Data>
+        <Data AD_Column_ID="56565" Column="P_Burden_Acct">50008</Data>
+        <Data AD_Column_ID="56571" Column="P_Overhead_Acct">50011</Data>
+        <Data AD_Column_ID="56572" Column="P_Scrap_Acct">50012</Data>
+        <Data AD_Column_ID="14431" Column="P_InventoryClearing_Acct">299</Data>
+        <Data AD_Column_ID="59073" Column="P_AverageCostVariance_Acct">50013</Data>
+        <Data AD_Column_ID="14432" Column="P_CostAdjustment_Acct">298</Data>
+        <Data AD_Column_ID="2559" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2558" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2565" Column="M_Product_ID">50047</Data>
+        <Data AD_Column_ID="2556" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="56557" Column="P_WIP_Acct">50001</Data>
+        <Data AD_Column_ID="2564" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="5109" Column="P_PurchasePriceVariance_Acct">232</Data>
+        <Data AD_Column_ID="3420" Column="P_Asset_Acct">231</Data>
+        <Data AD_Column_ID="3419" Column="P_Expense_Acct">230</Data>
+        <Data AD_Column_ID="6119" Column="P_TradeDiscountRec_Acct">283</Data>
+        <Data AD_Column_ID="6118" Column="P_InvoicePriceVariance_Acct">282</Data>
+        <Data AD_Column_ID="56563" Column="P_CostOfProduction_Acct">50009</Data>
+        <Data AD_Column_ID="56564" Column="P_Labor_Acct">50007</Data>
+        <Data AD_Column_ID="56560" Column="P_RateVariance_Acct">50005</Data>
+        <Data AD_Column_ID="56561" Column="P_MixVariance_Acct">50006</Data>
+        <Data AD_Column_ID="56562" Column="P_FloorStock_Acct">50002</Data>
+        <Data AD_Column_ID="56559" Column="P_UsageVariance_Acct">50004</Data>
+        <Data AD_Column_ID="2562" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3418" Column="P_Revenue_Acct">229</Data>
+        <Data AD_Column_ID="6120" Column="P_TradeDiscountGrant_Acct">284</Data>
+        <Data AD_Column_ID="84964" Column="UUID">fa2f8a96-5fd8-11e9-ac8f-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2590" StepType="AD">
+      <PO AD_Table_ID="327" Action="I" Record_ID="101" Table="M_Product_Costing">
+        <Data AD_Column_ID="3629" Column="Created">2019-04-15 19:48:33.821</Data>
+        <Data AD_Column_ID="3633" Column="CostStandard" isNewNull="true"/>
+        <Data AD_Column_ID="3628" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3631" Column="Updated">2019-04-15 19:48:33.821</Data>
+        <Data AD_Column_ID="6708" Column="PriceLastPO" isNewNull="true"/>
+        <Data AD_Column_ID="6711" Column="TotalInvAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3634" Column="CostAverage" isNewNull="true"/>
+        <Data AD_Column_ID="6703" Column="CostStandardPOAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6704" Column="CostStandardCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="6709" Column="PriceLastInv" isNewNull="true"/>
+        <Data AD_Column_ID="6710" Column="TotalInvQty" isNewNull="true"/>
+        <Data AD_Column_ID="6702" Column="CostStandardPOQty" isNewNull="true"/>
+        <Data AD_Column_ID="6705" Column="CostStandardCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="6706" Column="CostAverageCumQty" isNewNull="true"/>
+        <Data AD_Column_ID="5125" Column="CurrentCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="5126" Column="FutureCostPrice" isNewNull="true"/>
+        <Data AD_Column_ID="6707" Column="CostAverageCumAmt" isNewNull="true"/>
+        <Data AD_Column_ID="3626" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3627" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3632" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3630" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3625" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="3624" Column="M_Product_ID">50047</Data>
+        <Data AD_Column_ID="84970" Column="UUID">fae26274-5fd8-11e9-acb2-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2600" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-15 19:48:34.832</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-15 19:48:34.832</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">100</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50047</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">fb7ccff8-5fd8-11e9-accc-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2610" StepType="AD">
+      <PO AD_Table_ID="771" Action="I" Record_ID="0" Table="M_Cost">
+        <Data AD_Column_ID="13467" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="13476" Column="Updated">2019-04-15 19:48:35.777</Data>
+        <Data AD_Column_ID="13468" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="13473" Column="IsActive">true</Data>
+        <Data AD_Column_ID="13474" Column="Created">2019-04-15 19:48:35.777</Data>
+        <Data AD_Column_ID="14401" Column="CurrentQty">0</Data>
+        <Data AD_Column_ID="13475" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="13470" Column="M_CostType_ID">50000</Data>
+        <Data AD_Column_ID="14394" Column="Percent" isNewNull="true"/>
+        <Data AD_Column_ID="14201" Column="CumulatedAmt">0</Data>
+        <Data AD_Column_ID="56684" Column="IsCostFrozen">false</Data>
+        <Data AD_Column_ID="13472" Column="M_CostElement_ID">100</Data>
+        <Data AD_Column_ID="13477" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="13480" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="13478" Column="CurrentCostPrice">0</Data>
+        <Data AD_Column_ID="13479" Column="FutureCostPrice">0</Data>
+        <Data AD_Column_ID="13471" Column="C_AcctSchema_ID">101</Data>
+        <Data AD_Column_ID="13469" Column="M_Product_ID">50047</Data>
+        <Data AD_Column_ID="14196" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="14202" Column="CumulatedQty">0</Data>
+        <Data AD_Column_ID="56683" Column="FutureCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="59899" Column="CumulatedAmtLL" isNewNull="true"/>
+        <Data AD_Column_ID="56076" Column="CurrentCostPriceLL" isNewNull="true"/>
+        <Data AD_Column_ID="66648" Column="M_Warehouse_ID">0</Data>
+        <Data AD_Column_ID="84914" Column="UUID">fc0d0424-5fd8-11e9-ace7-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2620" StepType="AD">
+      <PO AD_Table_ID="453" Action="I" Record_ID="50047" Table="AD_TreeNodePR">
+        <Data AD_Column_ID="84443" Column="UUID">fc91ed88-5fd8-11e9-ad02-00ff97344bad</Data>
+        <Data AD_Column_ID="6170" Column="Updated">2019-04-15 19:48:36.65</Data>
+        <Data AD_Column_ID="6167" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6168" Column="Created">2019-04-15 19:48:36.65</Data>
+        <Data AD_Column_ID="6164" Column="Node_ID">50047</Data>
+        <Data AD_Column_ID="6174" Column="SeqNo">999</Data>
+        <Data AD_Column_ID="6172" Column="Parent_ID">0</Data>
+        <Data AD_Column_ID="6165" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="6166" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6163" Column="AD_Tree_ID">102</Data>
+        <Data AD_Column_ID="6171" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6169" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2630" StepType="AD">
+      <PO AD_Table_ID="251" Action="I" Record_ID="50047" Table="M_ProductPrice">
+        <Data AD_Column_ID="2059" Column="Created">2019-04-15 19:48:54.522</Data>
+        <Data AD_Column_ID="2058" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2061" Column="Updated">2019-04-15 19:48:54.522</Data>
+        <Data AD_Column_ID="2064" Column="M_Product_ID">50047</Data>
+        <Data AD_Column_ID="3028" Column="PriceStd">1.000000000000</Data>
+        <Data AD_Column_ID="3029" Column="PriceLimit">0.750000000000</Data>
+        <Data AD_Column_ID="3027" Column="PriceList">1.000000000000</Data>
+        <Data AD_Column_ID="2056" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="2057" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2062" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2760" Column="M_PriceList_Version_ID">104</Data>
+        <Data AD_Column_ID="2060" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84962" Column="UUID">07394984-5fd9-11e9-badf-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2640" StepType="AD">
+      <PO AD_Table_ID="53019" Action="I" Record_ID="50024" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53351" Column="Created">2019-04-15 19:50:09.02</Data>
+        <Data AD_Column_ID="53357" Column="IsCritical">false</Data>
+        <Data AD_Column_ID="53370" Column="Updated">2019-04-15 19:50:09.02</Data>
+        <Data AD_Column_ID="53356" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53372" Column="ValidFrom">2019-04-15 00:00:00.0</Data>
+        <Data AD_Column_ID="53350" Column="ComponentType">OP</Data>
+        <Data AD_Column_ID="53345" Column="Feature">Seeds</Data>
+        <Data AD_Column_ID="53347" Column="Assay">0</Data>
+        <Data AD_Column_ID="53353" Column="Description">A seed packet for Baby Breath flowers</Data>
+        <Data AD_Column_ID="53355" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53348" Column="BackflushGroup" isNewNull="true"/>
+        <Data AD_Column_ID="53368" Column="QtyBatch">0</Data>
+        <Data AD_Column_ID="53354" Column="Forecast">0</Data>
+        <Data AD_Column_ID="53360" Column="LeadTimeOffset">0</Data>
+        <Data AD_Column_ID="53358" Column="IsQtyPercentage">false</Data>
+        <Data AD_Column_ID="53363" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53359" Column="IssueMethod">1</Data>
+        <Data AD_Column_ID="53374" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53367" Column="QtyBOM">1.000000000000</Data>
+        <Data AD_Column_ID="58595" Column="CostAllocationPerc">0</Data>
+        <Data AD_Column_ID="53369" Column="Scrap">0</Data>
+        <Data AD_Column_ID="53346" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53365" Column="PP_Product_BOMLine_ID">50024</Data>
+        <Data AD_Column_ID="53361" Column="Line">60</Data>
+        <Data AD_Column_ID="53373" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53364" Column="M_Product_ID">50046</Data>
+        <Data AD_Column_ID="53366" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53362" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="53349" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53371" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85061" Column="UUID">33cfaaba-5fd9-11e9-baee-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2650" StepType="AD">
+      <PO AD_Table_ID="53193" Action="I" Record_ID="50024" Table="PP_Product_BOMLine_Trl">
+        <Data AD_Column_ID="57233" Column="Created">2019-04-15 19:50:10.569</Data>
+        <Data AD_Column_ID="57237" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57241" Column="Updated">2019-04-15 19:50:10.569</Data>
+        <Data AD_Column_ID="57235" Column="Description">A seed packet for Baby Breath flowers</Data>
+        <Data AD_Column_ID="57236" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57238" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57230" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57232" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57234" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57240" Column="PP_Product_BOMLine_ID">50024</Data>
+        <Data AD_Column_ID="57242" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57231" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="85062" Column="UUID">348ce300-5fd9-11e9-bb10-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2660" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50046" Table="M_Product">
+        <Data AD_Column_ID="53408" Column="LowLevel" oldValue="0">1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2670" StepType="AD">
+      <PO AD_Table_ID="53019" Action="I" Record_ID="50025" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53351" Column="Created">2019-04-15 19:50:34.617</Data>
+        <Data AD_Column_ID="53357" Column="IsCritical">false</Data>
+        <Data AD_Column_ID="53370" Column="Updated">2019-04-15 19:50:34.617</Data>
+        <Data AD_Column_ID="53356" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53372" Column="ValidFrom">2019-04-15 00:00:00.0</Data>
+        <Data AD_Column_ID="53350" Column="ComponentType">OP</Data>
+        <Data AD_Column_ID="53345" Column="Feature">Seeds</Data>
+        <Data AD_Column_ID="53347" Column="Assay">0</Data>
+        <Data AD_Column_ID="53353" Column="Description">Shasta Daisy seed packet</Data>
+        <Data AD_Column_ID="53355" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53348" Column="BackflushGroup" isNewNull="true"/>
+        <Data AD_Column_ID="53368" Column="QtyBatch">0</Data>
+        <Data AD_Column_ID="53354" Column="Forecast">0</Data>
+        <Data AD_Column_ID="53360" Column="LeadTimeOffset">0</Data>
+        <Data AD_Column_ID="53358" Column="IsQtyPercentage">false</Data>
+        <Data AD_Column_ID="53363" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53359" Column="IssueMethod">1</Data>
+        <Data AD_Column_ID="53374" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53367" Column="QtyBOM">1.000000000000</Data>
+        <Data AD_Column_ID="58595" Column="CostAllocationPerc">0</Data>
+        <Data AD_Column_ID="53369" Column="Scrap">0</Data>
+        <Data AD_Column_ID="53346" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53365" Column="PP_Product_BOMLine_ID">50025</Data>
+        <Data AD_Column_ID="53361" Column="Line">70</Data>
+        <Data AD_Column_ID="53373" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53364" Column="M_Product_ID">50045</Data>
+        <Data AD_Column_ID="53366" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53362" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="53349" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53371" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85061" Column="UUID">431ef55c-5fd9-11e9-bb21-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2680" StepType="AD">
+      <PO AD_Table_ID="53193" Action="I" Record_ID="50025" Table="PP_Product_BOMLine_Trl">
+        <Data AD_Column_ID="57233" Column="Created">2019-04-15 19:50:36.024</Data>
+        <Data AD_Column_ID="57237" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57241" Column="Updated">2019-04-15 19:50:36.024</Data>
+        <Data AD_Column_ID="57235" Column="Description">Shasta Daisy seed packet</Data>
+        <Data AD_Column_ID="57236" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57238" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57230" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57232" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57234" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57240" Column="PP_Product_BOMLine_ID">50025</Data>
+        <Data AD_Column_ID="57242" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57231" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="85062" Column="UUID">43b93bd0-5fd9-11e9-bb43-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2690" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50045" Table="M_Product">
+        <Data AD_Column_ID="53408" Column="LowLevel" oldValue="0">1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2700" StepType="AD">
+      <PO AD_Table_ID="53019" Action="I" Record_ID="50026" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53351" Column="Created">2019-04-15 19:51:02.871</Data>
+        <Data AD_Column_ID="53357" Column="IsCritical">false</Data>
+        <Data AD_Column_ID="53370" Column="Updated">2019-04-15 19:51:02.871</Data>
+        <Data AD_Column_ID="53356" Column="IsActive">true</Data>
+        <Data AD_Column_ID="53372" Column="ValidFrom">2019-04-15 00:00:00.0</Data>
+        <Data AD_Column_ID="53350" Column="ComponentType">OP</Data>
+        <Data AD_Column_ID="53345" Column="Feature">Seeds</Data>
+        <Data AD_Column_ID="53347" Column="Assay">0</Data>
+        <Data AD_Column_ID="53353" Column="Description">Forget Me Not flower Seed Packet</Data>
+        <Data AD_Column_ID="53355" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="53348" Column="BackflushGroup" isNewNull="true"/>
+        <Data AD_Column_ID="53368" Column="QtyBatch">0</Data>
+        <Data AD_Column_ID="53354" Column="Forecast">0</Data>
+        <Data AD_Column_ID="53360" Column="LeadTimeOffset">0</Data>
+        <Data AD_Column_ID="53358" Column="IsQtyPercentage">false</Data>
+        <Data AD_Column_ID="53363" Column="M_ChangeNotice_ID" isNewNull="true"/>
+        <Data AD_Column_ID="53359" Column="IssueMethod">1</Data>
+        <Data AD_Column_ID="53374" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="53367" Column="QtyBOM">1.000000000000</Data>
+        <Data AD_Column_ID="58595" Column="CostAllocationPerc">0</Data>
+        <Data AD_Column_ID="53369" Column="Scrap">0</Data>
+        <Data AD_Column_ID="53346" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="53365" Column="PP_Product_BOMLine_ID">50026</Data>
+        <Data AD_Column_ID="53361" Column="Line">80</Data>
+        <Data AD_Column_ID="53373" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="53352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="53364" Column="M_Product_ID">50047</Data>
+        <Data AD_Column_ID="53366" Column="PP_Product_BOM_ID">50007</Data>
+        <Data AD_Column_ID="53362" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="53349" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="53371" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="85061" Column="UUID">53e4b8e0-5fd9-11e9-8f4e-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2710" StepType="AD">
+      <PO AD_Table_ID="53193" Action="I" Record_ID="50026" Table="PP_Product_BOMLine_Trl">
+        <Data AD_Column_ID="57233" Column="Created">2019-04-15 19:51:04.265</Data>
+        <Data AD_Column_ID="57237" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57241" Column="Updated">2019-04-15 19:51:04.265</Data>
+        <Data AD_Column_ID="57235" Column="Description">Forget Me Not flower Seed Packet</Data>
+        <Data AD_Column_ID="57236" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57238" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="57230" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="57232" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57234" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="57240" Column="PP_Product_BOMLine_ID">50026</Data>
+        <Data AD_Column_ID="57242" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57231" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="85062" Column="UUID">548e41c6-5fd9-11e9-8f70-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2720" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50047" Table="M_Product">
+        <Data AD_Column_ID="53408" Column="LowLevel" oldValue="0">1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2730" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50024" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53372" Column="ValidFrom" oldValue="2019-04-15 00:00:00.0">2019-04-02 00:00:00.0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2740" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50025" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53372" Column="ValidFrom" oldValue="2019-04-15 00:00:00.0">2019-04-02 00:00:00.0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2750" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50026" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53372" Column="ValidFrom" oldValue="2019-04-15 00:00:00.0">2019-04-02 00:00:00.0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2760" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50043" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2770" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50044" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2780" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50038" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2790" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50039" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2800" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="137" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2810" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50041" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2820" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50042" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2830" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50046" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2840" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50045" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2850" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50047" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2860" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="133" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+        <Data AD_Column_ID="84959" Column="UUID" isOldNull="true">9a22d746-6368-11e9-b839-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2870" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50004" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+        <Data AD_Column_ID="84959" Column="UUID" isOldNull="true">9a93c32a-6368-11e9-b83d-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2880" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50005" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+        <Data AD_Column_ID="84959" Column="UUID" isOldNull="true">9aff57d4-6368-11e9-b841-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2890" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50000" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+        <Data AD_Column_ID="84959" Column="UUID" isOldNull="true">9b6fa778-6368-11e9-b845-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2900" StepType="AD">
+      <PO AD_Table_ID="208" Action="U" Record_ID="50001" Table="M_Product">
+        <Data AD_Column_ID="4711" Column="IsVerified" oldValue="false">true</Data>
+        <Data AD_Column_ID="84959" Column="UUID" isOldNull="true">9be3a0a6-6368-11e9-b849-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2910" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50006" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53367" Column="QtyBOM" oldValue="500">5.000000000000</Data>
+        <Data AD_Column_ID="85061" Column="UUID" isOldNull="true">c82be0ba-6368-11e9-8417-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2920" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50009" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53367" Column="QtyBOM" oldValue="650">6.500000000000</Data>
+        <Data AD_Column_ID="85061" Column="UUID" isOldNull="true">20f4fdd0-6369-11e9-994d-00ff97344bad</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2930" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50018" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53367" Column="QtyBOM" oldValue="0">1.000000000000</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2940" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50019" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53367" Column="QtyBOM" oldValue="0">1.000000000000</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2950" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50020" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53367" Column="QtyBOM" oldValue="0">1.000000000000</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2960" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50021" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53367" Column="QtyBOM" oldValue="0">1.000000000000</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2970" StepType="AD">
+      <PO AD_Table_ID="53019" Action="U" Record_ID="50022" Table="PP_Product_BOMLine">
+        <Data AD_Column_ID="53367" Column="QtyBOM" oldValue="0">1.000000000000</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WBOMDrop.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WBOMDrop.java
@@ -1,903 +1,556 @@
 /******************************************************************************
- * Product: Adempiere ERP & CRM Smart Business Solution                       *
- * Copyright (C) 1999-2006 ComPiere, Inc. All Rights Reserved.                *
- * This program is free software; you can redistribute it and/or modify it    *
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
  * under the terms version 2 of the GNU General Public License as published   *
  * by the Free Software Foundation. This program is distributed in the hope   *
- * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
  * See the GNU General Public License for more details.                       *
  * You should have received a copy of the GNU General Public License along    *
- * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
  * For the text or an alternative of this public license, you may reach us    *
- * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
- * or via info@compiere.org or http://www.compiere.org/license.html           *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
  *****************************************************************************/
 
 /**
  * 2007, Modified by Posterita Ltd.
+ * 2019, Extensively modified by Michael McKay, mckayerp@gmail.com
  */
 
 package org.adempiere.webui.apps.form;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.logging.Level;
 
-import org.adempiere.webui.component.Checkbox;
+import org.adempiere.controller.form.BOMDropController;
+import org.adempiere.controller.form.BOMDropForm;
+import org.adempiere.exceptions.ValueChangeEvent;
+import org.adempiere.exceptions.ValueChangeListener;
+import org.adempiere.webui.component.Borderlayout;
 import org.adempiere.webui.component.ConfirmPanel;
 import org.adempiere.webui.component.Grid;
 import org.adempiere.webui.component.GridFactory;
-import org.adempiere.webui.component.Label;
-import org.adempiere.webui.component.ListItem;
-import org.adempiere.webui.component.Listbox;
+import org.adempiere.webui.component.Panel;
 import org.adempiere.webui.component.Row;
 import org.adempiere.webui.component.Rows;
+import org.adempiere.webui.editor.WEditor;
+import org.adempiere.webui.editor.WNumberEditor;
+import org.adempiere.webui.editor.WRadioEditor;
+import org.adempiere.webui.editor.WSearchEditor;
+import org.adempiere.webui.editor.WTableDirEditor;
+import org.adempiere.webui.editor.WYesNoEditor;
 import org.adempiere.webui.panel.ADForm;
 import org.adempiere.webui.session.SessionManager;
 import org.adempiere.webui.window.FDialog;
-import org.compiere.model.MInvoice;
-import org.compiere.model.MInvoiceLine;
-import org.compiere.model.MOrder;
-import org.compiere.model.MOrderLine;
-import org.compiere.model.MProduct;
-import org.compiere.model.MProductBOM;
-import org.compiere.model.MProject;
-import org.compiere.model.MProjectLine;
-import org.compiere.model.MRole;
+import org.compiere.model.MLookup;
+import org.compiere.process.ProcessInfo;
+//import org.compiere.model.MProduct;
+import org.compiere.swing.CEditor;
 import org.compiere.util.CLogger;
-import org.compiere.util.DB;
+import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
-import org.compiere.util.KeyNamePair;
 import org.compiere.util.Msg;
 import org.zkoss.zk.ui.HtmlBasedComponent;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.Events;
+import org.zkoss.zkex.zul.Center;
+import org.zkoss.zkex.zul.North;
+import org.zkoss.zkex.zul.South;
 import org.zkoss.zul.Caption;
-import org.zkoss.zul.Decimalbox;
 import org.zkoss.zul.Groupbox;
 import org.zkoss.zul.Hbox;
-import org.zkoss.zul.Radio;
+import org.zkoss.zul.Label;
 import org.zkoss.zul.Radiogroup;
 import org.zkoss.zul.Separator;
-import org.zkoss.zul.Space;
+import org.zkoss.zul.Vbox;
 
-
-
-public class WBOMDrop extends ADForm implements EventListener
+/**
+ *	Drop BOM
+ *  <p>This custom form can be used standalone or as a button action on a Order, invoice, 
+ *  or project document. It allows the user to select a BOM and drop it into a draft 
+ *  document. The form has two parts, a selection panel where the BOM is selected and a 
+ *  product selection panel where individual lines of the BOM can be selected and 
+ *  quantities adjusted.
+ *  <p>Clicking OK will save the selected lines to the document. 
+ *	
+ *  @author Michael McKay, mckayERP@gmail.com
+ *  	<li>Extensive rewrites
+ */
+public class WBOMDrop extends ADForm implements BOMDropForm, EventListener, ValueChangeListener
 {
+	
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -5065364554398280623L;
+	private static final long serialVersionUID = 5158587501523544032L;
 
-	/**	Product to create BOMs from	*/
-	private MProduct m_product;
-	
-	/** BOM Qty						*/
-	private BigDecimal m_qty = Env.ONE;
-	
-	/**	Line Counter				*/
-	private int m_bomLine = 0;
-	
 	/**	Logger			*/
 	private static CLogger log = CLogger.getCLogger(WBOMDrop.class);
 	
-	/**	List of all selectors		*/
-	private ArrayList<org.zkoss.zul.Checkbox> m_selectionList = new ArrayList<org.zkoss.zul.Checkbox>();
-	
-	/**	List of all quantities		*/
-	private ArrayList<Decimalbox> m_qtyList = new ArrayList<Decimalbox>();
-	
-	/**	List of all products		*/
-	private ArrayList<Integer> m_productList = new ArrayList<Integer>();
-	
-	/** Alternative Group Lists		*/
-	private HashMap<String, Radiogroup> m_buttonGroups = new HashMap<String,Radiogroup>();
+	/** List of button groups to control radio buttons		*/
+	private HashMap<Object, Radiogroup> buttonGroups = new HashMap<Object,Radiogroup>();
 
-	private static final int WINDOW_WIDTH = 600;	//	width of the window
+	/** List option groups matching BOM Line features */
+	private ArrayList<Object> optionGroups = new ArrayList<Object>();
 	
 	private ConfirmPanel confirmPanel = new ConfirmPanel(true);
 	private Grid selectionPanel = GridFactory.newGridLayout();
-	private Listbox productField = new Listbox();
-	private Decimalbox productQty = new Decimalbox();
-	private Listbox orderField = new Listbox();
-	private Listbox invoiceField = new Listbox();
-	private Listbox projectField = new Listbox();
 	
-	private Groupbox grpSelectionPanel = new Groupbox();
+	private Groupbox selectBOMPanel = new Groupbox();
 	
-	private Groupbox grpSelectProd = new Groupbox();
+	private Groupbox selectBOMItemsPanel = new Groupbox();
+	private Hbox bomItemsHeader = new Hbox();
+
+	private BOMDropController controller;
+
+	private Rows rows;
+	private int currentCol;
+	
+	private Hbox boxBOMItem;
+
+	private Caption selectProductTitle;
+
+	/** Preferred window width */
+	private static final int	WINDOW_WIDTH = 600;	
+	/** Preferred window height */
+	private static final int	WINDOW_HEIGHT = 500;
 	
 	public WBOMDrop()
-	{}
+	{
+		super();
+		controller = new BOMDropController(this);
+	}
 	
-	/**
-	 *	Initialize Panel
-	 *  @param WindowNo window
-	 *  @param frame parent frame
-	 */
+	@Override
 	protected void initForm()
 	{
 		log.info("");
-
-		try
+		
+		//  This initForm() method needs to be called when the process info data is set.
+		//  As the form is initialized when its created, and then the process info is
+		//  set, this method can get called several times.  There is no harm in this but, 
+		//  in case, clear everything to prevent duplications and ID space collisions.
+		
+		this.getChildren().clear();
+		bomItemsHeader.getChildren().clear();
+		selectBOMPanel.getChildren().clear();
+		selectBOMItemsPanel.getChildren().clear();
+		selectionPanel.getChildren().clear();
+		
+		
+		if (getProcessInfo().getTable_ID() != 0)
 		{
-			 confirmPanel = new ConfirmPanel(true);
-			 
-			//	Top Selection Panel
-			createSelectionPanel(true, true, true);
-
-			//	Center
-			createMainPanel();
-
-			confirmPanel.addActionListener(Events.ON_CLICK, this);
+			// In a dialog, set the height and width
+			this.setHeight(WINDOW_HEIGHT + "px");
+			this.setWidth(WINDOW_WIDTH + "px");
 		}
-		catch(Exception e)
-		{
-			log.log(Level.SEVERE, "", e);
-		}
-		//sizeIt();
-	}	//	init
+		
+		Panel mainPanel = new Panel();
+		mainPanel.setHeight("100%");		
+		this.appendChild(mainPanel);
+		this.setBorder("normal");
+		
+		Borderlayout mainLayout = new Borderlayout();
+		mainPanel.appendChild(mainLayout);
+		mainLayout.setWidth("100%");
+		mainLayout.setHeight("100%");
 
+		bomItemsHeader.setHeight("15px"); // Hardcoded
+		bomItemsHeader.setWidth("100%");
+		North north = new North();
+		Vbox northBox = new Vbox();
+		northBox.setWidth("100%");
+		northBox.appendChild(selectBOMPanel);
+		northBox.appendChild(bomItemsHeader);
+		north.appendChild(northBox);
+		mainLayout.appendChild(north);
+		
+		South south = new South();
+		confirmPanel = new ConfirmPanel(true);
+		confirmPanel.addActionListener(Events.ON_CLICK, this);
+		south.appendChild(confirmPanel);
+		
+		mainLayout.appendChild(south);
+		
+		Center center = new Center();
+		center.appendChild(selectBOMItemsPanel); 
+		center.setBorder("none");
+		center.setFlex(true);
+		center.setAutoscroll(true);
+		mainLayout.appendChild(center);
+
+		Caption caption = new Caption(Msg.getMsg(Env.getCtx(), MSG_SELECTIONPANEL));
+		selectBOMPanel.appendChild(caption);
+		selectBOMPanel.appendChild(selectionPanel);
+		rows = selectionPanel.newRows();
+		
+		selectProductTitle = new Caption(Msg.translate(Env.getCtx(), MSG_SELECTBOMLINES));
+		selectBOMItemsPanel.appendChild(selectProductTitle);
+		
+		selectBOMItemsPanel.setVisible(false); // Initially
+						
+		buttonGroups.clear();
+		optionGroups.clear();
+		
+		controller.init(getProcessInfo(), getProcessInfo().getWindowNo());		
+	}	//	initForm
+		
 	/**
 	 * 	Dispose
 	 */
-	public void dispose()
-	{
-		if (selectionPanel != null)
-			selectionPanel.getChildren().clear();
+	@Override
+	public void dispose() {
 		
-		selectionPanel = null;
+		// If the process info has a table ID, we're a form.
+		// If not, we're a window.  There may be a better way to
+		// tell the difference.
+		if(getProcessInfo().getTable_ID() != 0) 
+		{
+			super.dispose();
+		} 
+		else 
+		{
+			SessionManager.getAppDesktop().closeActiveWindow();
+		}
 		
-		if (m_selectionList != null)
-			m_selectionList.clear();
-		
-		m_selectionList = null;
-		
-		if (m_productList != null)
-			m_productList.clear();
-		
-		m_productList = null;
-		
-		if (m_qtyList != null)
-			m_qtyList.clear();
-		
-		m_qtyList = null;
-		
-		if (m_buttonGroups != null)
-			m_buttonGroups.clear();
-		m_buttonGroups = null;
 	}	//	dispose
-	
-	/**************************************************************************
-	 * 	Create Selection Panel
-	 *	@param order
-	 *	@param invoice
-	 *	@param project
-	 */
-	
-	private void createSelectionPanel (boolean order, boolean invoice, boolean project)
-	{
-		Caption caption = new Caption(Msg.translate(Env.getCtx(), "Selection"));
 
-//		grpSelectionPanel.setWidth("100%");
-		grpSelectionPanel.appendChild(caption);
-		grpSelectionPanel.appendChild(selectionPanel);
-		
-		productField.setRows(1);
-		productField.setMold("select");
-		
-		KeyNamePair[] keyNamePair = getProducts();
-		
-		for (int i = 0; i < keyNamePair.length; i++)
-		{
-			productField.addItem(keyNamePair[i]);
-		}
-		
-		Rows rows = selectionPanel.newRows();
-		Row boxProductQty = rows.newRow();
-		
-		Label lblProduct = new Label(Msg.translate(Env.getCtx(), "M_Product_ID"));
-		Label lblQty = new Label(Msg.translate(Env.getCtx(), "Qty"));
-		productQty.setValue(new BigDecimal(1));
-		productField.addEventListener(Events.ON_SELECT, this);
-		productQty.addEventListener(Events.ON_CHANGE, this);
-		
-		productField.setWidth("99%");
-		boxProductQty.appendChild(lblProduct.rightAlign());
-		boxProductQty.appendChild(productField);
-		boxProductQty.appendChild(lblQty.rightAlign());
-		boxProductQty.appendChild(productQty);
-		
-		if (order)
-		{
-			keyNamePair = getOrders();
-			
-			orderField.setRows(1);
-			orderField.setMold("select");
-			orderField.setWidth("99%");
-			
-			for (int i = 0; i < keyNamePair.length; i++)
-			{
-				orderField.addItem(keyNamePair[i]);
-			}
-
-			Label lblOrder = new Label(Msg.translate(Env.getCtx(), "C_Order_ID"));
-
-			Row boxOrder = rows.newRow();
-			
-			orderField.addEventListener(Events.ON_CLICK, this);
-			
-			boxOrder.appendChild(lblOrder.rightAlign());
-			boxOrder.appendChild(orderField);
-			boxOrder.appendChild(new Space());
-			boxOrder.appendChild(new Space());
-		}
-
-		if (invoice)
-		{
-			invoiceField.setRows(1);
-			invoiceField.setMold("select");
-			invoiceField.setWidth("99%");
-			
-			keyNamePair = getInvoices();
-			
-			for (int i = 0; i < keyNamePair.length; i++)
-			{
-				invoiceField.addItem(keyNamePair[i]);
-			}
-			
-			Label lblInvoice = new Label(Msg.translate(Env.getCtx(), "C_Invoice_ID"));
-			
-			Row boxInvoices = rows.newRow();
-			
-			invoiceField.addEventListener(Events.ON_SELECT, this);
-			
-			boxInvoices.appendChild(lblInvoice.rightAlign());
-			boxInvoices.appendChild(invoiceField);
-			boxInvoices.appendChild(new Space());
-			boxInvoices.appendChild(new Space());
-		}
-		
-		if (project)
-		{
-			projectField.setRows(1);
-			projectField.setMold("select");
-			projectField.setWidth("99%");
-			
-			keyNamePair = getProjects();
-			
-			for (int i = 0; i < keyNamePair.length; i++)
-			{
-				projectField.addItem(keyNamePair[i]);
-			}
-			
-			Label lblProject = new Label(Msg.translate(Env.getCtx(), "C_Project_ID"));
-			
-			Row boxProject = rows.newRow();
-			
-			projectField.addEventListener(Events.ON_SELECT, this);
-			
-			boxProject.appendChild(lblProject.rightAlign());
-			boxProject.appendChild(projectField);
-			boxProject.appendChild(new Space());
-			boxProject.appendChild(new Space());			
-		}
-		
-		//	Enabled in ActionPerformed
-		confirmPanel.setEnabled("Ok", false);
-	}	//	createSelectionPanel
-
-	/**
-	 * 	Get Array of BOM Products
-	 *	@return products
-	 */
-	
-	private KeyNamePair[] getProducts()
-	{
-		String sql = "SELECT M_Product_ID, Name "
-			+ "FROM M_Product "
-			+ "WHERE IsBOM='Y' AND IsVerified='Y' AND IsActive='Y' "
-			+ "ORDER BY Name";
-	
-		return DB.getKeyNamePairs(MRole.getDefault().addAccessSQL(
-			sql, "M_Product", MRole.SQL_NOTQUALIFIED, MRole.SQL_RO), true);
-	}	//	getProducts
-	
-	/**
-	 * 	Get Array of open Orders
-	 *	@return orders
-	 */
-	
-	private KeyNamePair[] getOrders()
-	{
-		String sql = "SELECT C_Order_ID, DocumentNo || '_' || GrandTotal "
-			+ "FROM C_Order "
-			+ "WHERE Processed='N' AND DocStatus='DR' "
-			+ "ORDER BY DocumentNo";
-	
-		return DB.getKeyNamePairs(MRole.getDefault().addAccessSQL(
-			sql, "C_Order", MRole.SQL_NOTQUALIFIED, MRole.SQL_RO), true);
-	}	//	getOrders
-
-	/**
-	 * 	Get Array of open non service Projects
-	 *	@return orders
-	 */
-	
-	private KeyNamePair[] getProjects()
-	{
-		String sql = "SELECT C_Project_ID, Name "
-			+ "FROM C_Project "
-			+ "WHERE Processed='N' AND IsSummary='N' AND IsActive='Y'"
-			+ " AND ProjectCategory<>'S' "
-			+ "ORDER BY Name";
-	
-		return DB.getKeyNamePairs(MRole.getDefault().addAccessSQL(
-			sql, "C_Project", MRole.SQL_NOTQUALIFIED, MRole.SQL_RO), true);
-	}	//	getProjects
-	
-	/**
-	 * 	Get Array of open Invoices
-	 *	@return invoices
-	 */
-	
-	private KeyNamePair[] getInvoices()
-	{
-		String sql = "SELECT C_Invoice_ID, DocumentNo || '_' || GrandTotal "
-			+ "FROM C_Invoice "
-			+ "WHERE Processed='N' AND DocStatus='DR' "
-			+ "ORDER BY DocumentNo";
-	
-		return DB.getKeyNamePairs(MRole.getDefault().addAccessSQL(
-			sql, "C_Invoice", MRole.SQL_NOTQUALIFIED, MRole.SQL_RO), true);
-	}	//	getInvoices
-
-	/**************************************************************************
-	 * 	Create Main Panel.
-	 * 	Called when changing Product
-	 */
-	
-	private void createMainPanel ()
-	{
-		log.config(": " + m_product);
-		this.getChildren().clear();
-		//this.invalidate();
-		//this.setBorder(null);
-		
-		m_selectionList.clear();
-		m_productList.clear();
-		m_qtyList.clear();
-		m_buttonGroups.clear();
-		
-		this.appendChild(new Separator());
-		this.appendChild(grpSelectionPanel);
-		this.appendChild(new Separator());
-		this.appendChild(grpSelectProd);
-		this.appendChild(new Separator());
-		this.appendChild(confirmPanel);
-		this.appendChild(new Separator());
-		this.setBorder("normal");
-		
-		Caption title = new Caption(Msg.getMsg(Env.getCtx(), "SelectProduct"));
-
-		grpSelectProd.getChildren().clear();
-		grpSelectProd.appendChild(title);
-		
-		if (m_product != null && m_product.get_ID() > 0)
-		{
-			title.setLabel(m_product.getName());
-			
-			if (m_product.getDescription() != null && m_product.getDescription().length() > 0)
-				;//this.setsetToolTipText(m_product.getDescription());
-			
-			m_bomLine = 0;
-			addBOMLines(m_product, m_qty);
-		}
-	}	//	createMainPanel
-
-	/**
-	 * 	Add BOM Lines to this.
-	 * 	Called recursively
-	 * 	@param product product
-	 * 	@param qty quantity
-	 */
-	
-	private void addBOMLines (MProduct product, BigDecimal qty)
-	{
-		MProductBOM[] bomLines = MProductBOM.getBOMLines(product);
-		
-		for (int i = 0; i < bomLines.length; i++)
-		{
-			grpSelectProd.appendChild(new Separator());
-			addBOMLine (bomLines[i], qty);
-			grpSelectProd.appendChild(new Separator());
-		}
-		
-		log.fine("#" + bomLines.length);
-	}	//	addBOMLines
-
-	/**
-	 * 	Add BOM Line to this.
-	 * 	Calls addBOMLines if added product is a BOM
-	 * 	@param line BOM Line
-	 * 	@param qty quantity
-	 */
-	
-	private void addBOMLine (MProductBOM line, BigDecimal qty)
-	{
-		log.fine(line.toString());
-		String bomType = line.getBOMType();
-		
-		if (bomType == null)
-			bomType = MProductBOM.BOMTYPE_StandardPart;
-		//
-		BigDecimal lineQty = line.getBOMQty().multiply(qty);
-		MProduct product = line.getProduct();
-		
-		if (product == null)
-			return;
-		
-		if (product.isBOM() && product.isVerified())
-			addBOMLines (product, lineQty);		//	recursive
-		else
-			addDisplay (line.getM_Product_ID(),
-				product.getM_Product_ID(), bomType, product.getName(), lineQty);
-	}	//	addBOMLine
-
-	/**
-	 * 	Add Line to Display
-	 *	@param parentM_Product_ID parent product
-	 *	@param M_Product_ID product
-	 *	@param bomType bom type
-	 *	@param name name
-	 *	@param lineQty qty
-	 */
-	
-	private void addDisplay (int parentM_Product_ID,
-		int M_Product_ID, String bomType, String name, BigDecimal lineQty)
-	{
-		log.fine("M_Product_ID=" + M_Product_ID + ",Type=" + bomType + ",Name=" + name + ",Qty=" + lineQty);
-		
-		boolean selected = true;
-		
-		Hbox boxQty = new Hbox();
-		boxQty.setWidth("100%");
-		boxQty.setWidths("10%, 40%, 50%");
-		
-		if (MProductBOM.BOMTYPE_StandardPart.equals(bomType))
-		{
-			String title = "";
-			Checkbox cb = new Checkbox();
-			cb.setLabel(title);
-			cb.setChecked(true);
-			cb.setEnabled(false);
-
-			m_selectionList.add(cb);
-			boxQty.appendChild(cb);
-		}
-		else if (MProductBOM.BOMTYPE_OptionalPart.equals(bomType))
-		{
-			String title = Msg.getMsg(Env.getCtx(), "Optional");
-			Checkbox cb = new Checkbox();
-			cb.setLabel(title);
-			cb.setChecked(false);
-			selected = false;
-			cb.addEventListener(Events.ON_CHECK, this);
-			
-			m_selectionList.add(cb);
-			boxQty.appendChild(cb);
-		}
-		else	//	Alternative
-		{
-			String title = Msg.getMsg(Env.getCtx(), "Alternative") + " " + bomType;
-			Radio b = new Radio();
-			b.setLabel(title);
-			String groupName = String.valueOf(parentM_Product_ID) + "_" + bomType;
-			Radiogroup group = m_buttonGroups.get(groupName);
-			
-			if (group == null)
-			{
-				log.fine("ButtonGroup=" + groupName);
-				group = new Radiogroup();
-				m_buttonGroups.put(groupName, group);
-				group.appendChild(b);
-				b.setSelected(true);		//	select first one
-			}
-			else
-			{
-				group.appendChild(b);
-				b.setSelected(false);
-				selected = false;
-			}
-			b.addEventListener(Events.ON_CLICK, this);
-			m_selectionList.add(b);
-			boxQty.appendChild(b);
-		}
-		
-		//	Add to List & display
-		m_productList.add (new Integer(M_Product_ID));
-		Decimalbox qty = new Decimalbox();
-		qty.setValue(lineQty);
-		qty.setReadonly(!selected);
-		m_qtyList.add(qty);
-		
-		Label label = new Label(name);
-		HtmlBasedComponent c = (HtmlBasedComponent) label.rightAlign();
-		c.setStyle(c.getStyle() + ";margin-right: 5px");
-		boxQty.appendChild(c);
-		boxQty.appendChild(qty);
-
-		grpSelectProd.appendChild(boxQty);
-	}	//	addDisplay
-
-	/**************************************************************************
-	 *	Action Listener
-	 *  @param e event
-	 */
+	@Override
 	public void onEvent (Event e) throws Exception
 	{
 		log.config(e.getName());
 		
-		Object source = e.getTarget();
-
-		//	Toggle Qty Enabled
-		if (source instanceof Checkbox || source instanceof Radio)
-		{
-			cmd_selection (source);
-			//	need to de-select the others in group	
-			if (source instanceof Radio)
-			{
-				//	find Button Group
-				Iterator<Radiogroup> it = m_buttonGroups.values().iterator();
-				
-				while (it.hasNext())
-				{
-					Radiogroup group = it.next();
-					Enumeration en = (Enumeration) group.getChildren();
-				
-					while (en.hasMoreElements())
-					{
-						//	We found the group
-						if (source == en.nextElement())
-						{
-							Enumeration info = (Enumeration) group.getChildren();
-							
-							while (info.hasMoreElements())
-							{
-								Object infoObj = info.nextElement();
-								if (source != infoObj)
-									cmd_selection(infoObj);
-							}
-						}
-					}
-				}
-			}
-		}	//	JCheckBox or JRadioButton
-			
-		//	Product / Qty
-		else if (source == productField || source == productQty)
-		{
-			m_qty = productQty.getValue();
-			
-			ListItem listitem = productField.getSelectedItem();
-			
-			KeyNamePair pp = null;
-			
-			if (listitem != null)
-				pp = listitem.toKeyNamePair();
-			
-			m_product = MProduct.get (Env.getCtx(), pp.getKey());
-			createMainPanel();
-			//sizeIt();
-		}
-		
-		//	Order
-		else if (source == orderField)
-		{
-			ListItem listitem = orderField.getSelectedItem();
-			
-			KeyNamePair pp = null;
-			
-			if (listitem != null)
-				pp = listitem.toKeyNamePair();
-			
-			boolean valid = (pp != null && pp.getKey() > 0);
-			
-			if (invoiceField != null)
-				invoiceField.setEnabled(!valid);
-			if (projectField != null)
-				projectField.setEnabled(!valid);
-		}
-		//	Invoice
-		else if (source == invoiceField)
-		{
-			ListItem listitem = invoiceField.getSelectedItem();
-			
-			KeyNamePair pp = null;
-						
-			if (listitem != null)
-				pp = listitem.toKeyNamePair();
-			
-			boolean valid = (pp != null && pp.getKey() > 0);
-			
-			if (orderField != null)
-				orderField.setEnabled(!valid);
-			if (projectField != null)
-				projectField.setEnabled(!valid);
-		}
-		//	Project
-		else if (source == projectField)
-		{
-			ListItem listitem = projectField.getSelectedItem();
-			
-			KeyNamePair pp = null;
-			
-			if (listitem != null)
-				pp = listitem.toKeyNamePair();
-			
-			boolean valid = (pp != null && pp.getKey() > 0);
-			//
-			if (orderField != null)
-				orderField.setEnabled(!valid);
-			if (invoiceField != null)
-				invoiceField.setEnabled(!valid);
-		}
 		//	OK
-		else if (confirmPanel.getButton("Ok").equals(e.getTarget()))
+		if (confirmPanel.getButton("Ok").equals(e.getTarget()))
 		{
-			if (cmd_save())
-				SessionManager.getAppDesktop().closeActiveWindow();
+			controller.confirmOK();
 		}
 		else if (confirmPanel.getButton("Cancel").equals(e.getTarget()))
-			SessionManager.getAppDesktop().closeActiveWindow();
-			
-		//	Enable OK
-		boolean OK = m_product != null;
-		
-		if (OK)
 		{
-			KeyNamePair pp = null;
+			controller.confirmCancel();
+		}
 			
-			if (orderField != null)
+	}	//	onEvent
+
+	@Override
+	public void valueChange(ValueChangeEvent evt) {
+		// Not used
+	}
+
+	@Override
+	public CEditor createSelectionEditor(int displayType, MLookup lookup, String columnName, String name, String description, int rowNo, int colNo) {
+
+		if (DisplayType.isLookup(displayType) || displayType == DisplayType.ID)
+		{
+			Row row = null;
+			while (rows.getChildren().size() <= rowNo) {
+				row = rows.newRow();
+				currentCol = 0;
+			}
+			row = (Row) rows.getChildren().get(rowNo);
+			while (currentCol < colNo)
 			{
-				ListItem listitem = orderField.getSelectedItem();
-				
-				if (listitem != null)
-					pp = listitem.toKeyNamePair();
+				row.appendChild(new Label(""));
+				currentCol++;
 			}
 			
-			if ((pp == null || pp.getKey() <= 0) && invoiceField != null)
-			{
-				ListItem listitem = invoiceField.getSelectedItem();
-				
-				if (listitem != null)
-					pp = listitem.toKeyNamePair();
-			}
+			WEditor editor = null;
+	        if (displayType == DisplayType.TableDir || 
+	                displayType == DisplayType.Table || displayType == DisplayType.List
+	                || displayType == DisplayType.ID )
+	        {
+	        	editor = new WTableDirEditor(lookup, name, description, false, false, true);
+	        }
+	        else if (displayType == DisplayType.Search)
+	        {
+	        	editor = new WSearchEditor(lookup, name, description, false, false, true);
+	        }
+	        if (editor != null)
+	        {
+				row.appendChild(editor.getLabel().rightAlign());
+				row.appendChild(editor.getComponent());
+				currentCol += 2;
+	        }		
+			return editor;
+
+		}
+		else if (DisplayType.isNumeric(displayType))
+		{
 			
-			if ((pp == null || pp.getKey() <= 0) && projectField != null)
-			{
-				ListItem listitem = projectField.getSelectedItem();
-				
-				if (listitem != null)
-					pp = listitem.toKeyNamePair();
+			Row row = null;
+			while (rows.getChildren().size() <= rowNo) {
+				row = rows.newRow();
+				currentCol = 0;
 			}
-			OK = (pp != null && pp.getKey() > 0);
+			row = (Row) rows.getChildren().get(rowNo);
+			while (currentCol < colNo)
+			{
+				row.appendChild(new Label(""));
+				currentCol++;
+			}
+
+			
+			WNumberEditor editor = new WNumberEditor(columnName, false, false, true, DisplayType.Integer, name);
+			row.appendChild(editor.getLabel().rightAlign());
+			row.appendChild(editor.getComponent());
+			currentCol += 2;
+
+			return editor;
+
+		}
+		else if (DisplayType.YesNo == displayType)
+		{
+			
+			Row row = null;
+			while (rows.getChildren().size() <= rowNo) {
+				row = rows.newRow();
+				currentCol = 0;
+			}
+			row = (Row) rows.getChildren().get(rowNo);
+			while (currentCol < colNo)
+			{
+				row.appendChild(new Label(""));
+				currentCol++;
+			}
+	
+			WYesNoEditor editor = new WYesNoEditor(columnName, name,
+					description, false, false, true);
+	
+			row.appendChild(editor.getComponent());
+			currentCol++;
+			
+			return editor;
 		}
 		
-		confirmPanel.setEnabled("Ok", OK);
-	}	//	actionPerformed
-
-	/**
-	 * 	Enable/disable qty based on selection
-	 *	@param source JCheckBox or JRadioButton
-	 */
-	
-	private void cmd_selection (Object source)
-	{
-		for (int i = 0; i < m_selectionList.size(); i++)
-		{
-			if (source == m_selectionList.get(i))
-			{
-				boolean selected = isSelectionSelected(source);
-				Decimalbox qty = m_qtyList.get(i);
-				qty.setReadonly(!selected);
-				return;
-			}
-		}
-		log.log(Level.SEVERE, "not found - " + source);
-	}	//	cmd_selection
-
-	/**
-	 * 	Is Selection Selected
-	 *	@param source CheckBox or RadioButton
-	 *	@return true if selected
-	 */
-	
-	private boolean isSelectionSelected (Object source)
-	{
-		boolean retValue = false;
+		throw new IllegalArgumentException("Unhandled display type " + displayType);
 		
-		if (source instanceof Checkbox)
-			retValue = ((Checkbox)source).isChecked();
-		else if (source instanceof Radio)
-			retValue = ((Radio)source).isChecked();
+	}  //  createSelectionEditor
+
+	@Override
+	public void enableConfirmOK(boolean enable) {
+		
+		confirmPanel.setEnabled("Ok", enable);
+		
+	}
+
+	@Override
+	public void showDialog(String message, String result) {
+		
+		FDialog.info(this.getWindowNo(), this, message, result);
+		
+	}
+
+	@Override
+	public void clearBOMList() {
+
+		selectBOMItemsPanel.getChildren().clear();
+		selectBOMItemsPanel.appendChild(selectProductTitle);
+		selectBOMItemsPanel.setVisible(false);
+		bomItemsHeader.setVisible(false);
+		buttonGroups.clear();
+		optionGroups.clear();
+		
+	}
+
+	@Override
+	public void sizeIt() {
+		// Not used
+	}
+
+	@Override
+	public void updateFeatureCaption(Object feature, String caption) {
+		
+		if (feature != null && feature instanceof Groupbox)
+		{
+			Groupbox group = (Groupbox) feature;
+			Caption cap = group.getCaption();
+			cap.setLabel(caption);
+		}
+		
+	}
+
+	@Override
+	public Object createFeature(String featureKey, String featureName) {
+		
+		// Create a group box to show the items
+		Caption caption = new Caption(featureName);	
+		caption.setStyle("cursor: pointer");
+		Groupbox optionGroup = new Groupbox();
+		optionGroup.setMold("3d");
+		optionGroup.appendChild(caption);
+		optionGroup.setLegend(false);
+		optionGroup.setContentStyle("border-style: solid; border-color: lightgray; border-width: 0px 1px 1px 1px; border-radius: 0px 0px 5px 5px;");
+		optionGroup.setTooltiptext(Msg.translate(Env.getCtx(), MSG_ClickToOpen));
+		optionGroup.setClosable(true);
+		optionGroup.setOpen(false);
+		
+		if (selectBOMItemsPanel.getChildren().size() == 0)
+		{
+			selectBOMItemsPanel.appendChild(new Separator());
+		}
+		selectBOMItemsPanel.appendChild(optionGroup);
+		
+		return optionGroup;
+	}
+
+	@Override
+	public CEditor addCheck(Object feature, String itemType, String name) {
+		
+		boxBOMItem = new Hbox();
+		boxBOMItem.setWidth("100%");
+		boxBOMItem.setWidths("50%,25%,25%");
+
+		if (ITEMTYPE_CHECK.equals(itemType))
+		{
+			String title = "";
+			WYesNoEditor cb = new WYesNoEditor(name, name, title, false, feature==null, true);
+			boxBOMItem.appendChild(cb.getComponent());
+
+			if (feature != null && (feature instanceof Groupbox))
+			{
+				// Append the boxQty to the feature group
+				Groupbox optionGroup = (Groupbox) feature;				
+				optionGroup.appendChild(boxBOMItem);
+				cb.setValue(false);
+				cb.getComponent().setEnabled(true);
+			}
+			else
+			{
+				// Append the boxQty to the panel
+				cb.setValue(true);
+				cb.setReadWrite(false);
+				cb.getComponent().setEnabled(true);
+				if (selectBOMItemsPanel.getChildren().size() == 0)
+				{
+					selectBOMItemsPanel.appendChild(new Separator());
+				}
+				selectBOMItemsPanel.appendChild(boxBOMItem);
+			}
+			
+			return cb;
+
+		}
+		else if (ITEMTYPE_RADIO.equals(itemType))
+		{
+			
+			if (feature == null || !(feature instanceof Groupbox))
+				throw new IllegalArgumentException("Can't have radiobutton type without a group!");
+
+			String title = "";
+			WRadioEditor rb = new WRadioEditor(name, name, title, false, false, true);
+			
+			Groupbox optionGroup = (Groupbox) feature;
+			Radiogroup radioGroup = (Radiogroup) buttonGroups.get(optionGroup);
+			if (radioGroup == null)
+			{
+				radioGroup = new Radiogroup();
+				optionGroup.appendChild(radioGroup);
+				buttonGroups.put(optionGroup, radioGroup);
+				rb.setValue(true); // Select the first one
+			}
+
+			optionGroup.appendChild(radioGroup);
+			radioGroup.appendChild(boxBOMItem);
+			boxBOMItem.appendChild(rb.getComponent());
+			rb.addValueChangeListener(controller);
+			
+			return rb;
+			
+		}
 		else
-			log.log(Level.SEVERE, "Not valid - " + source);
-		
-		return retValue;
-	}	//	isSelected
-
-	/**************************************************************************
-	 * 	Save Selection
-	 * 	@return true if saved
-	 */
-	
-	private boolean cmd_save()
-	{
-		ListItem listitem = orderField.getSelectedItem();
-		
-		KeyNamePair pp = null;
-		
-		if (listitem != null)
-			pp = listitem.toKeyNamePair();
-		
-		if (pp != null && pp.getKey() > 0)
-			return cmd_saveOrder (pp.getKey());
-		
-		listitem = invoiceField.getSelectedItem();
-		
-		pp = null;
-		
-		if (listitem != null)
-			pp = listitem.toKeyNamePair();
-		
-		if (pp != null && pp.getKey() > 0)
-			return cmd_saveInvoice (pp.getKey());
-		
-		listitem = projectField.getSelectedItem();
-		
-		pp = null;
-		
-		if (listitem != null)
-			pp = listitem.toKeyNamePair();
-		
-		if (pp != null && pp.getKey() > 0)
-			return cmd_saveProject (pp.getKey());
-		
-		log.log(Level.SEVERE, "Nothing selected");
-		return false;
-	}	//	cmd_save
-
-	/**
-	 * 	Save to Order
-	 *	@param C_Order_ID id
-	 *	@return true if saved
-	 */
-	
-	private boolean cmd_saveOrder (int C_Order_ID)
-	{
-		log.config("C_Order_ID=" + C_Order_ID);
-		MOrder order = new MOrder (Env.getCtx(), C_Order_ID, null);
-		
-		if (order.get_ID() == 0)
 		{
-			log.log(Level.SEVERE, "Not found - C_Order_ID=" + C_Order_ID);
-			return false;
+			log.severe("Unhandled Item type: " + itemType);
+		}
+		return null;
+	}  //  addCheck
+
+	@Override
+	public CEditor addQty(Object feature, BigDecimal qty) {
+
+		WNumberEditor qtyEditor = new WNumberEditor("qty", false, false, true, DisplayType.Quantity, "");
+		qtyEditor.setValue(qty);
+		((HtmlBasedComponent) qtyEditor.getComponent()).setWidth("100%");
+		boxBOMItem.appendChild(qtyEditor.getComponent());
+		return qtyEditor;
+		
+	}
+
+	@Override
+	public CEditor addUOM(Object feature, MLookup uomLookup, int c_uom_id) {
+
+		String name = "";
+		String description = "";
+		int displayType = uomLookup.getDisplayType();
+		WEditor uomEditor = null;
+        if (displayType == DisplayType.TableDir || 
+                displayType == DisplayType.Table || displayType == DisplayType.List
+                || displayType == DisplayType.ID )
+        {
+        	uomEditor = new WTableDirEditor(uomLookup, name, description, true, false, true);
+        }
+        else if (displayType == DisplayType.Search)
+        {
+        	uomEditor = new WSearchEditor(uomLookup, name, description, true, false, true);
+        }
+        if (uomEditor != null)
+        {
+			uomEditor.setValue(c_uom_id);
+			uomEditor.addValueChangeListener(controller);
+			((HtmlBasedComponent) uomEditor.getComponent()).setWidth("100%");
+			boxBOMItem.appendChild(uomEditor.getComponent());
+        }
+		return uomEditor;
+	}  //  addUOM
+
+	@Override
+	public void enableBOMList() {
+		
+		selectBOMItemsPanel.setVisible(true);
+		bomItemsHeader.setVisible(true);
+		
+	}
+
+	@Override
+	public void setBOMListHeaders(String checkName, String productName, String qtyName, String uomName) {
+
+		bomItemsHeader.getChildren().clear();
+		bomItemsHeader.setWidth("100%");
+		bomItemsHeader.setWidths("10%, 40%,25%,25%");
+		
+		Label selectLabel = new Label(checkName);
+		Label nameLabel = new Label(productName);
+		Label qtyLabel = new Label(qtyName);
+		Label uomLabel = new Label(uomName);
+		bomItemsHeader.appendChild(selectLabel);
+		bomItemsHeader.appendChild(nameLabel);
+		bomItemsHeader.appendChild(qtyLabel);
+		bomItemsHeader.appendChild(uomLabel);
+
+	}
+
+	@Override
+	public ProcessInfo getProcessInfo() {
+		
+		ProcessInfo info = super.getProcessInfo();
+		if (info == null)
+		{
+		
+			info = new ProcessInfo("", 0, 0, 0);
+			info.setInterfaceType(ProcessInfo.INTERFACE_TYPE_ZK);
+			super.setProcessInfo (info);
 		}
 		
-		int lineCount = 0;
-		
-		//	for all bom lines
-		for (int i = 0; i < m_selectionList.size(); i++)
-		{
-			if (isSelectionSelected(m_selectionList.get(i)))
-			{
-				BigDecimal qty = m_qtyList.get(i).getValue();
-				int M_Product_ID = m_productList.get(i).intValue();
-				//	Create Line
-				MOrderLine ol = new MOrderLine (order);
-				ol.setM_Product_ID(M_Product_ID, true);
-				ol.setQty(qty);
-				ol.setPrice();
-				ol.setTax();
-				if (ol.save())
-					lineCount++;
-				else
-					log.log(Level.SEVERE, "Line not saved");
-			}	//	line selected
-		}	//	for all bom lines
-		
-		FDialog.info(-1, this, order.getDocumentInfo() + " " + Msg.translate(Env.getCtx(), "Inserted") + "=" + lineCount);
-		log.config("#" + lineCount);
-		return true;
-	}	//	cmd_saveOrder
-
-	/**
-	 * 	Save to Invoice
-	 *	@param C_Invoice_ID id
-	 *	@return true if saved
-	 */
+		return info;
+	}
 	
-	private boolean cmd_saveInvoice (int C_Invoice_ID)
-	{
-		log.config("C_Invoice_ID=" + C_Invoice_ID);
-		MInvoice invoice = new MInvoice (Env.getCtx(), C_Invoice_ID, null);
-		if (invoice.get_ID() == 0)
-		{
-			log.log(Level.SEVERE, "Not found - C_Invoice_ID=" + C_Invoice_ID);
-			return false;
-		}
-		int lineCount = 0;
-		
-		//	for all bom lines
-		for (int i = 0; i < m_selectionList.size(); i++)
-		{
-			if (isSelectionSelected(m_selectionList.get(i)))
-			{
-				BigDecimal qty = m_qtyList.get(i).getValue();
-				int M_Product_ID = m_productList.get(i).intValue();
-				//	Create Line
-				MInvoiceLine il = new MInvoiceLine (invoice);
-				il.setM_Product_ID(M_Product_ID, true);
-				il.setQty(qty);
-				il.setPrice();
-				il.setTax();
-				if (il.save())
-					lineCount++;
-				else
-					log.log(Level.SEVERE, "Line not saved");
-			}	//	line selected
-		}	//	for all bom lines
-		
-		FDialog.info(-1, this, invoice.getDocumentInfo() +  " " + Msg.translate(Env.getCtx(), "Inserted") + "=" + lineCount);
-		log.config("#" + lineCount);
-		return true;
-	}	//	cmd_saveInvoice
+	@Override
+	public void setProcessInfo(ProcessInfo pi) {
+		super.setProcessInfo(pi);
+		initForm();
+	}
 
-	/**
-	 * 	Save to Project
-	 *	@param C_Project_ID id
-	 *	@return true if saved
-	 */
-	private boolean cmd_saveProject (int C_Project_ID)
-	{
-		log.config("C_Project_ID=" + C_Project_ID);
-		MProject project = new MProject (Env.getCtx(), C_Project_ID, null);
-		if (project.get_ID() == 0)
-		{
-			log.log(Level.SEVERE, "Not found - C_Project_ID=" + C_Project_ID);
-			return false;
-		}
-		int lineCount = 0;
-		
-		//	for all bom lines
-		for (int i = 0; i < m_selectionList.size(); i++)
-		{
-			if (isSelectionSelected(m_selectionList.get(i)))
-			{
-				BigDecimal qty = m_qtyList.get(i).getValue();
-				int M_Product_ID = m_productList.get(i).intValue();
-				//	Create Line
-				MProjectLine pl = new MProjectLine (project);
-				pl.setM_Product_ID(M_Product_ID);
-				pl.setPlannedQty(qty);
-
-				if (pl.save())
-					lineCount++;
-				else
-					log.log(Level.SEVERE, "Line not saved");
-			}	//	line selected
-		}	//	for all bom lines
-		
-		FDialog.info(-1, this, project.getName() + " " + Msg.translate(Env.getCtx(), "Inserted") + "=" + lineCount);
-		log.config("#" + lineCount);
-		return true;
-	}	//	cmd_saveProject
 }

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/component/Radio.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/component/Radio.java
@@ -1,0 +1,110 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+
+package org.adempiere.webui.component;
+
+import org.zkoss.zk.ui.event.EventListener;
+import org.zkoss.zk.ui.event.Events;
+
+/**
+ * Basic Radio Button editor component.
+ * 
+ * @author Michael McKay, mckayERP@gmail.com, copied from Checkbox.java
+ * 
+ */
+public class Radio extends org.zkoss.zul.Radio
+{
+	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 3172880530358507033L;
+	
+	private Object oldValue;
+
+	public void setEnabled(boolean enabled)
+    {
+        this.setDisabled(!enabled);
+    }
+    
+    public boolean isEnabled()
+    {
+    	return !this.isDisabled();
+    }
+
+    /**
+     * alias for setLabel, added to ease porting of swing form
+     * @param label
+     */
+	public void setText(String label) {
+		if (label != null)
+			label = label.replaceAll("[&]", "");
+		setLabel(label);
+	}
+
+	/**
+	 * alias for addEventListener(Events.ON_CHECK, listener), to ease porting of swing form
+	 * @param listener
+	 */
+	public void addActionListener(EventListener listener) {
+		addEventListener(Events.ON_CHECK, listener);
+	}
+
+	/**
+	 *	Return Editor value
+	 *  @return value
+	 */
+	public String getValue()
+	{
+		return isChecked() ? "Y" : "N";
+	}	//	getValue
+
+	/**
+	 * Set the old value of the field.  For use in future comparisons.
+	 * The old value must be explicitly set though this call.
+	 * @param oldValue
+	 */
+	
+	public void set_oldValue() {
+		this.oldValue = getValue();
+	}
+	
+	/**
+	 * Get the old value of the field explicitly set in the past
+	 * @return
+	 */
+	public Object get_oldValue() {
+		return oldValue;
+	}
+	
+	/**
+	 * Has the field changed over time?
+	 * @return true if the old value is different than the current.
+	 */
+	public boolean hasChanged() {
+		// Both or either could be null
+		if(getValue() != null)
+			if(oldValue != null)
+				return !oldValue.equals(getValue());
+			else
+				return true;
+		else  // getValue() is null
+			if(oldValue != null)
+				return true;
+			else
+				return false;
+	}
+}

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WRadioEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WRadioEditor.java
@@ -1,0 +1,171 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2019 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+
+package org.adempiere.webui.editor;
+
+import java.beans.PropertyChangeEvent;
+import java.util.logging.Level;
+
+import org.adempiere.exceptions.ValueChangeEvent;
+import org.adempiere.webui.component.Radio;
+import org.adempiere.webui.event.ContextMenuEvent;
+import org.adempiere.webui.event.ContextMenuListener;
+import org.adempiere.webui.window.WRecordInfo;
+import org.compiere.model.GridField;
+import org.compiere.util.CLogger;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+import org.zkoss.zk.ui.event.Event;
+import org.zkoss.zk.ui.event.Events;
+
+/**
+ * An Adempiere ZK editor for a radio button.  To function within a RadioGroup, the 
+ * editor component needs to have the RadioGroup as an ancestor. 
+ * 
+ * @author Michael McKay, mckayERP@gmail.com, copied largely from WCheckbox.java
+ */
+public class WRadioEditor extends WEditor implements ContextMenuListener
+{
+    public static final String[] LISTENER_EVENTS = {Events.ON_CHECK};
+    private static final CLogger logger;
+
+    static
+    {
+        logger = CLogger.getCLogger(WRadioEditor.class);
+    }
+
+    private boolean oldValue = false;
+	private WEditorPopupMenu popupMenu;
+
+    public WRadioEditor(GridField gridField)
+    {
+        super(new Radio(), gridField);
+        init();
+    }
+
+    public WRadioEditor(String columnName, String label,
+			String description, boolean mandatory, boolean readonly,
+			boolean updateable) {
+		super(new Radio(), columnName, label, description, mandatory, readonly, updateable);
+		init();
+	}
+
+	private void init()
+    {
+		if (gridField != null)
+			getComponent().setLabel(gridField.getHeader());
+		else
+			getComponent().setLabel(label.getValue());
+        label.setValue("");
+        label.setTooltiptext("");
+        
+        popupMenu = new WEditorPopupMenu(false, false, true);
+		popupMenu.addMenuListener(this);
+		if (gridField != null && gridField.getGridTab() != null)
+		{
+			WRecordInfo.addMenu(popupMenu);
+		}
+		getComponent().setContext(popupMenu.getId());
+    }
+
+    public void onEvent(Event event)
+    {
+    	if (Events.ON_CHECK.equalsIgnoreCase(event.getName()))
+    	{
+	        Boolean newValue = (Boolean)getValue();
+	        ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), oldValue, newValue);
+	        super.fireValueChange(changeEvent);
+	        oldValue = newValue;
+    	}
+    }
+
+    public void propertyChange(PropertyChangeEvent evt)
+    {
+        if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY))
+        {
+            setValue(evt.getNewValue());
+        }
+    }
+
+    @Override
+    public String getDisplay()
+    {
+        String display = getComponent().isChecked() ? "Y" : "N";
+        return Msg.translate(Env.getCtx(), display);
+    }
+
+    @Override
+    public Object getValue()
+    {
+        return new Boolean(getComponent().isChecked());
+    }
+
+    @Override
+    public void setValue(Object value)
+    {
+        if (value == null || value instanceof Boolean)
+        {
+            Boolean val = ((value == null) ? false
+                    : (Boolean) value);
+            getComponent().setChecked(val);
+            oldValue = val;
+        }
+        else if (value instanceof String)
+        {
+            Boolean val = value.equals("Y");
+            getComponent().setChecked(val);
+            oldValue = val;
+        }
+        else
+        {
+            logger.log(Level.SEVERE,
+                    "New field value of unknown type, Type: "
+                    + value.getClass()
+                    + ", Value: " + value);
+            getComponent().setChecked(false);
+        }
+    }
+
+    @Override
+	public Radio getComponent() {
+		return (Radio) component;
+	}
+
+	@Override
+	public boolean isReadWrite() {
+		return getComponent().isEnabled();
+	}
+
+	@Override
+	public void setReadWrite(boolean readWrite) {
+		getComponent().setEnabled(readWrite);
+	}
+
+	public String[] getEvents()
+    {
+        return LISTENER_EVENTS;
+    }
+
+	@Override
+	public void onMenu(ContextMenuEvent evt) 
+	{
+		if (WEditorPopupMenu.CHANGE_LOG_EVENT.equals(evt.getContextEvent()))
+		{
+			WRecordInfo.start(gridField);
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes #2435 

This pull request fixes and improves the BOM Drop functionality.  The swing and ZK BOM Drop forms are equivalent and can be accessed from the menu or from an Order, Invoice or Project as a button/process.  A new radio button editor was added to support the optional/variant features.  A Plant Starter Kit product was added to Garden World, along with some subproducts to provide a test of the optional and variant features.

Note that a Role Access Update is required to access the BOM Drop process from the Order, Invoice or Project window/tab.

Draft documentation:  https://mckayerp.gitbook.io/adempiere/v/contrib_2435/introduction/products-and-material-management/bom-drop

See https://github.com/adempiere/adempiere/issues/2435

