### PR TITLE
Fix error on generate cost detail with reversed inventory documents

### DIFF
--- a/base/src/org/adempiere/engine/AverageInvoiceCostingMethod.java
+++ b/base/src/org/adempiere/engine/AverageInvoiceCostingMethod.java
@@ -90,7 +90,7 @@ public class AverageInvoiceCostingMethod extends AbstractCostingMethod
 
 		// If model is reversal then no calculate cost
 		//Validate if model have a reverses and processing of reverse
-		if (model.getReversalLine_ID() > 0 && costDetail == null)
+		if (model.getReversalLine_ID() > 0 && costDetail == null && !model.isReversalParent())
 			return;
 		else if( costDetail != null && costDetail.isReversal() && model.getReversalLine_ID() > 0)
 	    {
@@ -312,11 +312,11 @@ public class AverageInvoiceCostingMethod extends AbstractCostingMethod
 		// Ignore reversal transaction because is created based on the original
 		// transaction
 		//Validate if model have a reverses and processing of reverse
-		if (model.getReversalLine_ID() > 0 && costDetail == null ) {
+		if (model.getReversalLine_ID() > 0 && costDetail == null && !model.isReversalParent()) {
 			createReversalCostDetail();
 			return;
 		} 
-		else if (model.getReversalLine_ID() > 0)
+		else if (model.getReversalLine_ID() > 0 && !model.isReversalParent())
 			return;
 		
 

--- a/base/src/org/adempiere/engine/AveragePOCostingMethod.java
+++ b/base/src/org/adempiere/engine/AveragePOCostingMethod.java
@@ -94,7 +94,7 @@ public class AveragePOCostingMethod extends AbstractCostingMethod
 		//Validate if model have a reverses and processing of reverse
 		if (model.getReversalLine_ID() > 0 && costDetail == null)
 			return;
-		else if( costDetail != null && costDetail.isReversal() && model.getReversalLine_ID() > 0)
+		else if( costDetail != null && costDetail.isReversal() && model.getReversalLine_ID() > 0  && !model.isReversalParent())
 	    {
             setReversalCostDetail();
             return;
@@ -295,11 +295,11 @@ public class AveragePOCostingMethod extends AbstractCostingMethod
 		// Ignore reversal transaction because is created based on the original
 		// transaction
 		//Validate if model have a reverses and processing of reverse
-		if (model.getReversalLine_ID() > 0 && costDetail == null ) {
+		if (model.getReversalLine_ID() > 0 && costDetail == null  && !model.isReversalParent()) {
 			createReversalCostDetail();
 			return;
 		} 
-		else if (model.getReversalLine_ID() > 0)
+		else if (model.getReversalLine_ID() > 0  && !model.isReversalParent())
 			return;
 		
 

--- a/base/src/org/adempiere/engine/IDocumentLine.java
+++ b/base/src/org/adempiere/engine/IDocumentLine.java
@@ -52,4 +52,5 @@ public interface IDocumentLine
 	public BigDecimal getPriceActual();
 	public BigDecimal getPriceActualCurrency();
 	public IDocumentLine getReversalDocumentLine();
+	public boolean isReversalParent();
 }

--- a/base/src/org/adempiere/engine/StandardCostingMethod.java
+++ b/base/src/org/adempiere/engine/StandardCostingMethod.java
@@ -57,7 +57,7 @@ public class StandardCostingMethod extends AbstractCostingMethod implements
 	}
 
 	private void calculate() {
-		if (model.getReversalLine_ID() > 0)
+		if (model.getReversalLine_ID() > 0  && !model.isReversalParent())
 			return;
 
 		// try find the last cost detail transaction
@@ -112,7 +112,7 @@ public class StandardCostingMethod extends AbstractCostingMethod implements
 
 	private void createCostDetail() {
 		final String idColumnName = CostEngine.getIDColumnName(model);
-		if (model.getReversalLine_ID() > 0) {
+		if (model.getReversalLine_ID() > 0  && !model.isReversalParent()) {
 			createReversalCostDetail();
 			return;
 		}

--- a/base/src/org/compiere/model/MInOutLine.java
+++ b/base/src/org/compiere/model/MInOutLine.java
@@ -867,4 +867,9 @@ implements IDocumentLine , DocumentReversalLineEnable
 		return conversionTypeId;
 	}
 
+	@Override
+	public boolean isReversalParent() {
+		return getM_InOutLine_ID() < getReversalLine_ID();
+	}
+
 }	//	MInOutLine

--- a/base/src/org/compiere/model/MInventoryLine.java
+++ b/base/src/org/compiere/model/MInventoryLine.java
@@ -467,4 +467,9 @@ public class MInventoryLine extends X_M_InventoryLine implements IDocumentLine ,
 	{
 		return MConversionType.getDefault(getAD_Client_ID());
 	}
+
+	@Override
+	public boolean isReversalParent() {
+		return getM_InventoryLine_ID() < getReversalLine_ID();
+	}
 }	//	MInventoryLine

--- a/base/src/org/compiere/model/MLandedCostAllocation.java
+++ b/base/src/org/compiere/model/MLandedCostAllocation.java
@@ -267,5 +267,11 @@ public class MLandedCostAllocation extends X_C_LandedCostAllocation implements I
 				"SELECT i.C_ConversionType_ID FROM C_InvoiceLine il INNER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID) WHERE il.C_InvoiceLine_ID = ? ",
 				getC_InvoiceLine_ID());
 	}
