### PR TITLE
Add validation for Collect when it alreasy exist for deposit

### DIFF
--- a/base/src/org/compiere/model/MPayment.java
+++ b/base/src/org/compiere/model/MPayment.java
@@ -2505,6 +2505,19 @@ public final class MPayment extends X_C_Payment
 		//	For Cash Payment
 		MBankAccount bankAccount = MBankAccount.get(getCtx(), getC_BankAccount_ID());
 		MBank bank = MBank.get(getCtx(), bankAccount.getC_Bank_ID());
+		if(getRef_Payment_ID() != 0
+				&& !Util.isEmpty(bank.getBankType())
+				&& bank.getBankType().equals(MBank.BANKTYPE_CashJournal)) {
+			MPayment deposit = new MPayment(getCtx(), getRef_Payment_ID(), get_TrxName());
+			MBankAccount depositBankAccount = MBankAccount.get(getCtx(), deposit.getC_BankAccount_ID());
+			MBank depositBank = MBank.get(getCtx(), depositBankAccount.getC_Bank_ID());
+			if(!Util.isEmpty(depositBank.getBankType())
+					&& depositBank.getBankType().equals(MBank.BANKTYPE_Bank)
+					&& (deposit.getDocStatus().equals(MPayment.DOCSTATUS_Completed)
+							|| deposit.getDocStatus().equals(MPayment.DOCSTATUS_Closed))) {
+				throw new AdempiereException("@DepositAlreadyExistsForCash@");
+			}
+		}
 		if(!Util.isEmpty(bank.getBankType())
 				&& bank.getBankType().equals(MBank.BANKTYPE_CashJournal)
 				&& !isReceipt()) {

--- a/migration/392lts-393lts/05410_Add_Reverse_Collect_Validation.xml
+++ b/migration/392lts-393lts/05410_Add_Reverse_Collect_Validation.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add validation for reverse cash collect" ReleaseNo="3.9.3" SeqNo="5410">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="109" Action="I" Record_ID="53651" Table="AD_Message">
+        <Data AD_Column_ID="588" Column="IsActive">true</Data>
+        <Data AD_Column_ID="589" Column="Created">2019-09-25 12:32:01.406</Data>
+        <Data AD_Column_ID="198" Column="MsgText">Already exists a deposit for this cash collect, please reverse the deposit before reverse it</Data>
+        <Data AD_Column_ID="591" Column="Updated">2019-09-25 12:32:01.406</Data>
+        <Data AD_Column_ID="197" Column="MsgType">I</Data>
+        <Data AD_Column_ID="6766" Column="Value">DepositAlreadyExistsForCash</Data>
+        <Data AD_Column_ID="199" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="392" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="391" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="7716" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="6765" Column="AD_Message_ID">53651</Data>
+        <Data AD_Column_ID="590" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="592" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84346" Column="UUID">01163946-dfb2-11e9-90b6-0242ac110002</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="119" Action="I" Record_ID="53651" Table="AD_Message_Trl">
+        <Data AD_Column_ID="609" Column="Created">2019-09-25 12:32:09.333</Data>
+        <Data AD_Column_ID="611" Column="Updated">2019-09-25 12:32:09.333</Data>
+        <Data AD_Column_ID="608" Column="IsActive">true</Data>
+        <Data AD_Column_ID="344" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="342" Column="MsgText">Already exists a deposit for this cash collect, please reverse the deposit before reverse it</Data>
+        <Data AD_Column_ID="343" Column="MsgTip" isNewNull="true"/>
+        <Data AD_Column_ID="1192" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="1193" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID">53651</Data>
+        <Data AD_Column_ID="610" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="341" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="612" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84347" Column="UUID">050bf31a-dfb2-11e9-90b6-0242ac110002</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="119" Action="U" Record_ID="53651" Table="AD_Message_Trl">
+        <Data AD_Column_ID="342" Column="MsgText" oldValue="Already exists a deposit for this cash collect, please reverse the deposit before reverse it">Ya existe un depósito para esta cobranza, por favor anule el depósito antes de anular la cobranza</Data>
+        <Data AD_Column_ID="6767" Column="AD_Message_ID" oldValue="53651">53651</Data>
+        <Data AD_Column_ID="341" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
This pull request just add a validation for collects.

1. Create a collect from Cash Journal (as bank)
2. Make a cash closing
3. Make a deposit from cash selecting the collect created
4. Reverse collect from cash

The problem is that a collect when is transfered for bank should not will be reversed if deposit is completed or closed.