### PR TITLE
Fixed error with timestamp values

### DIFF
--- a/base/src/org/adempiere/pipo/PoFiller.java
+++ b/base/src/org/adempiere/pipo/PoFiller.java
@@ -133,7 +133,7 @@ public class PoFiller {
 		} else if (clazz == Boolean.class) {
 			valueAsObject = Boolean.valueOf(value);
 		} else if (clazz == Timestamp.class) {
-			Timestamp dateValue = Timestamp.valueOf(value);
+			Timestamp dateValue = new Timestamp(Long.parseLong(value));
 			valueAsObject = dateValue;
 		} else {
 			throw new AdempiereException("Class not supported - " + clazz);


### PR DESCRIPTION
The problem is that if you try export a timestamp like **Valid From** is exported as long value but when is imported is taked as String

See:
![Current ogv](https://user-images.githubusercontent.com/2333092/59619706-23990c80-90f9-11e9-9913-54a4680e834d.gif)


Here a log:

```Shell
java.lang.IllegalArgumentException: Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]
	at java.sql.Timestamp.valueOf(Timestamp.java:204)
	at org.adempiere.pipo.PoFiller.getValueFromType(PoFiller.java:136)
	at org.adempiere.pipo.PoFiller.setAttribute(PoFiller.java:105)
	at org.adempiere.pipo.handler.GenericPOHandler.startElement(GenericPOHandler.java:176)
	at org.adempiere.pipo.PackInHandler.startElement(PackInHandler.java:365)
	at org.apache.xerces.parsers.AbstractSAXParser.startElement(Unknown Source)
	at org.apache.xerces.parsers.AbstractXMLDocumentParser.emptyElement(Unknown Source)
	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanStartElement(Unknown Source)
	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl$FragmentContentDispatcher.dispatch(Unknown Source)
	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanDocument(Unknown Source)
	at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
	at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
	at org.apache.xerces.parsers.XMLParser.parse(Unknown Source)
	at org.apache.xerces.parsers.AbstractSAXParser.parse(Unknown Source)
	at org.apache.xerces.jaxp.SAXParserImpl$JAXPSAXParser.parse(Unknown Source)
	at javax.xml.parsers.SAXParser.parse(SAXParser.java:392)
	at javax.xml.parsers.SAXParser.parse(SAXParser.java:328)
	at org.adempiere.pipo.PackIn.importXML(PackIn.java:79)
	at org.adempiere.pipo.PackIn.doIt(PackIn.java:143)
	at org.compiere.process.SvrProcess.process(SvrProcess.java:175)
	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:128)

===========> PackIn.process: Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff] [37]
java.lang.IllegalArgumentException: Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]
	at java.sql.Timestamp.valueOf(Timestamp.java:204)
	at org.adempiere.pipo.PoFiller.getValueFromType(PoFiller.java:136)
	at org.adempiere.pipo.PoFiller.setAttribute(PoFiller.java:105)
	at org.adempiere.pipo.handler.GenericPOHandler.startElement(GenericPOHandler.java:176)
	at org.adempiere.pipo.PackInHandler.startElement(PackInHandler.java:365)
	at org.apache.xerces.parsers.AbstractSAXParser.startElement(Unknown Source)
	at org.apache.xerces.parsers.AbstractXMLDocumentParser.emptyElement(Unknown Source)
	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanStartElement(Unknown Source)
	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl$FragmentContentDispatcher.dispatch(Unknown Source)
	at org.apache.xerces.impl.XMLDocumentFragmentScannerImpl.scanDocument(Unknown Source)
	at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
	at org.apache.xerces.parsers.XML11Configuration.parse(Unknown Source)
	at org.apache.xerces.parsers.XMLParser.parse(Unknown Source)
	at org.apache.xerces.parsers.AbstractSAXParser.parse(Unknown Source)
	at org.apache.xerces.jaxp.SAXParserImpl$JAXPSAXParser.parse(Unknown Source)
	at javax.xml.parsers.SAXParser.parse(SAXParser.java:392)
	at javax.xml.parsers.SAXParser.parse(SAXParser.java:328)
	at org.adempiere.pipo.PackIn.importXML(PackIn.java:79)
	at org.adempiere.pipo.PackIn.doIt(PackIn.java:143)
	at org.compiere.process.SvrProcess.process(SvrProcess.java:175)
	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:128)

```
![Screenshot_20190617_120435](https://user-images.githubusercontent.com/2333092/59619756-3f9cae00-90f9-11e9-97ac-26c326041122.png)
