### PR TITLE
Fixed error with last month day for commission totally paid

### DIFF
--- a/base/src/org/compiere/model/MCommissionRun.java
+++ b/base/src/org/compiere/model/MCommissionRun.java
@@ -654,7 +654,7 @@ public class MCommissionRun extends X_C_CommissionRun implements DocAction, DocO
 				String sqlAppend = "";
 				if (commission.isTotallyPaid()) 
 		        	// Last payment must be within commission period 
-					sqlAppend = " AND (p.DateTrx <? or  p.DateTrx <?) AND maxPayDate(h.c_Invoice_ID) between ? AND ? ";
+					sqlAppend = " AND (p.DateTrx <= ? or  p.DateTrx <= ?) AND maxPayDate(h.c_Invoice_ID) between ? AND ? ";
 				else 
 					sqlAppend = " AND p.DateTrx BETWEEN ? AND ? ";
 				


### PR DESCRIPTION
This pull request resolve a problem with commission for calculation based on invoices totally paid, the problem is that search criteria is based on date ranges **>** and **<** but the correct search criteria should be **>=** and **<=**