### PR TITLE
Fixed Error with parent UUID reference for packout

### DIFF
--- a/base/src/org/adempiere/pipo/AbstractElementHandler.java
+++ b/base/src/org/adempiere/pipo/AbstractElementHandler.java
@@ -91,11 +91,11 @@ public abstract class AbstractElementHandler implements ElementHandler {
 	 * Get Node UUID from Node ID
 	 * @param ctx
 	 * @param tableName
-	 * @param value
+	 * @param nodeId
 	 * @return
 	 */
-	public String getUUIDFromNodeId(Properties ctx, String tableName, int value) {
-		return IDFinder.getUUIDFromNodeId(tableName, value, getTrxName(ctx));
+	public String getUUIDFromNodeId(Properties ctx, String tableName, int treeId, int nodeId) {
+		return IDFinder.getUUIDFromNodeId(tableName, treeId, nodeId, getTrxName(ctx));
 	}
 	
 	/**

--- a/base/src/org/adempiere/pipo/IDFinder.java
+++ b/base/src/org/adempiere/pipo/IDFinder.java
@@ -212,13 +212,13 @@ public final class IDFinder
 	/**
 	 * Get UUID from ID
 	 * @param tableName
-	 * @param value
+	 * @param nodeId
 	 * @param clientId
 	 * @param trxName
 	 * @return
 	 */
-	public static String getUUIDFromNodeId(String tableName, int value, String trxName) {
-		if (value <= 0)
+	public static String getUUIDFromNodeId(String tableName, int treeId, int nodeId, String trxName) {
+		if (nodeId <= 0)
 			return null;
 		
 		//construct cache key
@@ -227,7 +227,13 @@ public final class IDFinder
 			.append(".")
 		 	.append("Node_ID")
 			.append("=")
-			.append(value);
+			.append(nodeId)
+			.append(" AND ")
+			.append(tableName)
+			.append(".")
+			.append("AD_Tree_ID")
+			.append("=")
+			.append(treeId);
 		
 		ArrayList<Object> params = new ArrayList<Object>();
 		StringBuffer sql = new StringBuffer ("select ")
@@ -236,8 +242,11 @@ public final class IDFinder
 		 	.append(tableName)
 		 	.append(" where ")
 		 	.append("Node_ID")
+		 	.append(" = ?")
+		 	.append("AD_Tree_ID")
 		 	.append(" = ?");
-		params.add(value);
+		params.add(nodeId);
+		params.add(treeId);
 		//	Get
 		return getUUID(sql.toString(), params, key.toString(), trxName);
 	}

--- a/base/src/org/adempiere/pipo/IDFinder.java
+++ b/base/src/org/adempiere/pipo/IDFinder.java
@@ -243,6 +243,7 @@ public final class IDFinder
 		 	.append(" where ")
 		 	.append("Node_ID")
 		 	.append(" = ?")
+		 	.append(" and ")
 		 	.append("AD_Tree_ID")
 		 	.append(" = ?");
 		params.add(nodeId);

--- a/base/src/org/adempiere/pipo/handler/GenericPOHandler.java
+++ b/base/src/org/adempiere/pipo/handler/GenericPOHandler.java
@@ -372,10 +372,8 @@ public class GenericPOHandler extends AbstractElementHandler {
 	 */
 	private boolean isValidAccess(String accessLevel, String parentAccessLevel) {
 		//	Validate system
-		if((parentAccessLevel.equals(X_AD_Table.ACCESSLEVEL_SystemOnly)
-				|| parentAccessLevel.equals(X_AD_Table.ACCESSLEVEL_SystemPlusClient))
-				&& !accessLevel.equals(X_AD_Table.ACCESSLEVEL_SystemOnly)
-				&& !accessLevel.equals(X_AD_Table.ACCESSLEVEL_SystemPlusClient)) {
+		if((parentAccessLevel.equals(X_AD_Table.ACCESSLEVEL_SystemOnly))
+				&& !accessLevel.equals(X_AD_Table.ACCESSLEVEL_SystemOnly)) {
 			return false;
 		}
 		//	Ok

--- a/base/src/org/adempiere/pipo/handler/GenericPOHandler.java
+++ b/base/src/org/adempiere/pipo/handler/GenericPOHandler.java
@@ -520,7 +520,7 @@ public class GenericPOHandler extends AbstractElementHandler {
 					MTree tree = MTree.get(ctx, treeId, null);
 					MTable sourceTable = MTable.get(ctx, tree.getAD_Table_ID());
 					String sourceUuid = getUUIDFromId(ctx, sourceTable.getTableName(), nodeId);
-					String parentUuid = getUUIDFromNodeId(ctx, entity.get_TableName(), parentId);
+					String parentUuid = getUUIDFromNodeId(ctx, entity.get_TableName(), treeId, parentId);
 					//	Set
 					filler.addString(AttributeFiller.getUUIDAttribute(I_AD_TreeNode.COLUMNNAME_Node_ID), sourceUuid);
 					filler.addString(AttributeFiller.getUUIDAttribute(I_AD_TreeNode.COLUMNNAME_Parent_ID), parentUuid);


### PR DESCRIPTION
The problem is that when a tree node is exported the parent node UUID exported is wrong. It is because not exist a filter by Tree and Parent Node ID