### PR TITLE
Fixed error on Accounting of Shipment/Receipt

### DIFF
--- a/base/src/org/compiere/acct/Doc_InOut.java
+++ b/base/src/org/compiere/acct/Doc_InOut.java
@@ -95,7 +95,8 @@ public class Doc_InOut extends Doc
 			
 			DocLine docLine = new DocLine (line, this);
 			BigDecimal Qty = line.getMovementQty();
-			docLine.setReversalLine_ID(line.getReversalLine_ID());		
+			if (!line.isReversalParent())
+				docLine.setReversalLine_ID(line.getReversalLine_ID());		
 			docLine.setQty (Qty, !getDocumentType().equals(DOCTYPE_MatShipment));    //  sets Trx and Storage Qty
 			
 			//Define if Outside Processing 


### PR DESCRIPTION
When the accounting of original receipt or shipment is reset don't accounted the original document and reversal document

Before fixed:

Original Document
![image](https://user-images.githubusercontent.com/1847863/66145343-9d85d080-e5d8-11e9-9f19-0be1c5b35346.png)

Reversal Document
![image](https://user-images.githubusercontent.com/1847863/66145203-5a2b6200-e5d8-11e9-928a-2e4de0d05cbf.png)

After fixed:

Original Document
![image](https://user-images.githubusercontent.com/1847863/66145473-ea69a700-e5d8-11e9-9e80-f26c18b12f72.png)

Reversal Document
![image](https://user-images.githubusercontent.com/1847863/66145504-f9505980-e5d8-11e9-8382-81ac10fa8de9.png)

