### PR TITLE
Fixed error with date for commission run

### DIFF
--- a/base/src/org/compiere/model/MCommissionRun.java
+++ b/base/src/org/compiere/model/MCommissionRun.java
@@ -1581,9 +1581,9 @@ public class MCommissionRun extends X_C_CommissionRun implements DocAction, DocO
 	 */
 	private void setStartEndDate(String frequencyType) {
 		//	If Recalculate flag is false and Start and End Date are filled then it is not recalculated
-		if(getStartDate() != null
-				&& getEndDate() != null
-				&& !isReCalculate()) {
+		if((getStartDate() != null
+				&& getEndDate() != null)
+				|| !isReCalculate()) {
 			return;
 		}
 		GregorianCalendar cal = new GregorianCalendar(Language.getLoginLanguage().getLocale());


### PR DESCRIPTION
Currently exist a problem for commission calculation:

Step for reproduce

- Create a new commission with monthly frequency
- Set date for Start a End Date
- Note that when is processed the document is change dates for Start Date and End Date

This pull request resolve it