### PR TITLE
Add support to SQL values on Workflow node condition

### DIFF
--- a/migration/392lts-393lts/04710_Increase_WF_Condition_Column_Size.xml
+++ b/migration/392lts-393lts/04710_Increase_WF_Condition_Column_Size.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add Support to SQL for Workflow Condition Value" ReleaseNo="3.9.3" SeqNo="4710">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="11573" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="40">255</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="11576" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="40">255</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION

![Current ogv](https://user-images.githubusercontent.com/2333092/58727447-5f6e6b00-83b2-11e9-88fa-3d282e06f612.gif)

Currently is very useful when a client want to use workflow approval for ADempiere, however is nice to have a way for get SQL values to compare for condition of node.

A simple example is that a requisition must be add to approval level when **TotalLines** > **ApprovalAmt** of user.
Note that **ApprovalAmt** is  only a example of column.

The current problem is that if you want to compare values is allowed only values of PO or fix values, example:

**TotalLines** > **100**
or
**DateRequired** <> **DateDoc**

I want to compare **TotalLines** with **ApprovalAmt** of User table and need make a query to AD_User:

![Screenshot_20190531_143853](https://user-images.githubusercontent.com/2333092/58727387-2930eb80-83b2-11e9-854a-10981b18dacb.png)


```SQL
@SQL=SELECT ApprovalAmt FROM AD_User WHERE AD_User_ID = @SalesRep_ID@
```

After change is possible compare values with SQL