### PR TITLE
Add Invoice Order support

### DIFF
--- a/base/src/org/compiere/model/I_C_DocType.java
+++ b/base/src/org/compiere/model/I_C_DocType.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for C_DocType
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2
+ *  @version Release 3.9.3
  */
 public interface I_C_DocType 
 {
@@ -92,6 +92,19 @@ public interface I_C_DocType
 
 	public org.compiere.model.I_C_DocType getC_DocTypeDifference() throws RuntimeException;
 
+    /** Column name C_DocType_ID */
+    public static final String COLUMNNAME_C_DocType_ID = "C_DocType_ID";
+
+	/** Set Document Type.
+	  * Document type or rules
+	  */
+	public void setC_DocType_ID (int C_DocType_ID);
+
+	/** Get Document Type.
+	  * Document type or rules
+	  */
+	public int getC_DocType_ID();
+
     /** Column name C_DocTypeInvoice_ID */
     public static final String COLUMNNAME_C_DocTypeInvoice_ID = "C_DocTypeInvoice_ID";
 
@@ -151,19 +164,6 @@ public interface I_C_DocType
 	public int getC_DocTypeShipment_ID();
 
 	public org.compiere.model.I_C_DocType getC_DocTypeShipment() throws RuntimeException;
-
-    /** Column name C_DocType_ID */
-    public static final String COLUMNNAME_C_DocType_ID = "C_DocType_ID";
-
-	/** Set Document Type.
-	  * Document type or rules
-	  */
-	public void setC_DocType_ID (int C_DocType_ID);
-
-	/** Get Document Type.
-	  * Document type or rules
-	  */
-	public int getC_DocType_ID();
 
     /** Column name Created */
     public static final String COLUMNNAME_Created = "Created";
@@ -413,19 +413,6 @@ public interface I_C_DocType
 	  */
 	public boolean isDocNoControlled();
 
-    /** Column name IsInTransit */
-    public static final String COLUMNNAME_IsInTransit = "IsInTransit";
-
-	/** Set In Transit.
-	  * Movement is in transit
-	  */
-	public void setIsInTransit (boolean IsInTransit);
-
-	/** Get In Transit.
-	  * Movement is in transit
-	  */
-	public boolean isInTransit();
-
     /** Column name IsIndexed */
     public static final String COLUMNNAME_IsIndexed = "IsIndexed";
 
@@ -438,6 +425,19 @@ public interface I_C_DocType
 	  * Index the document for the internal search engine
 	  */
 	public boolean isIndexed();
+
+    /** Column name IsInTransit */
+    public static final String COLUMNNAME_IsInTransit = "IsInTransit";
+
+	/** Set In Transit.
+	  * Movement is in transit
+	  */
+	public void setIsInTransit (boolean IsInTransit);
+
+	/** Get In Transit.
+	  * Movement is in transit
+	  */
+	public boolean isInTransit();
 
     /** Column name IsOverwriteDateOnComplete */
     public static final String COLUMNNAME_IsOverwriteDateOnComplete = "IsOverwriteDateOnComplete";
@@ -509,19 +509,6 @@ public interface I_C_DocType
 	  */
 	public boolean isReversedWithOriginalAcct();
 
-    /** Column name IsSOTrx */
-    public static final String COLUMNNAME_IsSOTrx = "IsSOTrx";
-
-	/** Set Sales Transaction.
-	  * This is a Sales Transaction
-	  */
-	public void setIsSOTrx (boolean IsSOTrx);
-
-	/** Get Sales Transaction.
-	  * This is a Sales Transaction
-	  */
-	public boolean isSOTrx();
-
     /** Column name IsShipConfirm */
     public static final String COLUMNNAME_IsShipConfirm = "IsShipConfirm";
 
@@ -534,6 +521,19 @@ public interface I_C_DocType
 	  * Require Ship or Receipt Confirmation before processing
 	  */
 	public boolean isShipConfirm();
+
+    /** Column name IsSOTrx */
+    public static final String COLUMNNAME_IsSOTrx = "IsSOTrx";
+
+	/** Set Sales Transaction.
+	  * This is a Sales Transaction
+	  */
+	public void setIsSOTrx (boolean IsSOTrx);
+
+	/** Get Sales Transaction.
+	  * This is a Sales Transaction
+	  */
+	public boolean isSOTrx();
 
     /** Column name IsSplitWhenDifference */
     public static final String COLUMNNAME_IsSplitWhenDifference = "IsSplitWhenDifference";
@@ -587,19 +587,6 @@ public interface I_C_DocType
 	  */
 	public String getPrintName();
 
-    /** Column name UUID */
-    public static final String COLUMNNAME_UUID = "UUID";
-
-	/** Set Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public void setUUID (String UUID);
-
-	/** Get Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public String getUUID();
-
     /** Column name Updated */
     public static final String COLUMNNAME_Updated = "Updated";
 
@@ -615,4 +602,17 @@ public interface I_C_DocType
 	  * User who updated this records
 	  */
 	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
 }

