### PR TITLE
Add transaction name for business partner on beforeSave method

### DIFF
--- a/base/src/org/compiere/model/MBPGroup.java
+++ b/base/src/org/compiere/model/MBPGroup.java
@@ -41,18 +41,28 @@ public class MBPGroup extends X_C_BP_Group
 	private static final long serialVersionUID = 3037428352124938328L;
 
 	/**
-	 * 	Get MBPGroup from Cache
+	 * Get MBPGroup from Cache
+	 * @param ctx
+	 * @param C_BP_Group_ID
+	 * @return
+	 */
+	public static MBPGroup get (Properties ctx, int C_BP_Group_ID) {
+		return get(ctx, C_BP_Group_ID, null);
+	}
+	
+	/**
+	 * 	Get MBPGroup from Cache and transaction
 	 *	@param ctx context
 	 *	@param C_BP_Group_ID id
 	 *	@return MBPGroup
 	 */
-	public static MBPGroup get (Properties ctx, int C_BP_Group_ID)
+	public static MBPGroup get (Properties ctx, int C_BP_Group_ID, String trxName)
 	{
 		Integer key = new Integer (C_BP_Group_ID);
 		MBPGroup retValue = (MBPGroup) s_cache.get (key);
 		if (retValue != null)
 			return retValue;
-		retValue = new MBPGroup (ctx, C_BP_Group_ID, null);
+		retValue = new MBPGroup (ctx, C_BP_Group_ID, trxName);
 		if (retValue.get_ID () != 0)
 			s_cache.put (key, retValue);
 		return retValue;

--- a/base/src/org/compiere/model/MBPartner.java
+++ b/base/src/org/compiere/model/MBPartner.java
@@ -912,7 +912,7 @@ public class MBPartner extends X_C_BPartner
 			if (getC_BP_Group_ID() == 0)
 				m_group = MBPGroup.getDefault(getCtx());
 			else
-				m_group = MBPGroup.get(getCtx(), getC_BP_Group_ID());
+				m_group = MBPGroup.get(getCtx(), getC_BP_Group_ID(), get_TrxName());
 		}
 		return m_group;
 	}	//	getBPGroup


### PR DESCRIPTION
Currently when a business partner is saved is called a BP group from it but transaction name is not used for it.