### PR TITLE
Fixed error with duplicate key for inventory import

### DIFF
--- a/base/src/org/compiere/process/ImportInventory.java
+++ b/base/src/org/compiere/process/ImportInventory.java
@@ -189,7 +189,7 @@ public class ImportInventory extends ImportInventoryAbstract {
 		sql = new StringBuffer ("UPDATE I_Inventory "
 				+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=" + Msg.parseTranslation(getCtx(), "@SQLErrorNotUnique@ (@M_Inventory_ID@, @M_Locator_ID@, @M_Product_ID@) @Qty@ = ") 
 				+ " ' || (SELECT COUNT(i.I_Inventory_ID) FROM I_Inventory i WHERE i.M_Product_ID = I_Inventory.M_Product_ID AND i.M_Locator_ID = I_Inventory.M_Locator_ID GROUP BY i.M_Locator_ID, i.M_Product_ID) "
-				+ "WHERE EXISTS(SELECT 1 FROM I_Inventory i WHERE i.M_Product_ID = I_Inventory.M_Product_ID AND i.M_Locator_ID = I_Inventory.M_Locator_ID GROUP BY i.M_Locator_ID, i.M_Product_ID HAVING(COUNT(i.I_Inventory_ID) > 1)) "
+				+ "WHERE EXISTS(SELECT 1 FROM I_Inventory i WHERE i.M_Product_ID = I_Inventory.M_Product_ID AND i.M_Locator_ID = I_Inventory.M_Locator_ID AND i.I_IsImported<>'Y' GROUP BY i.M_Locator_ID, i.M_Product_ID HAVING(COUNT(i.I_Inventory_ID) > 1)) "
 				+ "AND EXISTS(SELECT 1 FROM M_Product p LEFT JOIN M_AttributeSet a ON(a.M_AttributeSet_ID = p.M_AttributeSet_ID) WHERE p.M_Product_ID = I_Inventory.M_Product_ID AND (p.M_AttributeSet_ID IS NULL OR a.IsInstanceAttribute = 'Y'))"
 				+ " AND I_IsImported<>'Y'").append (clientCheck);
 		no = DB.executeUpdate (sql.toString (), get_TrxName());

--- a/base/src/org/compiere/process/ImportInventory.java
+++ b/base/src/org/compiere/process/ImportInventory.java
@@ -21,8 +21,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.logging.Level;
-
-import org.compiere.model.MAcctSchema;
 import org.compiere.model.MAttributeSet;
 import org.compiere.model.MAttributeSetInstance;
 import org.compiere.model.MInventory;
@@ -40,102 +38,38 @@ import org.compiere.util.TimeUtil;
  * 	@version 	$Id: ImportInventory.java,v 1.2 2006/07/30 00:51:01 jjanke Exp $
  * 	@author Yamel Senih, ysenih@erpya.com, ERPCyA http://www.erpya.com
  */
-public class ImportInventory extends SvrProcess
-{
-	/**	Client to be imported to		*/
-	private int				p_AD_Client_ID = 0;
-	/**	Organization to be imported to	*/
-	private int				p_AD_Org_ID = 0;
-	/**	Location to be imported to		*/
-	private int				p_M_Locator_ID = 0;
-	/**	Default Date					*/
-	private Timestamp		p_MovementDate = null;
-	/**	Delete old Imported				*/
-	private boolean			p_DeleteOldImported = false;
-	
-	//@Trifon
-	/**	Update Costing					*/
-	private boolean			p_UpdateCosting = false;
-	/**	Accounting Schema in which costing to be updated	*/
-	private int				p_C_AcctSchema_ID = 0;
-	MAcctSchema acctSchema 	= null;
-	/**	Cost Type for which costing to be updated		*/
-	private int				p_M_CostType_ID = 0;
-	/**	Cost Element for which costing to be updated	*/
-	private int				p_M_CostElement_ID = 0;
-	/**	Organization for which Costing record must be updated	*/
-	private int				p_AD_OrgTrx_ID = 0;
-	
-	/**
-	 *  Prepare - e.g., get Parameters.
-	 */
-	protected void prepare()
-	{
-		ProcessInfoParameter[] para = getParameter();
-		for (int i = 0; i < para.length; i++)
-		{
-			String name = para[i].getParameterName();
-			if (para[i].getParameter() == null)
-				;
-			else if (name.equals("AD_Client_ID"))
-				p_AD_Client_ID = ((BigDecimal)para[i].getParameter()).intValue();
-			else if (name.equals("AD_Org_ID"))
-				p_AD_Org_ID = ((BigDecimal)para[i].getParameter()).intValue();
-			else if (name.equals("M_Locator_ID"))
-				p_M_Locator_ID = ((BigDecimal)para[i].getParameter()).intValue();
-			else if (name.equals("MovementDate"))
-				p_MovementDate = (Timestamp)para[i].getParameter();
-			else if (name.equals("DeleteOldImported"))
-				p_DeleteOldImported = "Y".equals(para[i].getParameter());
-			else if (name.equals("IsUpdateCosting"))
-				p_UpdateCosting = "Y".equals(para[i].getParameter());
-			else if (name.equals("C_AcctSchema_ID"))
-				p_C_AcctSchema_ID = ((BigDecimal)para[i].getParameter()).intValue();
-			else if (name.equals("M_CostType_ID"))
-				p_M_CostType_ID = ((BigDecimal)para[i].getParameter()).intValue();
-			else if (name.equals("M_CostElement_ID"))
-				p_M_CostElement_ID = ((BigDecimal)para[i].getParameter()).intValue();
-			else if (name.equals("AD_OrgTrx_ID"))
-				p_AD_OrgTrx_ID = ((BigDecimal)para[i].getParameter()).intValue();
-			else
-				log.log(Level.SEVERE, "Unknown Parameter: " + name);
-		}
-	}	//	prepare
-
-
+public class ImportInventory extends ImportInventoryAbstract {
 	/**
 	 *  Perform process.
 	 *  @return Message
 	 *  @throws Exception
 	 */
-	protected String doIt() throws java.lang.Exception
-	{
-		log.info("M_Locator_ID=" + p_M_Locator_ID + ",MovementDate=" + p_MovementDate);
+	protected String doIt() throws java.lang.Exception {
+		log.info("M_Locator_ID=" + getLocatorId() + ",MovementDate=" + getMovementDate());
 		
-		if (p_UpdateCosting) {
-			if (p_C_AcctSchema_ID <= 0) {
+		if (isUpdateCosting()) {
+			if (getAcctSchemaId() <= 0) {
 				throw new IllegalArgumentException("Accounting Schema required!");
 			}
-			if (p_M_CostType_ID <= 0) {
+			if (getCostTypeId() <= 0) {
 				throw new IllegalArgumentException("Cost Type required!");
 			}
-			if (p_M_CostElement_ID <= 0 ) {
+			if (getCostElementId() <= 0 ) {
 				throw new IllegalArgumentException("Cost Element required!");
 			}
-			if (p_AD_OrgTrx_ID < 0 ) {
+			if (getOrgTrxId() < 0 ) {
 				throw new IllegalArgumentException("AD_OrgTrx required!");
 			}
-			 acctSchema = MAcctSchema.get(getCtx(), p_C_AcctSchema_ID, get_TrxName());
 		}
 		
 		StringBuffer sql = null;
 		int no = 0;
-		String clientCheck = " AND AD_Client_ID=" + p_AD_Client_ID;
+		String clientCheck = " AND AD_Client_ID=" + getClientId();
 
 		//	****	Prepare	****
 
 		//	Delete Old Imported
-		if (p_DeleteOldImported)
+		if (isDeleteOldImported())
 		{
 			sql = new StringBuffer ("DELETE I_Inventory "
 				  + "WHERE I_IsImported='Y'").append (clientCheck);
@@ -145,10 +79,10 @@ public class ImportInventory extends SvrProcess
 
 		//	Set Client, Org, Location, IsActive, Created/Updated
 		sql = new StringBuffer ("UPDATE I_Inventory "
-			  + "SET AD_Client_ID = COALESCE (AD_Client_ID,").append (p_AD_Client_ID).append ("),"
-			  + " AD_Org_ID = COALESCE (AD_Org_ID,").append (p_AD_Org_ID).append ("),");
-		if (p_MovementDate != null)
-			sql.append(" MovementDate = COALESCE (MovementDate,").append (DB.TO_DATE(p_MovementDate)).append ("),");
+			  + "SET AD_Client_ID = COALESCE (AD_Client_ID,").append (getClientId()).append ("),"
+			  + " AD_Org_ID = COALESCE (AD_Org_ID,").append (getOrgId()).append ("),");
+		if (getMovementDate() != null)
+			sql.append(" MovementDate = COALESCE (MovementDate,").append (DB.TO_DATE(getMovementDate())).append ("),");
 		sql.append(" IsActive = COALESCE (IsActive, 'Y'),"
 			  + " Created = COALESCE (Created, SysDate),"
 			  + " CreatedBy = COALESCE (CreatedBy, 0),"
@@ -186,10 +120,10 @@ public class ImportInventory extends SvrProcess
 			+ " AND I_IsImported<>'Y'").append (clientCheck);
 		no = DB.executeUpdate (sql.toString (), get_TrxName());
 		log.fine("Set Locator from X,Y,Z =" + no);
-		if (p_M_Locator_ID != 0)
+		if (getLocatorId() != 0)
 		{
 			sql = new StringBuffer ("UPDATE I_Inventory "
-				+ "SET M_Locator_ID = ").append (p_M_Locator_ID).append (
+				+ "SET M_Locator_ID = ").append (getLocatorId()).append (
 				" WHERE M_Locator_ID IS NULL"
 				+ " AND I_IsImported<>'Y'").append (clientCheck);
 			no = DB.executeUpdate (sql.toString (), get_TrxName());
@@ -253,7 +187,7 @@ public class ImportInventory extends SvrProcess
 			log.warning ("No QtyCount=" + no);
 		
 		sql = new StringBuffer ("UPDATE I_Inventory "
-				+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=" + Msg.parseTranslation(getCtx(), "@SQLErrorNotUnique@ @M_Inventory_ID@, @M_Locator_ID@, @M_Product_ID@ @Qty@ = ") 
+				+ "SET I_IsImported='E', I_ErrorMsg=I_ErrorMsg||'ERR=" + Msg.parseTranslation(getCtx(), "@SQLErrorNotUnique@ (@M_Inventory_ID@, @M_Locator_ID@, @M_Product_ID@) @Qty@ = ") 
 				+ " ' || (SELECT COUNT(i.I_Inventory_ID) FROM I_Inventory i WHERE i.M_Product_ID = I_Inventory.M_Product_ID AND i.M_Locator_ID = I_Inventory.M_Locator_ID GROUP BY i.M_Locator_ID, i.M_Product_ID) "
 				+ "WHERE EXISTS(SELECT 1 FROM I_Inventory i WHERE i.M_Product_ID = I_Inventory.M_Product_ID AND i.M_Locator_ID = I_Inventory.M_Locator_ID GROUP BY i.M_Locator_ID, i.M_Product_ID HAVING(COUNT(i.I_Inventory_ID) > 1)) "
 				+ "AND EXISTS(SELECT 1 FROM M_Product p LEFT JOIN M_AttributeSet a ON(a.M_AttributeSet_ID = p.M_AttributeSet_ID) WHERE p.M_Product_ID = I_Inventory.M_Product_ID AND (p.M_AttributeSet_ID IS NULL OR a.IsInstanceAttribute = 'Y'))"
@@ -295,6 +229,7 @@ public class ImportInventory extends SvrProcess
 					inventory.setDescription("I " + importInventory.getM_Warehouse_ID() + " " + movementDate);
 					inventory.setM_Warehouse_ID(importInventory.getM_Warehouse_ID());
 					inventory.setMovementDate(movementDate);
+					inventory.setIsStocktake(true);
 					//
 					inventory.saveEx();
 					warehouseId = importInventory.getM_Warehouse_ID();
@@ -333,7 +268,7 @@ public class ImportInventory extends SvrProcess
 				
 				noInsertLine++;
 					//@Trifon update Product cost record if Update costing is enabled
-				if (p_UpdateCosting) 
+				if (isUpdateCosting()) 
 				{
 						inventoryLine.setCurrentCostPrice(importInventory.getCurrentCostPrice());
 						inventoryLine.setCurrentCostPriceLL(importInventory.getCurrentCostPriceLL());

--- a/base/src/org/compiere/process/ImportInventoryAbstract.java
+++ b/base/src/org/compiere/process/ImportInventoryAbstract.java
@@ -1,0 +1,202 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.										*
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+
+package org.compiere.process;
+
+import java.sql.Timestamp;
+
+/** Generated Process for (Import Inventory)
+ *  @author ADempiere (generated) 
+ *  @version Release 3.9.3
+ */
+public abstract class ImportInventoryAbstract extends SvrProcess {
+	/** Process Value 	*/
+	private static final String VALUE_FOR_PROCESS = "Import_Inventory";
+	/** Process Name 	*/
+	private static final String NAME_FOR_PROCESS = "Import Inventory";
+	/** Process Id 	*/
+	private static final int ID_FOR_PROCESS = 219;
+	/**	Parameter Name for Client	*/
+	public static final String AD_CLIENT_ID = "AD_Client_ID";
+	/**	Parameter Name for Organization	*/
+	public static final String AD_ORG_ID = "AD_Org_ID";
+	/**	Parameter Name for Locator	*/
+	public static final String M_LOCATOR_ID = "M_Locator_ID";
+	/**	Parameter Name for Movement Date	*/
+	public static final String MOVEMENTDATE = "MovementDate";
+	/**	Parameter Name for Delete old imported records	*/
+	public static final String DELETEOLDIMPORTED = "DeleteOldImported";
+	/**	Parameter Name for Update Costing	*/
+	public static final String ISUPDATECOSTING = "IsUpdateCosting";
+	/**	Parameter Name for Accounting Schema	*/
+	public static final String C_ACCTSCHEMA_ID = "C_AcctSchema_ID";
+	/**	Parameter Name for Cost Type	*/
+	public static final String M_COSTTYPE_ID = "M_CostType_ID";
+	/**	Parameter Name for Cost Element	*/
+	public static final String M_COSTELEMENT_ID = "M_CostElement_ID";
+	/**	Parameter Name for Trx Organization	*/
+	public static final String AD_ORGTRX_ID = "AD_OrgTrx_ID";
+	/**	Parameter Value for Client	*/
+	private int clientId;
+	/**	Parameter Value for Organization	*/
+	private int orgId;
+	/**	Parameter Value for Locator	*/
+	private int locatorId;
+	/**	Parameter Value for Movement Date	*/
+	private Timestamp movementDate;
+	/**	Parameter Value for Delete old imported records	*/
+	private boolean isDeleteOldImported;
+	/**	Parameter Value for Update Costing	*/
+	private boolean isUpdateCosting;
+	/**	Parameter Value for Accounting Schema	*/
+	private int acctSchemaId;
+	/**	Parameter Value for Cost Type	*/
+	private int costTypeId;
+	/**	Parameter Value for Cost Element	*/
+	private int costElementId;
+	/**	Parameter Value for Trx Organization	*/
+	private int orgTrxId;
+
+	@Override
+	protected void prepare() {
+		clientId = getParameterAsInt(AD_CLIENT_ID);
+		orgId = getParameterAsInt(AD_ORG_ID);
+		locatorId = getParameterAsInt(M_LOCATOR_ID);
+		movementDate = getParameterAsTimestamp(MOVEMENTDATE);
+		isDeleteOldImported = getParameterAsBoolean(DELETEOLDIMPORTED);
+		isUpdateCosting = getParameterAsBoolean(ISUPDATECOSTING);
+		acctSchemaId = getParameterAsInt(C_ACCTSCHEMA_ID);
+		costTypeId = getParameterAsInt(M_COSTTYPE_ID);
+		costElementId = getParameterAsInt(M_COSTELEMENT_ID);
+		orgTrxId = getParameterAsInt(AD_ORGTRX_ID);
+	}
+
+	/**	 Getter Parameter Value for Client	*/
+	protected int getClientId() {
+		return clientId;
+	}
+
+	/**	 Setter Parameter Value for Client	*/
+	protected void setClientId(int clientId) {
+		this.clientId = clientId;
+	}
+
+	/**	 Getter Parameter Value for Organization	*/
+	protected int getOrgId() {
+		return orgId;
+	}
+
+	/**	 Setter Parameter Value for Organization	*/
+	protected void setOrgId(int orgId) {
+		this.orgId = orgId;
+	}
+
+	/**	 Getter Parameter Value for Locator	*/
+	protected int getLocatorId() {
+		return locatorId;
+	}
+
+	/**	 Setter Parameter Value for Locator	*/
+	protected void setLocatorId(int locatorId) {
+		this.locatorId = locatorId;
+	}
+
+	/**	 Getter Parameter Value for Movement Date	*/
+	protected Timestamp getMovementDate() {
+		return movementDate;
+	}
+
+	/**	 Setter Parameter Value for Movement Date	*/
+	protected void setMovementDate(Timestamp movementDate) {
+		this.movementDate = movementDate;
+	}
+
+	/**	 Getter Parameter Value for Delete old imported records	*/
+	protected boolean isDeleteOldImported() {
+		return isDeleteOldImported;
+	}
+
+	/**	 Setter Parameter Value for Delete old imported records	*/
+	protected void setDeleteOldImported(boolean isDeleteOldImported) {
+		this.isDeleteOldImported = isDeleteOldImported;
+	}
+
+	/**	 Getter Parameter Value for Update Costing	*/
+	protected boolean isUpdateCosting() {
+		return isUpdateCosting;
+	}
+
+	/**	 Setter Parameter Value for Update Costing	*/
+	protected void setIsUpdateCosting(boolean isUpdateCosting) {
+		this.isUpdateCosting = isUpdateCosting;
+	}
+
+	/**	 Getter Parameter Value for Accounting Schema	*/
+	protected int getAcctSchemaId() {
+		return acctSchemaId;
+	}
+
+	/**	 Setter Parameter Value for Accounting Schema	*/
+	protected void setAcctSchemaId(int acctSchemaId) {
+		this.acctSchemaId = acctSchemaId;
+	}
+
+	/**	 Getter Parameter Value for Cost Type	*/
+	protected int getCostTypeId() {
+		return costTypeId;
+	}
+
+	/**	 Setter Parameter Value for Cost Type	*/
+	protected void setCostTypeId(int costTypeId) {
+		this.costTypeId = costTypeId;
+	}
+
+	/**	 Getter Parameter Value for Cost Element	*/
+	protected int getCostElementId() {
+		return costElementId;
+	}
+
+	/**	 Setter Parameter Value for Cost Element	*/
+	protected void setCostElementId(int costElementId) {
+		this.costElementId = costElementId;
+	}
+
+	/**	 Getter Parameter Value for Trx Organization	*/
+	protected int getOrgTrxId() {
+		return orgTrxId;
+	}
+
+	/**	 Setter Parameter Value for Trx Organization	*/
+	protected void setOrgTrxId(int orgTrxId) {
+		this.orgTrxId = orgTrxId;
+	}
+
+	/**	 Getter Parameter Value for Process ID	*/
+	public static final int getProcessId() {
+		return ID_FOR_PROCESS;
+	}
+
+	/**	 Getter Parameter Value for Process Value	*/
+	public static final String getProcessValue() {
+		return VALUE_FOR_PROCESS;
+	}
+
+	/**	 Getter Parameter Value for Process Name	*/
+	public static final String getProcessName() {
+		return NAME_FOR_PROCESS;
+	}
+}


### PR DESCRIPTION
The problem: if you try import a physical inventory from ADempiere importer currently not exists a validation for duplicate key before import then the error throw when physical inventory line is saved but the user can't see the error, a console log from debugger can show the problem but import inventory line don't have error:

```Shell
org.adempiere.exceptions.AdempiereException: ERROR: duplicate key value violates unique constraint "m_inventoryline_productlocattr"
  Detail: Key (m_inventory_id, m_locator_id, m_product_id, m_attributesetinstance_id)=(1000554, 1000048, 1000401, 0) already exists.
``` 

This change allows see the error line by line and validate before import, is very beautiful for end user

See a gif after fix it:
![Current ogv](https://user-images.githubusercontent.com/2333092/72030036-383c1e00-325e-11ea-98bc-fe65f0fbc078.gif)