### PR TITLE
Fixed error missing translation on Custom Tree when the table is not translated

### DIFF
--- a/base/src/org/compiere/model/MTable.java
+++ b/base/src/org/compiere/model/MTable.java
@@ -81,6 +81,7 @@ public class MTable extends X_AD_Table
 	/**	Cache						*/
 	private static CCache<Integer,MTable> s_cache = new CCache<Integer,MTable>("AD_Table", 20);
 	private static CCache<String,Class<?>> s_classCache = new CCache<String,Class<?>>("PO_Class", 20);
+	private static CCache<String,Boolean> s_cachetrl = new CCache<String,Boolean>("Table_Trl", 20);
 
 	/**	Columns				*/
 	private List<MColumn>	columns = null;
@@ -1104,5 +1105,25 @@ public class MTable extends X_AD_Table
 		sb.append (get_ID()).append ("-").append (getTableName()).append ("]");
 		return sb.toString ();
 	}	//	toString
+	
+	/**
+	 * Evaluate if table manage translation
+	 * @param tableName
+	 * @return
+	 */
+	public static boolean hasTranslation(String tableName) {
+		Boolean hasTrl = s_cachetrl.get(tableName);
+		if (hasTrl == null) {
+			hasTrl = new Query(Env.getCtx(), 
+						MColumn.Table_Name, 
+						"IsTranslated = 'Y' AND EXISTS(SELECT 1 FROM AD_Table t WHERE t.AD_Table_ID = AD_Column.AD_Table_ID AND t.TableName = ?)", 
+						null)
+				.setParameters(tableName)
+				.match();
+			s_cachetrl.put(tableName, hasTrl);
+		}
+		
+		return hasTrl;
+	}
 
 }	//	MTable

--- a/base/src/org/compiere/model/MTree.java
+++ b/base/src/org/compiere/model/MTree.java
@@ -977,9 +977,10 @@ public class MTree extends X_AD_Tree
 		//	Load for Custom Tree
 		else if(getTreeType().equals(TREETYPE_CustomTree)) {
 			boolean base = Env.isBaseLanguage(p_ctx, fromClause);
+			boolean translation = !base && MTable.hasTranslation(fromClause);
 			sourceTable = "t";
 			String recordClause = "";
-			if (base){
+			if (!translation){
 				sqlNode.append("SELECT t." + fromClause + "_ID, ")
 					.append("t.Name, t.Description, t.IsSummary, " + color + " AS Action ")
 					.append(recordClause.length() > 0 ? ", " + recordClause : "")
@@ -987,7 +988,7 @@ public class MTree extends X_AD_Tree
 					;
 			} else {
 				sqlNode.append("SELECT t." + fromClause + "_ID, ")
-					.append("COALESCE(m.Name, t.Name) AS Name, COALESCE(m.Description, t.Description) AS Description, t.IsSummary,  ")
+					.append("COALESCE(tt.Name, t.Name) AS Name, COALESCE(tt.Description, t.Description) AS Description, t.IsSummary,  ")
 					.append( color + " AS Action ")
 					.append(recordClause.length() > 0 ? ", " + recordClause : "")
 					.append(" FROM ").append(fromClause).append(" AS t ")


### PR DESCRIPTION
When the table is not translated and the windows associated is tree type the window stay finding translation.

![Screenshot_20190513_105725](https://user-images.githubusercontent.com/1847863/57632482-c34e0280-756f-11e9-9d27-eb0c40aadea7.png)

![Screenshot_20190513_105749](https://user-images.githubusercontent.com/1847863/57632495-c9dc7a00-756f-11e9-8a33-199bb68be8e3.png)

