### PR TITLE
Add validation for bank statement with lines without payment reference

### DIFF
--- a/base/src/org/compiere/model/MBankStatement.java
+++ b/base/src/org/compiere/model/MBankStatement.java
@@ -34,6 +34,7 @@ import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
 import org.compiere.util.TimeUtil;
+import org.compiere.util.Util;
 
 
 /**
@@ -442,7 +443,48 @@ public class MBankStatement extends X_C_BankStatement implements DocAction
 		if (!isApproved())
 			approveIt();
 		log.info("completeIt - " + toString());
-		
+		StringBuffer linesWithoutReference = new StringBuffer();
+		Arrays.asList(getLines(true)).stream()
+			.filter(statementLine -> statementLine.getC_Payment_ID() == 0)
+			.forEach(statementLine -> {
+				if(linesWithoutReference.length() > 0) {
+					linesWithoutReference.append(Env.NL);
+				}
+				//	Add
+				StringBuffer displayValue = new StringBuffer();
+				displayValue.append(statementLine.getLine());
+				//	Reference No
+				if(!Util.isEmpty(statementLine.getReferenceNo())) {
+					displayValue.append(" - @ReferenceNo@: ").append(statementLine.getReferenceNo());
+				}
+				//	Memo
+				if(!Util.isEmpty(statementLine.getMemo())) {
+					displayValue.append(" - @Memo@: ").append(statementLine.getMemo());
+				}
+				//	EFT Check No
+				if(!Util.isEmpty(statementLine.getEftCheckNo())) {
+					displayValue.append(" - @EftCheckNo@: ").append(statementLine.getEftCheckNo());
+				}
+				if(!Util.isEmpty(statementLine.getEftMemo())) {
+					displayValue.append(" - @EftMemo@: ").append(statementLine.getEftMemo());
+				}
+				//	Add amount
+				if (statementLine.getTrxAmt().compareTo(Env.ZERO) != 0) {
+					displayValue.append(" - @TrxAmt@: ").append(DisplayType.getNumberFormat(DisplayType.Amount).format(statementLine.getTrxAmt()));
+				}
+				if (statementLine.getChargeAmt().compareTo(Env.ZERO) != 0) {
+					displayValue.append(" - @ChargeAmt@: ").append(DisplayType.getNumberFormat(DisplayType.Amount).format(statementLine.getChargeAmt()));
+				}
+				if (statementLine.getInterestAmt().compareTo(Env.ZERO) != 0) {
+					displayValue.append(" - @InterestAmt@: ").append(DisplayType.getNumberFormat(DisplayType.Amount).format(statementLine.getInterestAmt()));
+				}
+				//	Add info
+				linesWithoutReference.append(displayValue);
+		});
+		//	Validate
+		if(linesWithoutReference.length() > 0) {
+			throw new AdempiereException("@Error@" + Env.NL + " @C_Payment_ID@ @NotFound@ " + Env.NL + linesWithoutReference.toString());
+		}
 		//	Set Payment reconciled
 		MBankStatementLine[] lines = getLines(false);
 		for (int i = 0; i < lines.length; i++)


### PR DESCRIPTION
This pull request allows validate lines for bank statement without payment reference before complete. See:
![Current ogv](https://user-images.githubusercontent.com/2333092/66329425-7c84ee80-e8fc-11e9-9e41-9e5b42989b68.gif)
