### PR TITLE
Eclipse class path corrections. 

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -334,15 +334,7 @@
 	<classpathentry kind="lib" path="tools/lib/oracle.jar"/>
 	<classpathentry kind="lib" path="tools/lib/zxing-2.3.0.jar"/>
 	<classpathentry kind="lib" path="tools/lib/commons-validator-1.6.jar"/>
-	<classpathentry kind="lib" path="tools/lib/sardine-5.9-SNAPSHOT.jar"/>
-	<classpathentry kind="lib" path="tools/lib/fluent-hc-4.5.6.jar"/>
-	<classpathentry kind="lib" path="tools/lib/httpclient-4.5.6.jar"/>
-	<classpathentry kind="lib" path="tools/lib/httpclient-cache-4.5.6.jar"/>
-	<classpathentry kind="lib" path="tools/lib/httpclient-win-4.5.6.jar"/>
-	<classpathentry kind="lib" path="tools/lib/httpcore-4.4.10.jar"/>
-	<classpathentry kind="lib" path="tools/lib/httpmime-4.5.6.jar"/>
-	<classpathentry kind="lib" path="tools/lib/jna-4.4.0.jar"/>
-	<classpathentry kind="lib" path="tools/lib/jna-platform-4.4.0.jar"/>
 	<classpathentry kind="lib" path="tools/lib/commons-codec-1.10.jar"/>
+	<classpathentry kind="lib" path="tools/lib/sardine-5.9-SNAPSHOT.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Fixes #2787. 

Changes to the eclipse classpath to reflect the removal of unnecessary libraries.