### PR TITLE
Fixed error with syntax error for commission paid when list details is flagged

### DIFF
--- a/base/src/org/compiere/model/MCommissionRun.java
+++ b/base/src/org/compiere/model/MCommissionRun.java
@@ -665,7 +665,7 @@ public class MCommissionRun extends X_C_CommissionRun implements DocAction, DocO
 						+ " (linenetamtrealinvoiceline(l.c_Invoiceline_ID) * (al.Amount/h.GrandTotal)) AS Amt,"
 						+ " (l.QtyInvoiced*al.Amount/h.GrandTotal) AS Qty,"
 						+ " NULL, l.C_InvoiceLine_ID, l.C_OrderLine_ID, (p.DocumentNo || '_' || h.DocumentNo) AS Reference,"
-						+ " COALESCE(prd.Value,l.Description) AS Info, h.DateInvoiced AS DateDoc"
+						+ " COALESCE(prd.Value,l.Description) AS Info, h.DateInvoiced AS DateDoc "
 						+ "FROM C_Payment p"
 						+ " INNER JOIN C_AllocationLine al ON (p.C_Payment_ID=al.C_Payment_ID)"
 						+ " INNER JOIN C_Invoice h ON (al.C_Invoice_ID = h.C_Invoice_ID)"
@@ -712,7 +712,7 @@ public class MCommissionRun extends X_C_CommissionRun implements DocAction, DocO
 				if (commission.isListDetails()) {
 					sql.append("SELECT h.C_Currency_ID, linenetamtrealorderline(l.c_OrderLine_ID) AS Amt, l.QtyOrdered AS Qty, "
 						+ "l.C_OrderLine_ID, NULL AS C_InvoiceLine_ID, h.DocumentNo AS Reference,"
-						+ " COALESCE(prd.Value,l.Description) AS Info,h.DateOrdered AS DateDoc"
+						+ " COALESCE(prd.Value,l.Description) AS Info,h.DateOrdered AS DateDoc "
 						+ "FROM C_Order h"
 						+ " INNER JOIN C_OrderLine l ON (h.C_Order_ID = l.C_Order_ID)"
 						+ " LEFT OUTER JOIN M_Product prd ON (l.M_Product_ID = prd.M_Product_ID) "


### PR DESCRIPTION
Step by Step
 - Create a new Commission Run
 - Select Document Base Type "Receipt"
 - Select flag "List Detail"
 - Prepare commission
This show the follow error:

```Shell
caused by: org.postgresql.util.PSQLException: ERROR: syntax error at or near "C_Payment"
  Position: 324; State=42601; ErrorCode=0
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2440)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2183)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:308)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:441)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:365)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:143)
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:106)
	at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeQuery(NewProxyPreparedStatement.java:76)
	at sun.reflect.GeneratedMethodAccessor6.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
	at com.sun.proxy.$Proxy2.executeQuery(Unknown Source)
	at org.compiere.model.MCommissionRun.createDetail(MCommissionRun.java:342)
	at org.compiere.model.MCommissionRun.processCommissionLine(MCommissionRun.java:1188)
	at org.compiere.model.MCommissionRun.createMovements(MCommissionRun.java:286)
	at org.compiere.model.MCommissionRun.prepareIt(MCommissionRun.java:219)
	at org.compiere.process.DocumentEngine.prepareIt(DocumentEngine.java:411)
	at org.compiere.process.DocumentEngine.processIt(DocumentEngine.java:280)
	at org.compiere.process.DocumentEngine.processIt(DocumentEngine.java:258)
	at org.compiere.model.MCommissionRun.processIt(MCommissionRun.java:164)
	at org.compiere.wf.MWFActivity.performWork(MWFActivity.java:904)
	at org.compiere.wf.MWFActivity.run(MWFActivity.java:794)
	at org.compiere.wf.MWFProcess.startNext(MWFProcess.java:370)
	at org.compiere.wf.MWFProcess.checkActivities(MWFProcess.java:280)
	at org.compiere.wf.MWFActivity.setWFState(MWFActivity.java:280)
	at org.compiere.wf.MWFActivity.run(MWFActivity.java:811)
	at org.compiere.wf.MWFProcess.startWork(MWFProcess.java:502)
	at org.compiere.wf.MWorkflow.start(MWorkflow.java:727)
	at org.compiere.wf.MWorkflow.startWait(MWorkflow.java:796)
```

This pull request fixed previous error caused by a blank space
