### PR TITLE
#2612 Solve error for Reference Validation Type Table

### DIFF
--- a/base/src/org/adempiere/pipo/handler/ReferenceElementHandler.java
+++ b/base/src/org/adempiere/pipo/handler/ReferenceElementHandler.java
@@ -23,6 +23,7 @@ import javax.xml.transform.sax.TransformerHandler;
 
 import org.adempiere.pipo.PackOut;
 import org.compiere.model.I_AD_Ref_List;
+import org.compiere.model.I_AD_Ref_Table;
 import org.compiere.model.Query;
 import org.compiere.model.X_AD_Ref_List;
 import org.compiere.model.X_AD_Ref_Table;
@@ -50,7 +51,7 @@ public class ReferenceElementHandler extends GenericPOHandler {
 				packOut.createGenericPO(document, referenceList, true, null);
 			}
 		} else if(reference.getValidationType().equals(X_AD_Reference.VALIDATIONTYPE_TableValidation)) {
-			List<X_AD_Ref_Table> referenceTableAsList = new Query(ctx, I_AD_Ref_List.Table_Name, I_AD_Ref_List.COLUMNNAME_AD_Reference_ID + " = ?", null)
+			List<X_AD_Ref_Table> referenceTableAsList = new Query(ctx, I_AD_Ref_Table.Table_Name, I_AD_Ref_Table.COLUMNNAME_AD_Reference_ID + " = ?", null)
 					.setParameters(referenceId)
 					.setOnlyActiveRecords(true)
 					.list();


### PR DESCRIPTION
When a packout is generated for reference with validation type table, it does not export the reference table record.
Example: 
```
<GenericPO_AD_Reference AD_ReferenceUUID="3b56cf00-66d9-11e9-97d0-0242ac140008" TableNameTag="AD_Reference" TableIdTag="102" IsActive="true" ValidationType="T" Help="" IsOrderByValue="false" VFormat="" Name="R_Request ReferenceNo" Description="" EntityType="CUST" UUID="3b56cf00-66d9-11e9-97d0-0242ac140008"/>
```

Now:
```
<GenericPO_AD_Reference AD_ReferenceUUID="3b56cf00-66d9-11e9-97d0-0242ac140008" TableNameTag="AD_Reference" TableIdTag="102" IsActive="true" ValidationType="T" Help="" IsOrderByValue="false" VFormat="" Name="R_Request ReferenceNo" Description="" EntityType="CUST" UUID="3b56cf00-66d9-11e9-97d0-0242ac140008"/>
<GenericPO_AD_Ref_Table AD_Ref_TableUUID="813d1588-66d9-11e9-97d0-0242ac140008" TableNameTag="AD_Ref_Table" TableIdTag="103" IsActive="true" OrderByClause="" IsValueDisplayed="false" WhereClause="" IsAlert="false" DisplaySQL="" IsDisplayIdentifier="false" AD_Display="1000126" AD_DisplayUUID="d9732dbe-5d6a-11e9-ae0a-0242ac140007" EntityType="CUST" AD_Table_ID="417" AD_Table_IDUUID="a4a66e20-fb40-11e8-a479-7a0060f0aa01" AD_Window_ID="" AD_Key="5415" AD_KeyUUID="8be3c874-fb40-11e8-a479-7a0060f0aa01" AD_Reference_ID="1000003" AD_Reference_IDUUID="3b56cf00-66d9-11e9-97d0-0242ac140008" UUID="813d1588-66d9-11e9-97d0-0242ac140008"/>
```