--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -385,6 +385,8 @@ public class MOrder extends X_C_Order implements DocAction
 	public static final String		DocSubTypeSO_OnCredit = "WI";
 	/** Sales Order Sub Type - RM	*/
 	public static final String		DocSubTypeSO_RMA = "RM";
+	/** Pre-Invoiced Sub Type - PI	*/
+	public static final String		DocSubTypeSO_Pre_Invoiced = "PI";
 
 	/**
 	 * 	Set Target Sales Document Type
@@ -1776,8 +1778,8 @@ public class MOrder extends X_C_Order implements DocAction
 		//	Create SO Invoice - Always invoice complete Order
 		if ( MDocType.DOCSUBTYPESO_POSOrder.equals(DocSubTypeSO)
 			|| MDocType.DOCSUBTYPESO_OnCreditOrder.equals(DocSubTypeSO) 	
-			|| MDocType.DOCSUBTYPESO_PrepayOrder.equals(DocSubTypeSO)) 
-		{
+			|| MDocType.DOCSUBTYPESO_PrepayOrder.equals(DocSubTypeSO)
+			|| MDocType.DOCSUBTYPESO_Pre_InvoicedOrder.equals(DocSubTypeSO)) {
 			MInvoice invoice = createInvoice (dt, shipment, realTimePOS ? null : getDateOrdered());
 			if (invoice == null)
 				return DocAction.STATUS_Invalid;

--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -386,7 +386,7 @@ public class MOrder extends X_C_Order implements DocAction
 	/** Sales Order Sub Type - RM	*/
 	public static final String		DocSubTypeSO_RMA = "RM";
 	/** Pre-Invoiced Sub Type - PI	*/