+
+	@Override
+	public boolean isReversalParent() {
+		// TODO Auto-generated method stub
+		return false;
+	}
 	
 }	//	MLandedCostAllocation

--- a/base/src/org/compiere/model/MMatchInv.java
+++ b/base/src/org/compiere/model/MMatchInv.java
@@ -578,5 +578,12 @@ public class MMatchInv extends X_M_MatchInv implements IDocumentLine
 	}
 
 
+	@Override
+	public boolean isReversalParent() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+
 
 }	//	MMatchInv

--- a/base/src/org/compiere/model/MMatchPO.java
+++ b/base/src/org/compiere/model/MMatchPO.java
@@ -1007,4 +1007,10 @@ public class MMatchPO extends X_M_MatchPO implements IDocumentLine
 		}
 		return null;
 	}
+
+	@Override
+	public boolean isReversalParent() {
+		// TODO Auto-generated method stub
+		return false;
+	}
 }	//	MMatchPO

--- a/base/src/org/compiere/model/MMovementLine.java
+++ b/base/src/org/compiere/model/MMovementLine.java
@@ -408,4 +408,9 @@ public class MMovementLine extends X_M_MovementLine implements IDocumentLine , D
 				.setOrderBy(MMovementLineMA.COLUMNNAME_Created)
 				.list();
 	}
+
+	@Override
+	public boolean isReversalParent() {
+		return getM_MovementLine_ID() < getReversalLine_ID();
+	}
 }	//	MMovementLine

--- a/base/src/org/compiere/model/MOrderLine.java
+++ b/base/src/org/compiere/model/MOrderLine.java
@@ -1064,4 +1064,10 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 	{
 		return getParent().getC_ConversionType_ID();
 	}
+
+	@Override
+	public boolean isReversalParent() {
+		// TODO Auto-generated method stub
+		return getC_OrderLine_ID() < getReversalLine_ID();
+	}
 }	//	MOrderLine

--- a/base/src/org/compiere/model/MProductionLine.java
+++ b/base/src/org/compiere/model/MProductionLine.java
@@ -679,5 +679,10 @@ public class MProductionLine extends X_M_ProductionLine implements IDocumentLine
 	{
 		return  MConversionType.getDefault(getAD_Client_ID());
 	}
+
+	@Override
+	public boolean isReversalParent() {
+		return getM_ProductionLine_ID() < getReversalLine_ID();
+	}
 	
 }

--- a/base/src/org/eevolution/model/MPPCostCollector.java
+++ b/base/src/org/eevolution/model/MPPCostCollector.java
@@ -1083,4 +1083,10 @@ public class MPPCostCollector extends X_PP_Cost_Collector implements DocAction ,
 		return  MConversionType.getDefault(getAD_Client_ID());
 	}
 
+	@Override
+	public boolean isReversalParent() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
 }	//	MPPCostCollector

--- a/org.adempiere.project/src/main/java/org/compiere/model/MProjectIssue.java
+++ b/org.adempiere.project/src/main/java/org/compiere/model/MProjectIssue.java
@@ -243,5 +243,11 @@ public class MProjectIssue extends X_C_ProjectIssue implements IDocumentLine
 		return  MConversionType.getDefault(getAD_Client_ID());
 	}
 
+	@Override
+	public boolean isReversalParent() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
 
 }	//	MProjectIssue


### PR DESCRIPTION
When one inventory document is reversed and generate cost transaction the process delete the cost transaction but don't generate again.

see this example:
![Bad_Generate_Reversal_Cost_Transaction](https://user-images.githubusercontent.com/1847863/61572207-ed3c0d80-aa67-11e9-9d7a-e3975d8bbf10.gif)

see this example with the fixes:
![Fix_Generate_Reversal_Cost_Transaction](https://user-images.githubusercontent.com/1847863/61572220-1a88bb80-aa68-11e9-90a0-6b882ead3cee.gif)
