### PR TITLE
Add support to parameter on export surrogate key for missing UUID

### DIFF
--- a/base/src/org/spin/process/ExportSurrogateKeyToMigration.java
+++ b/base/src/org/spin/process/ExportSurrogateKeyToMigration.java
@@ -151,12 +151,17 @@ public class ExportSurrogateKeyToMigration extends ExportSurrogateKeyToMigration
 	private void addTableToUpdate(String tableName) {
 		String keyId = tableName + "_ID";
 		String uuidKey = I_AD_Table.COLUMNNAME_UUID;
-		
-		KeyNamePair[] uuidValues = DB.getKeyNamePairs(get_TrxName(), "SELECT " + keyId + ", " + uuidKey + " FROM " + tableName + " WHERE AD_Client_ID = ? AND " + uuidKey + " IS NOT NULL" + entityTypeWhereClause, false, getAD_Client_ID());
+		String uuidWhereClause = uuidKey + " IS NOT NULL";
+		if(isOnlyUUIDMissing()) {
+			uuidKey = "getUUID()";
+			uuidWhereClause = I_AD_Table.COLUMNNAME_UUID + " IS NULL";
+		}
+		// Get
+		KeyNamePair[] uuidValues = DB.getKeyNamePairs(get_TrxName(), "SELECT " + keyId + ", " + uuidKey + " FROM " + tableName + " WHERE AD_Client_ID = ? AND " + uuidWhereClause + entityTypeWhereClause, false, getAD_Client_ID());
 		//	Get all UUID
 		for(KeyNamePair value : uuidValues) {
-			updateList.add("UPDATE " + tableName + " SET " + uuidKey + "= '" + value.getName() + "' WHERE " + keyId + " = " + value.getKey() + ";");
-			rollbackList.add("UPDATE " + tableName + " SET " + uuidKey + " = NULL WHERE " + keyId + " = " + value.getKey() + ";");
+			updateList.add("UPDATE " + tableName + " SET " + I_AD_Table.COLUMNNAME_UUID + "= '" + value.getName() + "' WHERE " + keyId + " = " + value.getKey() + ";");
+			rollbackList.add("UPDATE " + tableName + " SET " + I_AD_Table.COLUMNNAME_UUID + " = NULL WHERE " + keyId + " = " + value.getKey() + ";");
 		}
 		//	Add
 		addMigration();

--- a/base/src/org/spin/process/ExportSurrogateKeyToMigrationAbstract.java
+++ b/base/src/org/spin/process/ExportSurrogateKeyToMigrationAbstract.java
@@ -34,15 +34,20 @@ public abstract class ExportSurrogateKeyToMigrationAbstract extends SvrProcess {
 	public static final String AD_TABLE_ID = "AD_Table_ID";
 	/**	Parameter Name for Entity Type	*/
 	public static final String ENTITYTYPE = "EntityType";
+	/**	Parameter Name for Only UUID Missing	*/
+	public static final String ISONLYUUIDMISSING = "IsOnlyUUIDMissing";
 	/**	Parameter Value for Table	*/
 	private int tableId;
 	/**	Parameter Value for Entity Type	*/
 	private String entityType;
+	/**	Parameter Value for Only UUID Missing	*/
+	private boolean isOnlyUUIDMissing;
 
 	@Override
 	protected void prepare() {
 		tableId = getParameterAsInt(AD_TABLE_ID);
 		entityType = getParameterAsString(ENTITYTYPE);
+		isOnlyUUIDMissing = getParameterAsBoolean(ISONLYUUIDMISSING);
 	}
 
 	/**	 Getter Parameter Value for Table	*/
@@ -63,6 +68,16 @@ public abstract class ExportSurrogateKeyToMigrationAbstract extends SvrProcess {
 	/**	 Setter Parameter Value for Entity Type	*/
 	protected void setEntityType(String entityType) {
 		this.entityType = entityType;
+	}
+
+	/**	 Getter Parameter Value for Only UUID Missing	*/
+	protected boolean isOnlyUUIDMissing() {
+		return isOnlyUUIDMissing;
+	}
+
+	/**	 Setter Parameter Value for Only UUID Missing	*/
+	protected void setIsOnlyUUIDMissing(boolean isOnlyUUIDMissing) {
+		this.isOnlyUUIDMissing = isOnlyUUIDMissing;
 	}
 
 	/**	 Getter Parameter Value for Process ID	*/

--- a/migration/392lts-393lts/04670_2564_Add_Parameter_Export_Surrogate_Key.xml
+++ b/migration/392lts-393lts/04670_2564_Add_Parameter_Export_Surrogate_Key.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Line with centralized id does not have uuid in the seed #256" ReleaseNo="3.9.3" SeqNo="4670">
+    <Comments>Related to: https://github.com/adempiere/adempiere/issues/2564</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="276" Action="I" Record_ID="61002" Table="AD_Element">
+        <Data AD_Column_ID="2600" Column="Updated">2019-05-28 11:43:37.216</Data>
+        <Data AD_Column_ID="2597" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2603" Column="Name">Only UUID Missing</Data>
+        <Data AD_Column_ID="2604" Column="Description">Only Export UUID missing from tables</Data>
+        <Data AD_Column_ID="2598" Column="Created">2019-05-28 11:43:37.216</Data>
+        <Data AD_Column_ID="2602" Column="ColumnName">IsOnlyUUIDMissing</Data>
+        <Data AD_Column_ID="2605" Column="Help">Note that if your DB don't have UUID generated and you want to export migration you can use this flag for generate onlu missing UUID</Data>
+        <Data AD_Column_ID="6284" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="6285" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="4299" Column="PrintName">Only UUID Missing</Data>
+        <Data AD_Column_ID="6286" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="6283" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="58589" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="58588" Column="AD_Reference_ID">20</Data>
+        <Data AD_Column_ID="2594" Column="AD_Element_ID">61002</Data>
+        <Data AD_Column_ID="2596" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2595" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="6484" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="2599" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58590" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2601" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84316" Column="UUID">8ce87086-8163-11e9-b296-5fe490437ea4</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="277" Action="I" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2642" Column="Created">2019-05-28 11:43:38.303</Data>
+        <Data AD_Column_ID="6449" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="2641" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2644" Column="Updated">2019-05-28 11:43:38.303</Data>
+        <Data AD_Column_ID="2638" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6450" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="2648" Column="Help">Note that if your DB don't have UUID generated and you want to export migration you can use this flag for generate onlu missing UUID</Data>
+        <Data AD_Column_ID="2646" Column="Name">Only UUID Missing</Data>
+        <Data AD_Column_ID="2647" Column="Description">Only Export UUID missing from tables</Data>
+        <Data AD_Column_ID="2649" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="4300" Column="PrintName">Only UUID Missing</Data>
+        <Data AD_Column_ID="6451" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="6448" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="2640" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2639" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2645" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2643" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID">61002</Data>
+        <Data AD_Column_ID="84317" Column="UUID">8d40170a-8163-11e9-b2af-bbb354342879</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="2648" Column="Help" oldValue="Note that if your DB don't have UUID generated and you want to export migration you can use this flag for generate onlu missing UUID">Note que si su Base de Datos no tiene generados los UUIDsy usted desea exportar los UUID faltantes puede usar esta bandera para generar los UUID y exportarlos</Data>
+        <Data AD_Column_ID="2646" Column="Name" oldValue="Only UUID Missing">Sólo UUID Faltantes</Data>
+        <Data AD_Column_ID="2647" Column="Description" oldValue="Only Export UUID missing from tables">Sólo Exporta los UUIDs Faltantes</Data>
+        <Data AD_Column_ID="4300" Column="PrintName" oldValue="Only UUID Missing">Sólo UUID Faltantes</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="61002">61002</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="276" Action="U" Record_ID="61002" Table="AD_Element">
+        <Data AD_Column_ID="2605" Column="Help" oldValue="Note that if your DB don't have UUID generated and you want to export migration you can use this flag for generate onlu missing UUID">Note that if your DB don't have UUID generated and you want to export migration you can use this flag for generate only missing UUID</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="285" Action="I" Record_ID="56918" Table="AD_Process_Para">
+        <Data AD_Column_ID="2820" Column="Updated">2019-05-28 11:49:06.312</Data>
+        <Data AD_Column_ID="2822" Column="Name">Only UUID Missing</Data>
+        <Data AD_Column_ID="2817" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2830" Column="IsRange">false</Data>
+        <Data AD_Column_ID="2818" Column="Created">2019-05-28 11:49:06.312</Data>
+        <Data AD_Column_ID="3738" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="4017" Column="ColumnName">IsOnlyUUIDMissing</Data>
+        <Data AD_Column_ID="2823" Column="Description">Only Export UUID missing from tables</Data>
+        <Data AD_Column_ID="2824" Column="Help">Note that if your DB don't have UUID generated and you want to export migration you can use this flag for generate only missing UUID</Data>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="3739" Column="DefaultValue">N</Data>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="81287" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID">56918</Data>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="7728" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="3737" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID">54170</Data>
+        <Data AD_Column_ID="2819" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID">20</Data>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2826" Column="SeqNo">30</Data>
+        <Data AD_Column_ID="2821" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID">61002</Data>
+        <Data AD_Column_ID="84385" Column="UUID">5132342c-8164-11e9-b71c-a37528514645</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="286" Action="I" Record_ID="56918" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="2836" Column="Created">2019-05-28 11:49:07.415</Data>
+        <Data AD_Column_ID="2835" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2838" Column="Updated">2019-05-28 11:49:07.415</Data>
+        <Data AD_Column_ID="2840" Column="Name">Only UUID Missing</Data>
+        <Data AD_Column_ID="2842" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2841" Column="Description">Only Export UUID missing from tables</Data>
+        <Data AD_Column_ID="3743" Column="Help">Note that if your DB don't have UUID generated and you want to export migration you can use this flag for generate only missing UUID</Data>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID">56918</Data>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2837" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2832" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84386" Column="UUID">516a8f34-8164-11e9-b73f-17abf1beea91</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
This pull request allows generate only missing UUID from ADempiere seed, note that just need set a flag named **Only UUID Missing** 

See: 
![Current ogv](https://user-images.githubusercontent.com/2333092/58496754-81fd4b80-8148-11e9-9f39-0565eb0ed8f9.gif)


Related: #2564