### PR TITLE
Fixed error with ambiguous reference for zoom across

### DIFF
--- a/base/src/org/adempiere/model/GenericZoomProvider.java
+++ b/base/src/org/adempiere/model/GenericZoomProvider.java
@@ -129,7 +129,7 @@ public class GenericZoomProvider implements IZoomProvider {
 		MTab tab = new MTab(Env.getCtx(), AD_Tab_ID, null);
 		final MQuery query = new MQuery();
 
-		query.addRestriction(po.get_TableName() + "_ID=" + po.get_ID());
+		query.addRestriction(targetTableName + "." + po.get_TableName() + "_ID=" + po.get_ID());
 		if (tab.getWhereClause() != null && tab.getWhereClause().length() > 0)
 			query.addRestriction("(" + tab.getWhereClause() + ")");
 		query.setZoomTableName(targetTableName);


### PR DESCRIPTION
The zoom Across is a dynamic way for get reference from a record to other, currently exists a class for resolve all business model for it.

The problem: if You need implement it for multiples tables joined not exist a way for differenciate tables from zoom, a example of current behavior is that a Zoom from Business Partner to Valid combination is the follow:
```SQL
SELECT COUNT(*) FROM C_ValidCombination WHERE (C_BPartner_ID=113)
```

This change propose the follow query:

```SQL
SELECT COUNT(*) FROM C_ValidCombination WHERE (C_ValidCombination.C_BPartner_ID=113)
```

Just add Table name before column name and it worked ok 

Note: this change already exists for Zoom based on reference but for zoom dynamic PO does not exist