### PR TITLE
Fixed error with transit quantity when a Outbound order is delivered

### DIFF
--- a/org.eevolution.warehouse/src/main/java/ui/zk/org/spin/form/WOutBoundOrder.java
+++ b/org.eevolution.warehouse/src/main/java/ui/zk/org/spin/form/WOutBoundOrder.java
@@ -564,7 +564,7 @@ public class WOutBoundOrder extends OutBoundOrder
 		documentDateField.setValue(Env.getContextAsDate(Env.getCtx(), "#Date"));
 		shipmentDateField.setValue(Env.getContextAsDate(Env.getCtx(), "#Date"));
 		shipperPick.setValue(null);
-		docActionPick.setValue(DocAction.ACTION_Prepare);
+		docActionPick.setValue(DocAction.ACTION_Complete);
 	}
 
 	/**
@@ -945,20 +945,19 @@ public class WOutBoundOrder extends OutBoundOrder
 		boolean isOrderLine = (event.getModel().equals(orderLineTable.getModel()));
 		if(isOrder) {
 			//	Load Lines
-//			if(m_C_UOM_Weight_ID != 0) {
-				StringBuffer sql = getQueryLine(w_orderTable);
-				Vector<Vector<Object>> data = getOrderLineData(w_orderTable, sql);
-				Vector<String> columnNames = getOrderLineColumnNames();
+			StringBuffer sql = getQueryLine(w_orderTable);
+			Vector<Vector<Object>> data = getOrderLineData(w_orderTable, sql);
+			Vector<String> columnNames = getOrderLineColumnNames();
 				
-				loadBuffer(orderLineTable);
-				//  Remove previous listeners
-				orderLineTable.getModel().removeTableModelListener(this);
-				//  Set Model
-				ListModelTable modelP = new ListModelTable(data);
-				modelP.addTableModelListener(this);
-				orderLineTable.setData(modelP, columnNames);
-				setOrderLineColumnClass(orderLineTable);
-				setValueFromBuffer(orderLineTable);	
+			loadBuffer(orderLineTable);
+			//  Remove previous listeners
+			orderLineTable.getModel().removeTableModelListener(this);
+			//  Set Model
+			ListModelTable modelP = new ListModelTable(data);
+			modelP.addTableModelListener(this);
+			orderLineTable.setData(modelP, columnNames);
+			setOrderLineColumnClass(orderLineTable);
+			setValueFromBuffer(orderLineTable);	
 		} else if(isOrderLine) {
 			if(col == OL_QTY) {	//	Quantity
 				BigDecimal qty = (BigDecimal) orderLineTable.getValueAt(row, OL_QTY);


### PR DESCRIPTION
Step by Step:

1. Generate a Sales Order with 10 units for a product
2. Generate a outbound order from Form for generate Outbound order (From Sales Order / Distribution Orders) with 10 units for product
3. Generate Shipment from Outbound order with 10 units of generated outbound order
4. Try generate other outbound order for 5 units remaining of sales order

Note that the order line is missing, this because the validation for generate order is:
QtyOrdered - QtyDelivered - QtyInTransit (Quantity on Outbound Order not shipped)
The problem is that QtyInTransit have quantities that was shipped then the result si bad.

QtyOrdered = 15
QtyDelivered = 10
QtyInTransit = 10

Result = 15 - 10 - 10 = -5

The correct behavior is:

QtyOrdered = 15
QtyDelivered = 10
QtyInTransit = 0

Result = 15 - 10 - 0 = 5

This pull request resolve it