### PR TITLE
Add support to updated values for overwrite local changes

### DIFF
--- a/base/src/org/adempiere/pipo/handler/GenericPOHandler.java
+++ b/base/src/org/adempiere/pipo/handler/GenericPOHandler.java
@@ -104,8 +104,7 @@ public class GenericPOHandler extends AbstractElementHandler {
 		//	Validate update time
 		if(!Env.getContext(ctx, "UpdateMode").equals("true")) {
 			//	Validate it
-			if(currentPOTime > 0
-					&& importTime > 0
+			if(importTime > 0
 					&& currentPOTime >= importTime
 					&& !entity.is_new()) {
 				element.skip = true;


### PR DESCRIPTION
The problem:
Now is possible import packing with validation for update column, example:

- First test case: 
**Current Element:** Name
**Current Lenght:** 30
**Current Updated:** 2019-01-01 : 01:50
**Imported Element:** Name
**Imported Length:** 60
**Imported Updated:** 2019-01-01 : 01:51
**Result:** Imported is applied
- Second test case:
**Current Element:** Name
**Current Lenght:** 30
**Current Updated:** 2019-01-01 : 01:51
**Imported Element:** Name
**Imported Length:** 30
**Imported Updated:** 2019-01-01 : 01:51
**Result:** Imported is unaplied
- Third test case:
**Current Element:** Name
**Current Lenght:** 30
**Current Updated:** null
**Imported Element:** Name
**Imported Length:** 60
**Imported Updated:** 2019-01-01 : 01:51
**Result:** Imported is unaplied (Here is a bug)

This pull request resolve previous behavior
