### PR TITLE
Fixed Error on Accounting of Match Invoice

### DIFF
--- a/base/src/org/compiere/acct/FactLine.java
+++ b/base/src/org/compiere/acct/FactLine.java
@@ -1151,8 +1151,12 @@ public final class FactLine extends X_Fact_Acct
 
 		String sql = "SELECT * "
 			+ "FROM Fact_Acct "
-			+ "WHERE C_AcctSchema_ID=? AND AD_Table_ID=? AND Record_ID=?"
-			+ " AND Line_ID=? AND Account_ID=? AND Qty=?";
+			+ "WHERE C_AcctSchema_ID=? AND AD_Table_ID=? AND Record_ID=?";
+		
+		if (Line_ID != 0)
+			sql += "AND Line_ID=?";
+		
+		sql += " AND Account_ID=? AND Qty=?";
 		// MZ Goodwill
 		// for Inventory Move
 		if (MMovement.Table_ID == AD_Table_ID)
@@ -1162,13 +1166,15 @@ public final class FactLine extends X_Fact_Acct
 		ResultSet rs = null;
 		try
 		{
+			int index=1;
 			pstmt = DB.prepareStatement(sql, get_TrxName());
-			pstmt.setInt(1, getC_AcctSchema_ID());
-			pstmt.setInt(2, AD_Table_ID);
-			pstmt.setInt(3, Record_ID);
-			pstmt.setInt(4, Line_ID);
-			pstmt.setInt(5, m_acct.getAccount_ID());
-            pstmt.setBigDecimal(6, quantity.negate()); // Negate quantity to get the credit account fact
+			pstmt.setInt(index++, getC_AcctSchema_ID());
+			pstmt.setInt(index++, AD_Table_ID);
+			pstmt.setInt(index++, Record_ID);
+			if (Line_ID != 0)
+				pstmt.setInt(index++, Line_ID);
+			pstmt.setInt(index++, m_acct.getAccount_ID());
+            pstmt.setBigDecimal(index++, quantity.negate()); // Negate quantity to get the credit account fact
 			// MZ Goodwill
 			// for Inventory Move
 			if (MMovement.Table_ID == AD_Table_ID)

--- a/base/src/org/compiere/model/MMatchInv.java
+++ b/base/src/org/compiere/model/MMatchInv.java
@@ -580,8 +580,7 @@ public class MMatchInv extends X_M_MatchInv implements IDocumentLine
 
 	@Override
 	public boolean isReversalParent() {
-		// TODO Auto-generated method stub
-		return false;
+		return getM_MatchInv_ID() < getReversal_ID();
 	}
 
 


### PR DESCRIPTION
Currently, at reversing invoice, credit note, receipt or vendor return , this generate a new invoice matching  associated to reverse document, but the accounting for this document is incorrect.

Original Document:
![image](https://user-images.githubusercontent.com/1847863/66168784-40a40d80-e60c-11e9-9cc7-09fcea206dd0.png)


Reversed Document:
![image](https://user-images.githubusercontent.com/1847863/66168706-ef941980-e60b-11e9-831d-26028ef8eddc.png)

Accounting of documents:
![image](https://user-images.githubusercontent.com/1847863/66168876-7ba64100-e60c-11e9-9375-db4fa5d26af7.png)

Accounting of documents after fixed:
![image](https://user-images.githubusercontent.com/1847863/66168912-9a0c3c80-e60c-11e9-97f4-f5f04c0f72e2.png)
