### PR TITLE
Add contract for Employee information

### DIFF
--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRProcess.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRProcess.java
@@ -1062,6 +1062,7 @@ public class MHRProcess extends X_HR_Process implements DocAction , DocumentReve
 		scriptCtx.remove("_HR_Employee_ValidFrom");
 		scriptCtx.remove("_HR_Employee_ValidTo");
 		scriptCtx.remove("_HR_Employee_Payroll_Value");
+		scriptCtx.remove("_HR_Employee_Contract");
 
 		scriptCtx.put("_DateStart", employee.getStartDate());
 		scriptCtx.put("_DateEnd", employee.getEndDate() == null ? dateTo == null ? getDateAcct() : dateTo : employee.getEndDate());
@@ -1074,6 +1075,10 @@ public class MHRProcess extends X_HR_Process implements DocAction , DocumentReve
 		//	Get Employee valid from and to
 		scriptCtx.put("_HR_Employee_ValidFrom", employeeValidFrom);
 		scriptCtx.put("_HR_Employee_ValidTo", employeeValidTo);
+		if(employee.getHR_Payroll_ID() > 0) {
+			MHRContract contract = MHRContract.getById(getCtx(), employee.getHR_Payroll().getHR_Contract_ID(), get_TrxName());
+			scriptCtx.put("_HR_Employee_Contract", contract);
+		}
 		//	
 		if(getHR_Period_ID() > 0) {
 			createCostCollectorMovements(partner.get_ID(), payrollPeriod);


### PR DESCRIPTION
This add more info to #761

Currently, the payroll processing have the follow values:

- By Run:
  - **process**: MHRProcess Object
  - **_Process**: HR_Process_ID int
  - **_Period**: HR_Period_ID int
  - **_Payroll**: HR_Payroll_ID int
  - **_Department**: HR_Department_ID int
  - **_From**: StartDate (Payroll) Timestamp
  - **_To**: EndDate (Payroll) Timestamp
  - **_HR_Payroll_Value**: Current Payroll Value String 
- By Employee run:
  - **_DateStart**: StartDate (Employee) Timestamp
  - **_DateEnd**: EndDate (Employee) Timestamp
  - **_Days**: Days between StartDate (Payroll) and EndDate (Payroll) int
  - **_C_BPartner_ID**: C_BPartner_ID int
  - **_HR_Employee_ID**: HR_Employee_ID int
  - **_C_BPartner**: MBPartner Object
  - **_HR_Employee**: MHREmployee Object
  - **_HR_Employee_ValidFrom**: (Employee valid from): <pre>(_DateStart > _From? _DateStart: _From)</pre>
  - **_HR_Employee_ValidTo**: (Employee valid to): <pre>(_DateEnd < _To? _DateEnd: _To)</pre>
  - **_HR_Employee_Payroll_Value**: Payroll value of Employee String
- By Concept run
  - **_HR_Concept_ID**: HR_Concept_ID int
  - **_HR_Concept**: MHRConcept Object
  - **_HR_PayrollConcept_ID**:  HR_PayrollConcept_ID int

I propose the follow variables for help to user to get important values from Ctx:
- By Employee run:
  - **_HR_Employee_Contract**: Current Contract object for employee  