### PR TITLE
Fixed error with long time for commission when is called from payroll

### DIFF
--- a/base/src/org/compiere/model/MCommission.java
+++ b/base/src/org/compiere/model/MCommission.java
@@ -161,9 +161,11 @@ public class MCommission extends X_C_Commission
 	 * @param bPartnerId
 	 * @param from
 	 * @param to
+	 * @param docBasisType
+	 * @param trxName
 	 * @return
 	 */
-	public static BigDecimal getCommissionAmt(int bPartnerId, Timestamp from, Timestamp to, String docBasisType) {
+	public static BigDecimal getCommissionAmt(int bPartnerId, Timestamp from, Timestamp to, String docBasisType, String trxName) {
 		ArrayList<Object> params = new ArrayList<Object>();
 		String whereClause = new String();
 		//	Add BPartner
@@ -190,16 +192,5 @@ public class MCommission extends X_C_Commission
 		BigDecimal value = DB.getSQLValueBDEx(null, sql.toString(), params);
 		//	Valid Value
 		return value;
-	}
-	
-	/**
-	 * Get commission amount for a sales representative without doc basis type
-	 * @param bPartnerId
-	 * @param from
-	 * @param to
-	 * @return
-	 */
-	public static BigDecimal getCommissionAmt(int bPartnerId, Timestamp from, Timestamp to) {
-		return getCommissionAmt(bPartnerId, from, to, null);
 	}
 }	//	MCommission

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRProcess.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRProcess.java
@@ -2574,7 +2574,7 @@ public class MHRProcess extends X_HR_Process implements DocAction , DocumentReve
 	 * @return
 	 */
 	public double getCommissionAmt(int bPartnerId, Timestamp from, Timestamp to, String docBasisType) {
-		BigDecimal value = MCommission.getCommissionAmt(bPartnerId, from, to, docBasisType);
+		BigDecimal value = MCommission.getCommissionAmt(bPartnerId, from, to, docBasisType, get_TrxName());
 		//	Validate value
 		if(value == null)
 			return 0.0;


### PR DESCRIPTION
Currently exists a method for get commission amount from payroll process
```Java
getCommissionAmt
```
This method allows get commission from employee from payroll, the problem is that transaction name is null and can be keep a transaction for long time while payroll process is processed.

This pull request just add transaction name for method.