### PR TITLE
#2306 Add the missing operator to Postgres.  

### DIFF
--- a/migration/391lts-392lts/04550_2306_CorrectMissingOperatorPostgres.xml
+++ b/migration/391lts-392lts/04550_2306_CorrectMissingOperatorPostgres.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="#2251 &amp; #2306 Missing Operator in Postgres" ReleaseNo="3.9.2" SeqNo="4550">
+    <Comments>#2251 &amp; #2306 - Correct missing definition of timestamp +/- integer in postgres</Comments>
+    <Step DBType="Postgres" Parse="Y" SeqNo="10" StepType="SQL">
+      <Comments>Correct missing operator Timestamp +/- Integer in Postgres</Comments>
+      <SQLStatement>--DROP OPERATOR + (timestamptz, NUMERIC);
+CREATE OPERATOR + ( PROCEDURE = adddays,
+    LEFTARG = TIMESTAMPTZ, RIGHTARG = NUMERIC,
+    COMMUTATOR = +);
+
+--DROP OPERATOR - (timestamptz, NUMERIC);
+CREATE OPERATOR - ( PROCEDURE = subtractdays,
+    LEFTARG = TIMESTAMPTZ, RIGHTARG = NUMERIC,
+    COMMUTATOR = -);</SQLStatement>
+      <RollbackStatement>DROP OPERATOR + (timestamptz, NUMERIC);
+DROP OPERATOR - (timestamptz, NUMERIC);</RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Fixes #2251.
Fixes #2306.

This migration has a single step with a postgres specific SQL as provided by Victor (@e-Evolution).  It won't affect other database types.