-	public static final String		DocSubTypeSO_Pre_Invoiced = "PI";
+	public static final String		DocSubTypeSO_InvoiceOrder = "IO";
 
 	/**
 	 * 	Set Target Sales Document Type
@@ -1779,7 +1779,7 @@ public class MOrder extends X_C_Order implements DocAction
 		if ( MDocType.DOCSUBTYPESO_POSOrder.equals(DocSubTypeSO)
 			|| MDocType.DOCSUBTYPESO_OnCreditOrder.equals(DocSubTypeSO) 	
 			|| MDocType.DOCSUBTYPESO_PrepayOrder.equals(DocSubTypeSO)
-			|| MDocType.DOCSUBTYPESO_Pre_InvoicedOrder.equals(DocSubTypeSO)) {
+			|| MDocType.DOCSUBTYPESO_InvoiceOrder.equals(DocSubTypeSO)) {
 			MInvoice invoice = createInvoice (dt, shipment, realTimePOS ? null : getDateOrdered());
 			if (invoice == null)
 				return DocAction.STATUS_Invalid;

--- a/base/src/org/compiere/model/X_C_DocType.java
+++ b/base/src/org/compiere/model/X_C_DocType.java
@@ -23,14 +23,14 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Model for C_DocType
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2 - $Id$ */
+ *  @version Release 3.9.3 - $Id$ */
 public class X_C_DocType extends PO implements I_C_DocType, I_Persistent 
 {
 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20191120L;
+	private static final long serialVersionUID = 20200301L;
 
     /** Standard Constructor */
     public X_C_DocType (Properties ctx, int C_DocType_ID, String trxName)
@@ -50,13 +50,13 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 			setIsDefaultCounterDoc (false);
 			setIsDocNoControlled (true);
 // Y
-			setIsInTransit (false);
 			setIsIndexed (false);
+			setIsInTransit (false);
 			setIsPickQAConfirm (false);
 			setIsPrepareSplitDocument (true);
 // Y
-			setIsSOTrx (false);
 			setIsShipConfirm (false);
+			setIsSOTrx (false);
 			setIsSplitWhenDifference (false);
 // N
 			setName (null);
@@ -143,6 +143,29 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 	public int getC_DocTypeDifference_ID () 
 	{
 		Integer ii = (Integer)get_Value(COLUMNNAME_C_DocTypeDifference_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Document Type.
+		@param C_DocType_ID 
+		Document type or rules
+	  */
+	public void setC_DocType_ID (int C_DocType_ID)
+	{
+		if (C_DocType_ID < 0) 
+			set_ValueNoCheck (COLUMNNAME_C_DocType_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_C_DocType_ID, Integer.valueOf(C_DocType_ID));
+	}
+
+	/** Get Document Type.
+		@return Document type or rules
+	  */
+	public int getC_DocType_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_C_DocType_ID);
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
@@ -255,29 +278,6 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 	public int getC_DocTypeShipment_ID () 
 	{
 		Integer ii = (Integer)get_Value(COLUMNNAME_C_DocTypeShipment_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
-	}
-
-	/** Set Document Type.
-		@param C_DocType_ID 
-		Document type or rules
-	  */
-	public void setC_DocType_ID (int C_DocType_ID)
-	{
-		if (C_DocType_ID < 0) 
-			set_ValueNoCheck (COLUMNNAME_C_DocType_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_C_DocType_ID, Integer.valueOf(C_DocType_ID));
-	}
-
-	/** Get Document Type.
-		@return Document type or rules
-	  */
-	public int getC_DocType_ID () 
-	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_C_DocType_ID);
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
@@ -477,6 +477,8 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 	public static final String DOCSUBTYPESO_ReturnMaterial = "RM";
 	/** Prepay Order = PR */
 	public static final String DOCSUBTYPESO_PrepayOrder = "PR";
+	/** Pre-Invoiced Order = PI */
+	public static final String DOCSUBTYPESO_Pre_InvoicedOrder = "PI";
 	/** Set SO Sub Type.
 		@param DocSubTypeSO 
 		Sales Order Sub Type
@@ -773,30 +775,6 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 		return false;
 	}
 
-	/** Set In Transit.
-		@param IsInTransit 
-		Movement is in transit
-	  */
-	public void setIsInTransit (boolean IsInTransit)
-	{
-		set_Value (COLUMNNAME_IsInTransit, Boolean.valueOf(IsInTransit));
-	}
-
-	/** Get In Transit.
-		@return Movement is in transit
-	  */
-	public boolean isInTransit () 
-	{
-		Object oo = get_Value(COLUMNNAME_IsInTransit);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
-	}
-
 	/** Set Indexed.
 		@param IsIndexed 
 		Index the document for the internal search engine
@@ -812,6 +790,30 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 	public boolean isIndexed () 
 	{
 		Object oo = get_Value(COLUMNNAME_IsIndexed);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set In Transit.
+		@param IsInTransit 
+		Movement is in transit
+	  */
+	public void setIsInTransit (boolean IsInTransit)
+	{
+		set_Value (COLUMNNAME_IsInTransit, Boolean.valueOf(IsInTransit));
+	}
+
+	/** Get In Transit.
+		@return Movement is in transit
+	  */
+	public boolean isInTransit () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsInTransit);
 		if (oo != null) 
 		{
 			 if (oo instanceof Boolean) 
@@ -959,30 +961,6 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 		return false;
 	}
 
-	/** Set Sales Transaction.
-		@param IsSOTrx 
-		This is a Sales Transaction
-	  */
-	public void setIsSOTrx (boolean IsSOTrx)
-	{
-		set_Value (COLUMNNAME_IsSOTrx, Boolean.valueOf(IsSOTrx));
-	}
-
-	/** Get Sales Transaction.
-		@return This is a Sales Transaction
-	  */
-	public boolean isSOTrx () 
-	{
-		Object oo = get_Value(COLUMNNAME_IsSOTrx);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
-	}
-
 	/** Set Ship/Receipt Confirmation.
 		@param IsShipConfirm 
 		Require Ship or Receipt Confirmation before processing
@@ -998,6 +976,30 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 	public boolean isShipConfirm () 
 	{
 		Object oo = get_Value(COLUMNNAME_IsShipConfirm);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Sales Transaction.
+		@param IsSOTrx 
+		This is a Sales Transaction
+	  */
+	public void setIsSOTrx (boolean IsSOTrx)
+	{
+		set_Value (COLUMNNAME_IsSOTrx, Boolean.valueOf(IsSOTrx));
+	}
+
+	/** Get Sales Transaction.
+		@return This is a Sales Transaction
+	  */
+	public boolean isSOTrx () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsSOTrx);
 		if (oo != null) 
 		{
 			 if (oo instanceof Boolean) 

--- a/base/src/org/compiere/model/X_C_DocType.java
+++ b/base/src/org/compiere/model/X_C_DocType.java
@@ -30,7 +30,7 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20200301L;
+	private static final long serialVersionUID = 20200321L;
 
     /** Standard Constructor */
     public X_C_DocType (Properties ctx, int C_DocType_ID, String trxName)
@@ -477,8 +477,8 @@ public class X_C_DocType extends PO implements I_C_DocType, I_Persistent
 	public static final String DOCSUBTYPESO_ReturnMaterial = "RM";
 	/** Prepay Order = PR */
 	public static final String DOCSUBTYPESO_PrepayOrder = "PR";
-	/** Pre-Invoiced Order = PI */
-	public static final String DOCSUBTYPESO_Pre_InvoicedOrder = "PI";
+	/** Invoice Order = IO */
+	public static final String DOCSUBTYPESO_InvoiceOrder = "IO";
 	/** Set SO Sub Type.
 		@param DocSubTypeSO 
 		Sales Order Sub Type

--- a/migration/393lts-394lts/05620_Add_Invoice_Order.xml
+++ b/migration/393lts-394lts/05620_Add_Invoice_Order.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add Pre-Invoiced Order as Sub Type for orders" ReleaseNo="3.9.3" SeqNo="5620">
+  <Migration EntityType="D" Name="Add Invoice Order as Sub Type for orders" ReleaseNo="3.9.3" SeqNo="5620">
+    <Comments>See: https://github.com/adempiere/adempiere/pull/3042</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="104" Action="I" Record_ID="55447" Table="AD_Ref_List">
         <Data AD_Column_ID="563" Column="IsActive">true</Data>
         <Data AD_Column_ID="564" Column="Created">2020-02-21 21:19:15.418</Data>
         <Data AD_Column_ID="566" Column="Updated">2020-02-21 21:19:15.418</Data>
-        <Data AD_Column_ID="200" Column="Value">PI</Data>
+        <Data AD_Column_ID="200" Column="Value">IO</Data>
         <Data AD_Column_ID="7712" Column="EntityType">ECA02</Data>
         <Data AD_Column_ID="151" Column="AD_Reference_ID">148</Data>
-        <Data AD_Column_ID="150" Column="Description">Pre-Invoiced order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process</Data>
+        <Data AD_Column_ID="150" Column="Description">Invoice Order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process</Data>
         <Data AD_Column_ID="152" Column="ValidFrom" isNewNull="true"/>
-        <Data AD_Column_ID="149" Column="Name">Pre-Invoiced Order</Data>
+        <Data AD_Column_ID="149" Column="Name">Invoice Order</Data>
         <Data AD_Column_ID="153" Column="ValidTo" isNewNull="true"/>
         <Data AD_Column_ID="148" Column="AD_Ref_List_ID">55447</Data>
         <Data AD_Column_ID="372" Column="AD_Org_ID">0</Data>
@@ -23,12 +24,12 @@
     </Step>
     <Step SeqNo="20" StepType="AD">
       <PO AD_Table_ID="136" Action="I" Record_ID="55447" Table="AD_Ref_List_Trl">
-        <Data AD_Column_ID="707" Column="Created">2020-02-21 21:19:27.106</Data>
         <Data AD_Column_ID="709" Column="Updated">2020-02-21 21:19:27.106</Data>
+        <Data AD_Column_ID="707" Column="Created">2020-02-21 21:19:27.106</Data>
         <Data AD_Column_ID="706" Column="IsActive">true</Data>
-        <Data AD_Column_ID="338" Column="Name">Pre-Invoiced Order</Data>
+        <Data AD_Column_ID="338" Column="Name">Invoice Order</Data>
         <Data AD_Column_ID="340" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="339" Column="Description">Pre-Invoiced order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process</Data>
+        <Data AD_Column_ID="339" Column="Description">Invoice Order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process</Data>
         <Data AD_Column_ID="1216" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="1215" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="710" Column="UpdatedBy">100</Data>
@@ -40,10 +41,10 @@
     </Step>
     <Step SeqNo="30" StepType="AD">
       <PO AD_Table_ID="136" Action="U" Record_ID="55447" Table="AD_Ref_List_Trl">
-        <Data AD_Column_ID="339" Column="Description" oldValue="Pre-Invoiced order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process">La orden Pre-Facturada permite generar una factura automáticamente al completarse, la entrega es basada en la regla de entrega desde el proceso estándar de ventas</Data>
+        <Data AD_Column_ID="339" Column="Description" oldValue="Invoice Order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process">La orden Pre-Facturada permite generar una factura automáticamente al completarse, la entrega es basada en la regla de entrega desde el proceso estándar de ventas</Data>
         <Data AD_Column_ID="336" Column="AD_Ref_List_ID" oldValue="55447">55447</Data>
         <Data AD_Column_ID="337" Column="AD_Language" oldValue="es_MX">es_MX</Data>
-        <Data AD_Column_ID="338" Column="Name" oldValue="Pre-Invoiced Order">Orden Pre-Facturada</Data>
+        <Data AD_Column_ID="338" Column="Name" oldValue="Invoice Order">Orden Facturada (Automáticamente)</Data>
       </PO>
     </Step>
   </Migration>

--- a/migration/393lts-394lts/05620_Add_Pre_Invoiced_Order.xml
+++ b/migration/393lts-394lts/05620_Add_Pre_Invoiced_Order.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add Pre-Invoiced Order as Sub Type for orders" ReleaseNo="3.9.3" SeqNo="5620">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="104" Action="I" Record_ID="55447" Table="AD_Ref_List">
+        <Data AD_Column_ID="563" Column="IsActive">true</Data>
+        <Data AD_Column_ID="564" Column="Created">2020-02-21 21:19:15.418</Data>
+        <Data AD_Column_ID="566" Column="Updated">2020-02-21 21:19:15.418</Data>
+        <Data AD_Column_ID="200" Column="Value">PI</Data>
+        <Data AD_Column_ID="7712" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="151" Column="AD_Reference_ID">148</Data>
+        <Data AD_Column_ID="150" Column="Description">Pre-Invoiced order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process</Data>
+        <Data AD_Column_ID="152" Column="ValidFrom" isNewNull="true"/>
+        <Data AD_Column_ID="149" Column="Name">Pre-Invoiced Order</Data>
+        <Data AD_Column_ID="153" Column="ValidTo" isNewNull="true"/>
+        <Data AD_Column_ID="148" Column="AD_Ref_List_ID">55447</Data>
+        <Data AD_Column_ID="372" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="371" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="565" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="567" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84390" Column="UUID">2e566fc6-b08b-464d-8b10-5684654b18cb</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="136" Action="I" Record_ID="55447" Table="AD_Ref_List_Trl">
+        <Data AD_Column_ID="707" Column="Created">2020-02-21 21:19:27.106</Data>
+        <Data AD_Column_ID="709" Column="Updated">2020-02-21 21:19:27.106</Data>
+        <Data AD_Column_ID="706" Column="IsActive">true</Data>
+        <Data AD_Column_ID="338" Column="Name">Pre-Invoiced Order</Data>
+        <Data AD_Column_ID="340" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="339" Column="Description">Pre-Invoiced order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process</Data>
+        <Data AD_Column_ID="1216" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="1215" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="710" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="708" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="336" Column="AD_Ref_List_ID">55447</Data>
+        <Data AD_Column_ID="337" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84391" Column="UUID">9d507747-08eb-4ddd-ade2-2a4b9314faf5</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="136" Action="U" Record_ID="55447" Table="AD_Ref_List_Trl">
+        <Data AD_Column_ID="339" Column="Description" oldValue="Pre-Invoiced order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process">La orden Pre-Facturada permite generar una factura automáticamente al completarse, la entrega es basada en la regla de entrega desde el proceso estándar de ventas</Data>
+        <Data AD_Column_ID="336" Column="AD_Ref_List_ID" oldValue="55447">55447</Data>
+        <Data AD_Column_ID="337" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="338" Column="Name" oldValue="Pre-Invoiced Order">Orden Pre-Facturada</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/migration/393lts-394lts/05630_Add_Invoice_Order_Example_Data_for_Garden_World.xml
+++ b/migration/393lts-394lts/05630_Add_Invoice_Order_Example_Data_for_Garden_World.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add Invoice Order Example Data for Garden World" ReleaseNo="3.9.4" SeqNo="5630">
+    <Comments>See: https://github.com/adempiere/adempiere/pull/3042</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="115" Action="I" Record_ID="55252" Table="AD_Sequence">
+        <Data AD_Column_ID="349" Column="IsActive">true</Data>
+        <Data AD_Column_ID="347" Column="Description">Invoice Order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process</Data>
+        <Data AD_Column_ID="629" Column="Updated">2020-03-21 20:11:12.896</Data>
+        <Data AD_Column_ID="627" Column="Created">2020-03-21 20:11:12.896</Data>
+        <Data AD_Column_ID="225" Column="StartNewYear">false</Data>
+        <Data AD_Column_ID="1187" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="1188" Column="IsAutoSequence">true</Data>
+        <Data AD_Column_ID="222" Column="IsAudited">false</Data>
+        <Data AD_Column_ID="223" Column="Prefix">IO-</Data>
+        <Data AD_Column_ID="224" Column="Suffix" isNewNull="true"/>
+        <Data AD_Column_ID="54272" Column="DateColumn" isNewNull="true"/>
+        <Data AD_Column_ID="54309" Column="DecimalPattern" isNewNull="true"/>
+        <Data AD_Column_ID="216" Column="Name">Invoice Order</Data>
+        <Data AD_Column_ID="427" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="426" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="1186" Column="AD_Sequence_ID">55252</Data>
+        <Data AD_Column_ID="2747" Column="IncrementNo">1</Data>
+        <Data AD_Column_ID="2746" Column="StartNo">300000</Data>
+        <Data AD_Column_ID="350" Column="IsTableID">false</Data>
+        <Data AD_Column_ID="3887" Column="CurrentNextSys">100</Data>
+        <Data AD_Column_ID="220" Column="CurrentNext">50000</Data>
+        <Data AD_Column_ID="628" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="630" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84417" Column="UUID">d5854f79-0dfd-4241-9d60-76f38144f61c</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="217" Action="I" Record_ID="50038" Table="C_DocType">
+        <Data AD_Column_ID="89355" Column="IsBankTransfer">false</Data>
+        <Data AD_Column_ID="85653" Column="IsReversedWithOriginalAcct">false</Data>
+        <Data AD_Column_ID="1507" Column="Updated">2020-03-21 20:11:30.493</Data>
+        <Data AD_Column_ID="86860" Column="IsAllocateImmediate">false</Data>
+        <Data AD_Column_ID="1504" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3024" Column="DocBaseType">SOO</Data>
+        <Data AD_Column_ID="4428" Column="IsSOTrx">true</Data>
+        <Data AD_Column_ID="87473" Column="C_DocTypePayment_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1521" Column="IsDocNoControlled">true</Data>
+        <Data AD_Column_ID="1505" Column="Created">2020-03-21 20:11:30.493</Data>
+        <Data AD_Column_ID="15806" Column="IsIndexed">true</Data>
+        <Data AD_Column_ID="62601" Column="PrintDocument" isNewNull="true"/>
+        <Data AD_Column_ID="4204" Column="IsDefault">false</Data>
+        <Data AD_Column_ID="84052" Column="IsCopyDocNoOnReversal">false</Data>
+        <Data AD_Column_ID="3392" Column="DocSubTypeSO">IO</Data>
+        <Data AD_Column_ID="3023" Column="PrintName">Invoice Order</Data>
+        <Data AD_Column_ID="12417" Column="IsCreateCounter">true</Data>
+        <Data AD_Column_ID="54087" Column="IsOverwriteSeqOnComplete">false</Data>
+        <Data AD_Column_ID="54089" Column="IsOverwriteDateOnComplete">false</Data>
+        <Data AD_Column_ID="12075" Column="IsDefaultCounterDoc">false</Data>
+        <Data AD_Column_ID="1509" Column="Name">Invoice Order</Data>
+        <Data AD_Column_ID="1510" Column="Description">Invoice Order allows generate a invoice automatically after complete, the delivery is based on delivery rule from standar sales process</Data>
+        <Data AD_Column_ID="3697" Column="HasCharges">false</Data>
+        <Data AD_Column_ID="3025" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3913" Column="HasProforma">false</Data>
+        <Data AD_Column_ID="12080" Column="IsPickQAConfirm">false</Data>
+        <Data AD_Column_ID="54088" Column="DefiniteSequence_ID" isNewNull="true"/>
+        <Data AD_Column_ID="12112" Column="IsInTransit">false</Data>
+        <Data AD_Column_ID="12081" Column="IsShipConfirm">false</Data>
+        <Data AD_Column_ID="12405" Column="IsSplitWhenDifference">false</Data>
+        <Data AD_Column_ID="59148" Column="IsPrepareSplitDocument">true</Data>
+        <Data AD_Column_ID="1527" Column="GL_Category_ID">108</Data>
+        <Data AD_Column_ID="1501" Column="C_DocType_ID">50038</Data>
+        <Data AD_Column_ID="1503" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="1502" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="8761" Column="AD_PrintFormat_ID" isNewNull="true"/>
+        <Data AD_Column_ID="4205" Column="DocumentCopies">1</Data>
+        <Data AD_Column_ID="3915" Column="C_DocTypeShipment_ID">122</Data>
+        <Data AD_Column_ID="3914" Column="C_DocTypeProforma_ID" isNewNull="true"/>
+        <Data AD_Column_ID="1508" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="1522" Column="DocNoSequence_ID">55252</Data>
+        <Data AD_Column_ID="1506" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3916" Column="C_DocTypeInvoice_ID">116</Data>
+        <Data AD_Column_ID="12404" Column="C_DocTypeDifference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84652" Column="UUID">c69a77fd-b774-4b06-a85d-7b81d884b5c4</Data>
+        <Data AD_Column_ID="94551" Column="IsPayrollPayment">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="300" Action="I" Record_ID="50038" Table="C_DocType_Trl">
+        <Data AD_Column_ID="3130" Column="Created">2020-03-21 20:11:31.531</Data>
+        <Data AD_Column_ID="3132" Column="Updated">2020-03-21 20:11:31.531</Data>
+        <Data AD_Column_ID="3129" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3136" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="4322" Column="Name">Invoice Order</Data>
+        <Data AD_Column_ID="3134" Column="PrintName">Invoice Order</Data>
+        <Data AD_Column_ID="3135" Column="DocumentNote" isNewNull="true"/>
+        <Data AD_Column_ID="3128" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="3125" Column="C_DocType_ID">50038</Data>
+        <Data AD_Column_ID="3127" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="3126" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="3131" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3133" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84654" Column="UUID">94c534d7-41db-4ed8-846d-6a80f916da69</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Currently exists many Sub-Document Type for handle order:
- Standard = **SO**: Standard order for generate invoices and shipment
- Quotation = **OB**: Quotation (with reserve)
- Proposal = **ON**: Proposal (without reserve)
- Prepay = **PR**: Validate prepay before complete
- POS = **WR**: Generate Invoice and shipment after complete
- Warehouse = **WP**: Used for make a picking
- OnCredit = **WI**: Credit Order
- RMA = **RM**: Return Order Authorization

This pull request allows add a new Sub Document Base for Order **invoiced automatically** used for generate invoiced after complete order, is nice because you can generate invoice and collect it after complete.

The warehouse manager can get order for deliver it. This order is very usefull for Retail where is invoiced and collect a product for a POS but the deliver is make from other warehouse.

The follow is the value:
- Pre-Invoiced = **PI**
![Screenshot_20200301_132354](https://user-images.githubusercontent.com/2333092/75630352-89aebc80-5bc0-11ea-85f5-1380a351dc45.png)
