### PR TITLE
Fixed error with reload registration ID

### DIFF
--- a/base/src/org/spin/util/support/AppSupportHandler.java
+++ b/base/src/org/spin/util/support/AppSupportHandler.java
@@ -71,9 +71,12 @@ public class AppSupportHandler {
     	}
         if(!appSupportGeneratorMap.containsKey(registration.getAD_AppSupport_ID())) {
             loadClass(registration.getAD_AppRegistration_ID(), registration.getAD_AppSupport_ID());
+            return appSupportGeneratorMap.get(registration.getAD_AppSupport_ID());
         }
         //  Default return
-        return appSupportGeneratorMap.get(registration.getAD_AppSupport_ID());
+        IAppSupport supportedApplication = appSupportGeneratorMap.get(registration.getAD_AppSupport_ID());
+        supportedApplication.setAppRegistrationId(registration.getAD_AppRegistration_ID());
+        return supportedApplication;
     }
     
     /**


### PR DESCRIPTION
The problem:
Currently the App registration instance is loaded when not exists this but after loaded instance always keep the same registration ID, it is a error because never is changed for distints applications