### PR TITLE
#2839 Error in credit limit when revert an invoice the credit used is…

### DIFF
--- a/base/src/org/compiere/model/MInvoice.java
+++ b/base/src/org/compiere/model/MInvoice.java
@@ -2193,7 +2193,6 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 			return null;
 		}
 		reversal.setC_Payment_ID(0);
-		reversal.setIsPaid(true);
 		reversal.closeIt();
 		reversal.setProcessing (false);
 		reversal.setDocStatus(DOCSTATUS_Reversed);
@@ -2219,7 +2218,6 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 		setDocStatus(DOCSTATUS_Reversed);	//	may come from void
 		setDocAction(DOCACTION_None);
 		setC_Payment_ID(0);
-		setIsPaid(true);
 
 		//	Create Allocation
 		MAllocationHdr allocationHdr = new MAllocationHdr(getCtx(), false, reversalDate,


### PR DESCRIPTION
… calculated incorrectly  https://github.com/adempiere/adempiere/issues/2839

- Setting as is paid when the allocation is processed for reversal Invoice