### PR TITLE
Validate if exist changes for PO before save migration

### DIFF
--- a/base/src/org/compiere/model/MSession.java
+++ b/base/src/org/compiere/model/MSession.java
@@ -332,8 +332,12 @@ public class MSession extends X_AD_Session
 		if(pinfo.isIgnoreMigration())
 			return;
 		// ignore statistic updates
-		if ( pinfo.getTableName().equalsIgnoreCase("AD_Process") && !po.is_new() && po.is_ValueChanged("Statistic_Count") )
+		if (pinfo.getTableName().equalsIgnoreCase("AD_Process") && !po.is_new() && po.is_ValueChanged("Statistic_Count"))
 			return;
+		//	Validate change
+		if(!po.is_Changed()) {
+			return;
+		}
 		
 		// Check that m_migration still points to a valid migration.  A merge during the session
 		// may have deleted the current migration.  If needed, create a new one.


### PR DESCRIPTION
When a packin is imported with log migration enabled, it make unnecessary changes for migration.

This pull request fix it