### PR TITLE
Fixed problem with new value as null, this bug was introduced by myself

### DIFF
--- a/base/src/org/compiere/model/PO.java
+++ b/base/src/org/compiere/model/PO.java
@@ -636,7 +636,8 @@ public abstract class PO
 			return false;
 		}
 		if (m_newValues[index] == null
-				|| m_newValues[index].equals(Null.NULL))
+				|| (m_newValues[index].equals(Null.NULL)
+						&& m_oldValues[index] == null))
 			return false;
 		return !m_newValues[index].equals(m_oldValues[index]);
 	}   //  is_ValueChanged


### PR DESCRIPTION
Fixed error with new value as null.

Test case (As Garden World):
 - Go to Business Partner
 - Select a BP with a language configured
 - Unselect language
 - Save

The result is that language is not setted as null

This was introduced by myself here: https://github.com/adempiere/adempiere/pull/2628 I apologize by it