### PR TITLE
Fixed error with BaseTable_ID from context

### DIFF
--- a/base/src/org/compiere/model/GridWindowVO.java
+++ b/base/src/org/compiere/model/GridWindowVO.java
@@ -209,7 +209,7 @@ public class GridWindowVO implements Serializable
 				continue;
 			}
 			if (mWindowVO.AD_Table_ID == 0)
-				mWindowVO.AD_Table_ID = tab.getAD_Tab_ID();
+				mWindowVO.AD_Table_ID = tab.getAD_Table_ID();
 			//  Create TabVO
 			GridTabVO mTabVO = GridTabVO.create(mWindowVO, tabNo, tab,
 				mWindowVO.WindowType.equals(WINDOWTYPE_QUERY),  //  isRO


### PR DESCRIPTION
Currently after add [ASP functionality](https://github.com/adempiere/adempiere/pull/2438) I find a error with Document Action, the problem is:

A Sales Order with **Completed** status can be: **Re-Activate** / **Void** / **Close**. The problem is that now just show **Close** action, see the gif

![DocAction_Error](https://user-images.githubusercontent.com/2333092/57951573-7001ea00-78b8-11e9-96f7-de514df9a2aa.gif)

The bug is because I get a tab ID isntead table ID for GridWindowVO
See:
<pre>
if (mWindowVO.AD_Table_ID == 0)
	mWindowVO.AD_Table_ID = tab.getAD_Tab_ID();
</pre>

![Screenshot_20190517_152953](https://user-images.githubusercontent.com/2333092/57951643-a2abe280-78b8-11e9-9106-c13bc617ec73.png)

After fix it now is ok:
![DocAction_Fixed](https://user-images.githubusercontent.com/2333092/57951649-accde100-78b8-11e9-867d-4563784e523f.gif)

I apologize for add this bug for trunk

Best regard