### PR TITLE
Fixed error with AND condition for replenish report

### DIFF
--- a/base/src/org/compiere/process/ReplenishReport.java
+++ b/base/src/org/compiere/process/ReplenishReport.java
@@ -696,7 +696,7 @@ public class ReplenishReport extends ReplenishReportAbstract {
 		//	For Standard Process
 		StringBuffer localWhere = new StringBuffer("AD_PInstance_ID=?");
 		if(!isMandatoryBusinessPartner) {
-			localWhere.append(" AND ").append(" AND C_BPartner_ID > 0");
+			localWhere.append(" AND ").append(" C_BPartner_ID > 0");
 		}
 		if (!Util.isEmpty(where)) {
 			localWhere.append(" AND ").append(where);


### PR DESCRIPTION
This pull request resolve a issue with a AND condition unnecessary for query of replenish report

Fixes: #2721 

![Replenish_Error](https://user-images.githubusercontent.com/2333092/76990938-25f5f480-691f-11ea-81d2-46c92dde1961.gif)


```SQL
or at or near "AND" Position: 312, SQL=SELECT QtyToOrder,C_DocType_ID,Updated,ReplenishType,QtyOnHand,Order_Pack,QtyReserved,QtyOrdered,ReplenishmentCreate,M_WarehouseSource_ID,Order_Min,Level_Min,Level_Max,AD_Org_ID,AD_Client_ID,AD_PInstance_ID,M_Warehouse_ID,M_Product_ID,UpdatedBy,UUID,C_BPartner_ID FROM T_Replenish WHERE (AD_PInstance_ID=? AND AND C_BPartner_ID > 0 AND M_WarehouseSource_ID IS NULL) ORDER BY M_Warehouse_ID, M_WarehouseSource_ID, C_BPartner_ID
```