### PR TITLE
adempiere #2876 Duplicate BankstatementLine for Pos Payments

### DIFF
--- a/base/src/org/compiere/model/MPayment.java
+++ b/base/src/org/compiere/model/MPayment.java
@@ -1866,7 +1866,7 @@ public final class MPayment extends X_C_Payment
 			processMsg += " @CounterDoc@: @C_Payment_ID@=" + counter.getDocumentNo();
 
 		// @Trifon - CashPayments
-		if ( isCashTrx()) {
+		if ( isCashTrx() && getC_POS_ID() == 0) {
 			// Create Cash Book entry - check that the bank is a cash bank
 			// The bank account is mandatory
 			MBankAccount bankAccount = (MBankAccount) getC_BankAccount();


### PR DESCRIPTION
fixes https://github.com/adempiere/adempiere/issues/2876

Result:
The line before last was created by a POS payment, the last by a cash payment, tendertype cash
![Annotation 2019-10-15 072245](https://user-images.githubusercontent.com/15349639/66835660-26780280-ef1d-11e9-816c-1c533d7e8435.png)
