### PR TITLE
#2926 Add a silent mode to the RUN_ImportAdempiere scripts.

### DIFF
--- a/utils/RUN_ImportAdempiere.bat
+++ b/utils/RUN_ImportAdempiere.bat
@@ -41,13 +41,19 @@ SET errorImportData=60
 SET errorImportSqlj=61
 
 
-
-REM if called with any argument, import the reference database
+REM If called with argument "silent", run without pause (See #2926)
+REM if called with any other argument, import the reference database
 REM otherwise import the seed database
+SET silentMode=Pause
 SET importMode=Seed
-SET argCount=0
-FOR %%a IN (%*) DO SET /A argCount+=1
-IF NOT %argCount%==0 SET importMode=Reference
+FOR %%a IN (%*) DO (
+    IF %%a==silent (
+        SET silentMode=silent
+    ) ELSE (
+        SET importMode=Reference
+    )
+)
+
 
 REM identify this script
 ECHO.
@@ -186,7 +192,7 @@ ECHO Re-create user %dbUser%
 ECHO and import %dbSeedFile%
 ECHO.
 ECHO == The import will show warnings. This is OK ==
-PAUSE
+IF "%silentMode%"=="Pause" PAUSE
 	
 CALL "%dbImportScript%" "%dbVendor%" "%dbHost%" "%dbPort%" "%dbUser%" "%dbPwd%" "%sysUser%" "%sysPwd%" "%dbName%" "%dbCatalog%" "%dbSchema%" "%dbSeedFile%" "%dbSqljFile%"
 SET result=%ERRORLEVEL% 

--- a/utils/RUN_ImportAdempiere.sh
+++ b/utils/RUN_ImportAdempiere.sh
@@ -38,13 +38,23 @@ errorModifySchema=53	# the schema could not be modified
 errorImportData=60		# an error occured while trying to import data
 errorImportSqlj=61		# an error occured while trying to import sqlj
 
-
-# if called with any argument, import the reference database
-# otherwise import the seed database
+# The script can be called with multiple arguments
+# If called with argument "silent", run without pause (See #2926)
+# If any other argument is used, import the reference database
+# otherwise import the seed database.
 importMode="Seed"
-if [ $# -gt 0 ] 
+silentMode="Pause"
+if [ $# -gt 0 ]
 then
-	importMode="Reference"
+	for argument in "$@"
+	do
+		if [ "$argument" == "silent" ]
+		then
+			silentMode="Silent"
+		else
+			importMode="Reference"
+		fi
+	done
 fi
 
 # identify this script
@@ -175,8 +185,11 @@ then
 	echo "and import $dbSeedFile"
 	echo
 	echo "== The import will show warnings. This is OK =="
-	echo "Press enter to continue ..."
-	read in
+	if [ "$silentMode" == "Pause" ]
+	then
+		echo "Press enter to continue ..."
+		read in
+	fi
 	
 	$dbImportScript "$dbVendor" "$dbHost" "$dbPort" "$dbUser" "$dbPwd" "$sysUser" "$sysPwd" "$dbName" "$dbCatalog" "$dbSchema" "$dbSeedFile" "$dbSqljFile"
 	result=$? 


### PR DESCRIPTION
Updates the RUN_ImportAdempiere.bat/sh scripts to take an argument "silent" which will cause the script to run without pause.  This is useful when using the script in another script such as when creating a docker container.  

The scripts will currently accept any number of arguments and, if any are found, will import the reference database instead of the seed.  This change has no impact on the current use of the scripts. 