### PR TITLE
#2968 Enable Sign Change for Calculated Lines in Financial Reports

### DIFF
--- a/migration/393lts-394lts/05560_2968_ShowOppositeSignForALineCalculated.xml
+++ b/migration/393lts-394lts/05560_2968_ShowOppositeSignForALineCalculated.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Change sign for calculated line, It is also required, there " ReleaseNo="3.9.4" SeqNo="5560">
+    <Comments>https://github.com/adempiere/adempiere/issues/2968</Comments>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="80199" Table="AD_Field">
+        <Data AD_Column_ID="177" Column="DisplayLogic" oldValue="@LineType@=S">@LineType@=S | @LineType@=C</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Fixes #2968

Now the Show Opposite Sign is displayed.

![image](https://user-images.githubusercontent.com/786968/73586858-e3647f80-4478-11ea-8e5f-8453cc1f6f5f.png)
