### PR TITLE
Add Sales Order line reference on create Receipt from Invoice

### DIFF
--- a/base/src/org/compiere/process/InOutCreateFrom.java
+++ b/base/src/org/compiere/process/InOutCreateFrom.java
@@ -172,6 +172,7 @@ public class InOutCreateFrom extends InOutCreateFromAbstract {
 							.divide(invoiceLine.getQtyEntered(), 12, BigDecimal.ROUND_HALF_UP));
 					inOutLine.setC_UOM_ID(invoiceLine.getC_UOM_ID());
 				}
+				inOutLine.setC_OrderLine_ID(invoiceLine.getC_OrderLine_ID());
 				inOutLine.setDescription(invoiceLine.getDescription());
 				inOutLine.setC_Project_ID(invoiceLine.getC_Project_ID());
 				inOutLine.setC_ProjectPhase_ID(invoiceLine.getC_ProjectPhase_ID());


### PR DESCRIPTION
When the receipt is create form an invoice allocated an sales order the sales order line is not referenced.

![image](https://user-images.githubusercontent.com/1847863/71904169-00d55080-313c-11ea-9891-992daad5c869.png)
