### PR TITLE
Fixed error with NPE for request when sender not have mail

### DIFF
--- a/org.adempiere.request/src/main/java/org/compiere/model/MRequest.java
+++ b/org.adempiere.request/src/main/java/org/compiere/model/MRequest.java
@@ -1143,7 +1143,7 @@ public class MRequest extends X_R_Request
 				if (from !=null)
 					isIncludeOwnChanges = from.isIncludeOwnChanges();
 				if (userId == updatedBy
-						&& !from.isIncludeOwnChanges())
+						&& !isIncludeOwnChanges)
 					continue;
 				
 				//	No confidential to externals


### PR DESCRIPTION
Step for reproduce:
- Create a new user without email or pass
- login wth new user
- Create a new request
- save (here is the error)

```Java
-----------> GridTable.saveWarning: Error -  [52]
-----------> GridTable.saveWarning: Error -  [52]
-----------> MRequest.saveFinish: afterSave [51]
java.lang.NullPointerException
	at org.compiere.model.MRequest.sendNotices(MRequest.java:1146)
	at org.compiere.model.MRequest.afterSave(MRequest.java:993)
	at org.compiere.model.PO.saveFinish(PO.java:2352)
	at org.compiere.model.PO.saveNew(PO.java:2951)
	at org.compiere.model.PO.save(PO.java:2236)
	at org.compiere.model.GridTable.dataSavePO(GridTable.java:2192)
	at org.compiere.model.GridTable.dataSave(GridTable.java:1516)
	at org.compiere.model.GridTab.dataSave(GridTab.java:997)
	at org.adempiere.webui.panel.AbstractADWindowPanel.onSave(AbstractADWindowPanel.java:1682)
	at org.adempiere.webui.panel.AbstractADWindowPanel.onSave(AbstractADWindowPanel.java:1656)
	at sun.reflect.GeneratedMethodAccessor97.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.adempiere.webui.component.CWindowToolbar.doOnClick(CWindowToolbar.java:405)
	at org.adempiere.webui.component.CWindowToolbar.onEvent(CWindowToolbar.java:369)
	at org.zkoss.zk.ui.impl.EventProcessor.process0(EventProcessor.java:197)
	at org.zkoss.zk.ui.impl.EventProcessor.process(EventProcessor.java:141)
	at org.zkoss.zk.ui.impl.EventProcessingThreadImpl.process0(EventProcessingThreadImpl.java:519)
	at org.zkoss.zk.ui.impl.EventProcessingThreadImpl.run(EventProcessingThreadImpl.java:446)
```