### PR TITLE
Fixed error with overwrite Smart Browser for Where clause

### DIFF
--- a/client/src/org/compiere/apps/APanel.java
+++ b/client/src/org/compiere/apps/APanel.java
@@ -98,6 +98,7 @@ import org.compiere.util.Language;
 import org.compiere.util.Msg;
 import org.compiere.util.Util;
 import org.eevolution.form.VBrowser;
+import org.spin.util.ASPUtil;
 
 /**
  *	Main Panel of application window.
@@ -2684,8 +2685,7 @@ public final class APanel extends CPanel
 			pi.setAD_Client_ID (Env.getAD_Client_ID(ctx));
 			FormFrame ff = new FormFrame(getWindowNo());
 			ff.setProcessInfo(pi);
-			MBrowse browse = new MBrowse(Env.getCtx(), browse_ID , null);
-			new VBrowser(ff, true , getWindowNo(), "" , browse , "" , true, "", Env.isSOTrx(Env.getCtx(), m_curWindowNo));
+			new VBrowser(ff, true , getWindowNo(), "" , ASPUtil.getInstance().getBrowse(browse_ID), "" , true, "", Env.isSOTrx(Env.getCtx(), m_curWindowNo));
 			ff.pack();
 			AEnv.showCenterScreen(ff);
 			//	Yamel Senih

--- a/client/src/org/eevolution/form/VBrowser.java
+++ b/client/src/org/eevolution/form/VBrowser.java
@@ -69,6 +69,7 @@ import org.compiere.util.Splash;
 import org.eevolution.grid.Browser;
 import org.eevolution.grid.BrowserSearch;
 import org.eevolution.grid.VBrowserTable;
+import org.spin.util.ASPUtil;
 
 /**
  * UI Browser
@@ -715,7 +716,6 @@ public class VBrowser extends Browser implements ActionListener, ListSelectionLi
 		login.batchLogin();
 
 		Properties m_ctx = Env.getCtx();
-		MBrowse browse = new MBrowse(m_ctx, 50025, null);
 		FormFrame frame = new FormFrame(0);
 		boolean modal = true;
 		int WindowNo = 0;
@@ -723,7 +723,7 @@ public class VBrowser extends Browser implements ActionListener, ListSelectionLi
 		String keyColumn = "";
 		boolean multiSelection = true;
 		String whereClause = "";
-		VBrowser browser = new VBrowser(frame, modal, WindowNo, value, browse,
+		VBrowser browser = new VBrowser(frame, modal, WindowNo, value, ASPUtil.getInstance().getBrowse(50025),
 				keyColumn, multiSelection, whereClause, true);
 		// browser.setPreferredSize(getPreferredSize ());
 		browser.getFrame().setVisible(true);

--- a/org.adempiere.pos/src/main/java/ui/swing/org/adempiere/pos/POSActionMenu.java
+++ b/org.adempiere.pos/src/main/java/ui/swing/org/adempiere/pos/POSActionMenu.java
@@ -43,6 +43,7 @@ import org.compiere.process.ProcessInfo;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
 import org.eevolution.form.VBrowser;
+import org.spin.util.ASPUtil;
 
 /**
  * Class that execute business logic from POS
@@ -233,8 +234,8 @@ public class POSActionMenu implements  ActionListener , POSQueryListener{
                 Dimension size = new Dimension(1024, 768);
                 FormFrame ff = new FormFrame(pos.getWindowNo());
                 ff.setSize(size);
-                MBrowse browse = new MBrowse(Env.getCtx(), 50056 , null);
-                new VBrowser(ff, true , pos.getWindowNo(), "" , browse , "" , true, "", true);
+                //	Danger --- Hardcode
+                new VBrowser(ff, true , pos.getWindowNo(), "" , ASPUtil.getInstance().getBrowse(50056), "" , true, "", true);
                 ff.pack();
                 AEnv.showCenterScreen(ff);
             } else if (command.getCommand() == CommandManager.CLOSE_STATEMENT) {

--- a/zkwebui/WEB-INF/src/org/eevolution/form/WBrowser.java
+++ b/zkwebui/WEB-INF/src/org/eevolution/form/WBrowser.java
@@ -61,6 +61,7 @@ import org.compiere.util.Msg;
 import org.eevolution.grid.Browser;
 import org.eevolution.grid.BrowserSearch;
 import org.eevolution.grid.WBrowserTable;
+import org.spin.util.ASPUtil;
 import org.zkoss.util.media.AMedia;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
@@ -137,14 +138,13 @@ public class WBrowser extends Browser implements IFormController,
 	 * @return
 	 */
 	public static CustomForm openBrowse(int windowNo , int browserId , String whereClause, Boolean isSOTrx) {
-		MBrowse browse = new MBrowse(Env.getCtx(), browserId , null);
 		boolean modal = false;
 		if (windowNo > 0)
 			modal = true;
 		String value = "";
 		String keyColumn = "";
 		boolean multiSelection = true;
-		return new WBrowser(modal, windowNo, value, browse, keyColumn, multiSelection, whereClause,isSOTrx).getForm();
+		return new WBrowser(modal, windowNo, value, ASPUtil.getInstance().getBrowse(browserId), keyColumn, multiSelection, whereClause,isSOTrx).getForm();
 	}
 	
 	/**


### PR DESCRIPTION
Currently if I want to overwrite a Where clause for a Smart Browser it not work, a example:

Original Browser: Create Payment Selection (From Invoice)
Original Where Clause: 
```SQL
 inv.DocStatus IN('CO')
```

Custom Where Clause from Smart Browser Customization window: 
```SQL
 inv.DocStatus IN('CO') AND inv.DateInvoiced = now()
```

The new Custom **Where Clause** should overwrite original where clause according with https://github.com/adempiere/adempiere/pull/2438 

The problem is that Smart Browse calling from Windows not have a calling with **ASPUtil**

With this pull request it worked