### PR TITLE
Fixed error with alias for generated SQL for Smart browser

### DIFF
--- a/base/src/org/adempiere/model/MView.java
+++ b/base/src/org/adempiere/model/MView.java
@@ -28,6 +28,7 @@ import org.compiere.model.Query;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 /**
  * Class Model for Smart View
@@ -219,16 +220,31 @@ public class MView extends X_AD_View {
 	/**
 	 * get SQL from View
 	 * 
-	 * @param AD_View_ID
+	 * @param viewId
 	 * @param trxName
 	 * @return SQL string
 	 */
-	public static String getSQLFromView(int AD_View_ID, String trxName) {
+	public static String getSQLFromView(int viewId, String trxName) {
+		return getSQLFromView(viewId, null, trxName);
+	}
+	
+	/**
+	 * Get SQL from View with a custom column as alias
+	 * @param viewId
+	 * @param columnNameForAlias
+	 * @param trxName
+	 * @return
+	 */
+	public static String getSQLFromView(int viewId, String columnNameForAlias, String trxName) {
+		if(Util.isEmpty(columnNameForAlias)) {
+			columnNameForAlias = I_AD_View_Column.COLUMNNAME_ColumnName;
+		}
+		boolean isColumnName = columnNameForAlias.equals(I_AD_View_Column.COLUMNNAME_ColumnName);
 		StringBuffer sql = new StringBuffer();
 		StringBuffer joins = new StringBuffer();
 		StringBuffer cols = new StringBuffer();
 		String from = "";
-		MView view = new MView(Env.getCtx(), AD_View_ID, null);
+		MView view = new MView(Env.getCtx(), viewId, null);
 
 		sql.append("SELECT ");
 		boolean co = false;
@@ -244,13 +260,18 @@ public class MView extends X_AD_View {
 					cols.append(",");
 				if (col.getColumnSQL() != null
 						&& col.getColumnSQL().length() > 0) {
-					cols.append(col.getColumnSQL() + " as " + col.getColumnName());
+					cols.append(col.getColumnSQL());
 					co = true;
 				} else if (col.getColumnName() != null
 						&& col.getColumnName().length() > 0) {
-					cols.append(def.getTableAlias() + "." + col.getColumnName()
-							+ " as " + col.getColumnName());
+					cols.append(def.getTableAlias() + "." + col.getColumnName());
 					co = true;
+				}
+				//	Add Alias
+				if(isColumnName) {
+					cols.append(" AS \"" + col.get_ValueAsString(columnNameForAlias) + "\"");
+				} else { 
+					cols.append(" AS \"" + col.get_Translation(columnNameForAlias) + "\"");
 				}
 			}
 

--- a/base/src/org/adempiere/model/MView.java
+++ b/base/src/org/adempiere/model/MView.java
@@ -244,14 +244,12 @@ public class MView extends X_AD_View {
 					cols.append(",");
 				if (col.getColumnSQL() != null
 						&& col.getColumnSQL().length() > 0) {
-
-					cols.append(col.getColumnSQL() + " as " + col.getName());
+					cols.append(col.getColumnSQL() + " as " + col.getColumnName());
 					co = true;
 				} else if (col.getColumnName() != null
 						&& col.getColumnName().length() > 0) {
-
 					cols.append(def.getTableAlias() + "." + col.getColumnName()
-							+ " as " + col.getName());
+							+ " as " + col.getColumnName());
 					co = true;
 				}
 			}
@@ -266,7 +264,7 @@ public class MView extends X_AD_View {
 				from = table.getTableName() + " " + def.getTableAlias();
 		}
 
-		sql.append(cols).append(" from ").append(from).append(" ")
+		sql.append(cols).append(" FROM ").append(from).append(" ")
 				.append(joins);
 
 		return sql.toString();


### PR DESCRIPTION
Currently exists a helper method for get dynamically a SQL from Browser View named **getSQLFromView(int AD_View_ID, String trxName)** if it is called with a example like Requisition View the result is:

```SQL
SELECT r.AD_OrgTrx_ID as Trx Organization,r.AD_Client_ID as Client,r.C_Project_ID as Project,r.User1_ID as User List 1,r.IsActive as Active,r.Processed as Processed,r.DocAction as Document Action,r.DocumentNo as Document No,r.DocStatus as Document Status,r.Processing as Process Now,r.Posted as Posted,r.IsApproved as Approved,r.Updated as Updated,r.Created as Created,r.TotalLines as Total Lines,r.C_DocType_ID as Document Type,r.Help as Comment/Help,r.PriorityRule as Priority,r.DateRequired as Date Required,r.DateDoc as Document Date,r.Description as Description,r.ProcessedOn as Processed On,r.C_Activity_ID as Activity,r.M_Requisition_ID as Requisition,r.AD_Org_ID as Organization,r.CreatedBy as Created By,r.User4_ID as User List 4,r.C_Campaign_ID as Campaign,r.User2_ID as User List 2,r.User3_ID as User List 3,r.UpdatedBy as Updated By,r.M_PriceList_ID as Price List,r.M_Warehouse_ID as Warehouse,r.AD_User_ID as User/Contact,rl.C_ProjectPhase_ID as Project Phase,rl.C_ProjectTask_ID as Project Task,rl.User2_ID as User List 2,rl.User3_ID as User List 3,rl.User4_ID as User List 4,rl.C_OrderLine_ID as Sales Order Line,rl.UpdatedBy as Updated By,rl.M_Requisition_ID as Requisition,rl.M_AttributeSetInstance_ID as Attribute Set Instance,rl.Updated as Updated,rl.IsActive as Active,rl.Created as Created,rl.Description as Description,rl.PriceActual as Unit Price,rl.C_Charge_ID as Charge,rl.Qty as Quantity,rl.LineNetAmt as Line Amount,rl.C_UOM_ID as UOM,rl.C_BPartner_ID as Business Partner ,rl.AD_Org_ID as Organization,rl.CreatedBy as Created By,rl.AD_Client_ID as Client,rl.Line as Line No,rl.M_RequisitionLine_ID as Requisition Line,rl.M_Product_ID as Product,rl.C_Activity_ID as Activity,rl.C_Project_ID as Project,rl.C_Campaign_ID as Campaign,rl.AD_OrgTrx_ID as Trx Organization,rl.User1_ID as User List 1,ol.AD_Org_ID as Organization,ol.AD_Client_ID as Client,ol.M_Shipper_ID as Shipper,ol.C_Currency_ID as Currency,ol.C_Tax_ID as Tax,ol.CreatedBy as Created By,ol.C_BPartner_Location_ID as Partner Location,ol.UpdatedBy as Updated By,ol.S_ResourceAssignment_ID as Resource Assignment,ol.C_UOM_ID as UOM,ol.C_BPartner_ID as Business Partner ,ol.M_Promotion_ID as Promotion,ol.C_Charge_ID as Charge,ol.Updated as Updated,ol.PriceList as List Price,ol.QtyDelivered as Delivered Quantity,ol.PriceActual as Unit Price,ol.Created as Created,ol.DatePromised as Date Promised,ol.IsActive as Active,ol.C_ProjectPhase_ID as Project Phase,ol.Processed as Processed,ol.RRStartDate as Revenue Recognition Start,ol.C_ProjectTask_ID as Project Task,ol.QtyEntered as Quantity,ol.Description as Description,ol.DateOrdered as Date Ordered,ol.QtyReserved as Reserved Quantity,ol.QtyInvoiced as Quantity Invoiced,ol.DateDelivered as Date Delivered,ol.PriceLimit as Limit Price,ol.Line as Line No,ol.AD_OrgTrx_ID as Trx Organization,ol.PriceCost as Cost Price,ol.C_Campaign_ID as Campaign,ol.QtyLostSales as Lost Sales Qty,ol.FreightAmt as Freight Amount,ol.IsConsumesForecast as Is Consumes Forecast,ol.IsDescription as Description Only,ol.QtyOrdered as Ordered Quantity,ol.DateInvoiced as Date Invoiced,ol.PriceEntered as Price,ol.C_Project_ID as Project,ol.Discount as Discount %,ol.LineNetAmt as Line Amount,ol.RRAmt as Revenue Recognition Amt,ol.User2_ID as User List 2,ol.C_Activity_ID as Activity,ol.User1_ID as User List 1,ol.CreateFrom as Create lines from,ol.CreateShipment as Create Shipment,ol.PickedQty as Picked Qty,ol.C_OrderLine_ID as Sales Order Line,ol.C_Order_ID as Order,ol.User4_ID as User List 4,ol.M_Warehouse_ID as Warehouse,ol.PP_Cost_Collector_ID as Manufacturing Cost Collector,ol.Ref_OrderLine_ID as Referenced Order Line,ol.M_Product_ID as Product,ol.M_AttributeSetInstance_ID as Attribute Set Instance,ol.Link_OrderLine_ID as Linked Order Line,ol.M_FreightCategory_ID as Freight Category,ol.User3_ID as User List 3 
from M_Requisition r  
INNER JOIN M_RequisitionLine rl ON (r.M_Requisition_ID=rl.M_Requisition_ID)  
LEFT JOIN C_OrderLine ol ON (rl.C_OrderLine_ID = ol.C_OrderLine_ID)  
WHERE r.DocStatus=?  
AND r.DateRequired >= ?  
AND r.AD_Client_ID IN(0,11) 
AND r.AD_Org_ID IN(0,11,12,50000,50002,50001,50004,50006,50005,50007) 
ORDER BY 98,101
```
Note that alias for columns will be a error for SQL because is not a column name and have blank spaces

**SELECT r.AD_OrgTrx_ID as Trx Organization**

Affter change it can be running with:

```SQL
SELECT r.AD_OrgTrx_ID as R_AD_OrgTrx_ID,r.AD_Client_ID as R_AD_Client_ID,r.C_Project_ID as R_C_Project_ID,r.User1_ID as R_User1_ID,r.IsActive as R_IsActive,r.Processed as R_Processed,r.DocAction as R_DocAction,r.DocumentNo as R_DocumentNo,r.DocStatus as R_DocStatus,r.Processing as R_Processing,r.Posted as R_Posted,r.IsApproved as R_IsApproved,r.Updated as R_Updated,r.Created as R_Created,r.TotalLines as R_TotalLines,r.C_DocType_ID as R_C_DocType_ID,r.Help as R_Help,r.PriorityRule as R_PriorityRule,r.DateRequired as R_DateRequired,r.DateDoc as R_DateDoc,r.Description as R_Description,r.ProcessedOn as R_ProcessedOn,r.C_Activity_ID as R_C_Activity_ID,r.M_Requisition_ID as R_M_Requisition_ID,r.AD_Org_ID as R_AD_Org_ID,r.CreatedBy as R_CreatedBy,r.User4_ID as R_User4_ID,r.C_Campaign_ID as R_C_Campaign_ID,r.User2_ID as R_User2_ID,r.User3_ID as R_User3_ID,r.UpdatedBy as R_UpdatedBy,r.M_PriceList_ID as R_M_PriceList_ID,r.M_Warehouse_ID as R_M_Warehouse_ID,r.AD_User_ID as R_AD_User_ID,rl.C_ProjectPhase_ID as RL_C_ProjectPhase_ID,rl.C_ProjectTask_ID as RL_C_ProjectTask_ID,rl.User2_ID as RL_User2_ID,rl.User3_ID as RL_User3_ID,rl.User4_ID as RL_User4_ID,rl.C_OrderLine_ID as RL_C_OrderLine_ID,rl.UpdatedBy as RL_UpdatedBy,rl.M_Requisition_ID as RL_M_Requisition_ID,rl.M_AttributeSetInstance_ID as RL_M_AttributeSetInstance_ID,rl.Updated as RL_Updated,rl.IsActive as RL_IsActive,rl.Created as RL_Created,rl.Description as RL_Description,rl.PriceActual as RL_PriceActual,rl.C_Charge_ID as RL_C_Charge_ID,rl.Qty as RL_Qty,rl.LineNetAmt as RL_LineNetAmt,rl.C_UOM_ID as RL_C_UOM_ID,rl.C_BPartner_ID as RL_C_BPartner_ID,rl.AD_Org_ID as RL_AD_Org_ID,rl.CreatedBy as RL_CreatedBy,rl.AD_Client_ID as RL_AD_Client_ID,rl.Line as RL_Line,rl.M_RequisitionLine_ID as RL_M_RequisitionLine_ID,rl.M_Product_ID as RL_M_Product_ID,rl.C_Activity_ID as RL_C_Activity_ID,rl.C_Project_ID as RL_C_Project_ID,rl.C_Campaign_ID as RL_C_Campaign_ID,rl.AD_OrgTrx_ID as RL_AD_OrgTrx_ID,rl.User1_ID as RL_User1_ID,ol.AD_Org_ID as OL_AD_Org_ID,ol.AD_Client_ID as OL_AD_Client_ID,ol.M_Shipper_ID as OL_M_Shipper_ID,ol.C_Currency_ID as OL_C_Currency_ID,ol.C_Tax_ID as OL_C_Tax_ID,ol.CreatedBy as OL_CreatedBy,ol.C_BPartner_Location_ID as OL_C_BPartner_Location_ID,ol.UpdatedBy as OL_UpdatedBy,ol.S_ResourceAssignment_ID as OL_S_ResourceAssignment_ID,ol.C_UOM_ID as OL_C_UOM_ID,ol.C_BPartner_ID as OL_C_BPartner_ID,ol.M_Promotion_ID as OL_M_Promotion_ID,ol.C_Charge_ID as OL_C_Charge_ID,ol.Updated as OL_Updated,ol.PriceList as OL_PriceList,ol.QtyDelivered as OL_QtyDelivered,ol.PriceActual as OL_PriceActual,ol.Created as OL_Created,ol.DatePromised as OL_DatePromised,ol.IsActive as OL_IsActive,ol.C_ProjectPhase_ID as OL_C_ProjectPhase_ID,ol.Processed as OL_Processed,ol.RRStartDate as OL_RRStartDate,ol.C_ProjectTask_ID as OL_C_ProjectTask_ID,ol.QtyEntered as OL_QtyEntered,ol.Description as OL_Description,ol.DateOrdered as OL_DateOrdered,ol.QtyReserved as OL_QtyReserved,ol.QtyInvoiced as OL_QtyInvoiced,ol.DateDelivered as OL_DateDelivered,ol.PriceLimit as OL_PriceLimit,ol.Line as OL_Line,ol.AD_OrgTrx_ID as OL_AD_OrgTrx_ID,ol.PriceCost as OL_PriceCost,ol.C_Campaign_ID as OL_C_Campaign_ID,ol.QtyLostSales as OL_QtyLostSales,ol.FreightAmt as OL_FreightAmt,ol.IsConsumesForecast as OL_IsConsumesForecast,ol.IsDescription as OL_IsDescription,ol.QtyOrdered as OL_QtyOrdered,ol.DateInvoiced as OL_DateInvoiced,ol.PriceEntered as OL_PriceEntered,ol.C_Project_ID as OL_C_Project_ID,ol.Discount as OL_Discount,ol.LineNetAmt as OL_LineNetAmt,ol.RRAmt as OL_RRAmt,ol.User2_ID as OL_User2_ID,ol.C_Activity_ID as OL_C_Activity_ID,ol.User1_ID as OL_User1_ID,ol.CreateFrom as OL_CreateFrom,ol.CreateShipment as OL_CreateShipment,ol.PickedQty as OL_PickedQty,ol.C_OrderLine_ID as OL_C_OrderLine_ID,ol.C_Order_ID as OL_C_Order_ID,ol.User4_ID as OL_User4_ID,ol.M_Warehouse_ID as OL_M_Warehouse_ID,ol.PP_Cost_Collector_ID as OL_PP_Cost_Collector_ID,ol.Ref_OrderLine_ID as OL_Ref_OrderLine_ID,ol.M_Product_ID as OL_M_Product_ID,ol.M_AttributeSetInstance_ID as OL_M_AttributeSetInstance_ID,ol.Link_OrderLine_ID as OL_Link_OrderLine_ID,ol.M_FreightCategory_ID as OL_M_FreightCategory_ID,ol.User3_ID as OL_User3_ID 
FROM M_Requisition r  
INNER JOIN M_RequisitionLine rl ON (r.M_Requisition_ID=rl.M_Requisition_ID)  
LEFT JOIN C_OrderLine ol ON (rl.C_OrderLine_ID = ol.C_OrderLine_ID)  
WHERE r.DocStatus=?  
AND r.DateRequired >= ?  
AND r.AD_Client_ID IN(0,11) 
AND r.AD_Org_ID IN(0,11,12,50000,50002,50001,50004,50006,50005,50007) 
ORDER BY 98,101
``` 

**SELECT r.AD_OrgTrx_ID as R_AD_OrgTrx_ID**