### PR TITLE
Fixed error with open amount for receipt created directly on payment / Colect

### DIFF
--- a/base/src/org/compiere/model/MPaySelectionCheck.java
+++ b/base/src/org/compiere/model/MPaySelectionCheck.java
@@ -157,11 +157,15 @@ public final class MPaySelectionCheck extends X_C_PaySelectionCheck
 			}
 			//	For all
 			paySelectionLine.setIsPrepayment(payment.isPrepayment());
-			//	
+			//	calculate open amount from payment amount
+			BigDecimal openAmount = Env.ZERO;
+			if(payment.isOverUnderPayment()) {
+				openAmount = payment.getPayAmt().add(payment.getDiscountAmt()).add(payment.getOverUnderAmt());
+			}
 			paySelectionLine.setC_BPartner_ID(payment.getC_BPartner_ID());
 			paySelectionLine.setIsSOTrx (payment.isReceipt());
 			paySelectionLine.setAmtSource(payment.getPayAmt());
-			paySelectionLine.setOpenAmt(payment.getPayAmt().add(payment.getDiscountAmt()));
+			paySelectionLine.setOpenAmt(openAmount);
 			paySelectionLine.setPayAmt (payment.getPayAmt());
 			paySelectionLine.setDiscountAmt(payment.getDiscountAmt());
 			paySelectionLine.setDifferenceAmt (Env.ZERO);


### PR DESCRIPTION
The problem:
When is created a collect from Payment / Collect window ADempiere automatically create a payment selection when is printed the payment.

The payment selection is ok and allows show a detail from collect, the problem is that if is selected a invoice with open amount the column "Open Amount" is setted with payment amount instead real open amount and report is wrong.

