### PR TITLE
Bugfix/#process builder user not found

### DIFF
--- a/base/src/org/eevolution/service/dsl/ProcessBuilder.java
+++ b/base/src/org/eevolution/service/dsl/ProcessBuilder.java
@@ -189,6 +189,7 @@ public class ProcessBuilder {
             processInfo.setAD_User_ID(100);
         } else {
             processInfo.setAD_Client_ID(instance.getAD_Client_ID());
+            processInfo.setAD_User_ID(instance.getAD_User_ID());
         }
 
         ProcessInfoUtil.setParameterFromDB(processInfo);


### PR DESCRIPTION
Currently when a process is runned from ProcessBuilder utility class is throwed a error for missing user value

<pre>
org.adempiere.exceptions.AdempiereException: Process failed during execution Error:  User/Contact * Not found *
</pre>

The problem is that **AD_User_ID** attribute is not filled

This pull request fix it