### PR TITLE
Fixed error with not displayed browse key

### DIFF
--- a/base/src/org/spin/util/ASPUtil.java
+++ b/base/src/org/spin/util/ASPUtil.java
@@ -247,7 +247,7 @@ public class ASPUtil {
 		}
 		//	Filter
 		return fields.stream()
-			.filter(field -> field.isQueryCriteria())
+			.filter(field -> field.isActive() && field.isQueryCriteria())
 			.sorted(Comparator.comparing(MBrowseField::getSeqNoGrid))
 			.collect(Collectors.toList());
 	}
@@ -264,7 +264,7 @@ public class ASPUtil {
 		}
 		//	Filter
 		return fields.stream()
-			.filter(field -> field.isIdentifier())
+			.filter(field -> field.isActive() && field.isIdentifier())
 			.sorted(Comparator.comparing(MBrowseField::getSeqNo))
 			.collect(Collectors.toList());
 	}
@@ -281,7 +281,7 @@ public class ASPUtil {
 		}
 		//	Filter
 		return fields.stream()
-			.filter(field -> field.isOrderBy() && field.isDisplayed())
+			.filter(field -> field.isActive() && field.isOrderBy() && field.isDisplayed())
 			.sorted(Comparator.comparing(MBrowseField::getSeqNo))
 			.collect(Collectors.toList());
 	}
@@ -298,7 +298,7 @@ public class ASPUtil {
 		}
 		//	Filter
 		return fields.stream()
-			.filter(field -> field.isDisplayed() || field.isIdentifier())
+			.filter(field -> field.isActive() && field.isDisplayed() || field.isIdentifier())
 			.sorted(Comparator.comparing(MBrowseField::getSeqNo))
 			.collect(Collectors.toList());
 	}
@@ -315,7 +315,7 @@ public class ASPUtil {
 		}
 		//	Filter
 		return fields.stream()
-			.filter(field -> field.isKey())
+			.filter(field -> field.isActive() && field.isKey())
 			.sorted(Comparator.comparing(MBrowseField::getSeqNo))
 			.findFirst()
 			.get();

--- a/migration/393lts-394lts/05600_Fixed_error_with_browse_key.xml
+++ b/migration/393lts-394lts/05600_Fixed_error_with_browse_key.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Fixed error with browse key" ReleaseNo="3.9.4" SeqNo="5600">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="106" Action="U" Record_ID="53247" Table="AD_Tab">
+        <Data AD_Column_ID="2741" Column="WhereClause" oldValue="(IsDisplayed='Y' OR IsQueryCriteria='Y' OR IsIdentifier = 'Y')">(IsDisplayed='Y' OR IsQueryCriteria='Y' OR IsIdentifier = 'Y' OR IsKey = 'Y')</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="106" Action="U" Record_ID="54763" Table="AD_Tab">
+        <Data AD_Column_ID="2741" Column="WhereClause" oldValue="(IsDisplayed='Y' OR IsQueryCriteria='Y' OR IsIdentifier = 'Y')">(IsDisplayed='Y' OR IsQueryCriteria='Y' OR IsIdentifier = 'Y' OR IsKey = 'Y')</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
The problem: currently if a browse field is hidden and is flagged as **IsKey** should be showed like all fields flagged as **IsQuery**, **IsDisplayed** or **IsIdentifier**. This problem cause that if a field flagged as **IsKey** and **IsDisplayed** is set to IsDisplayed = false the result is a key that is not exist a way for see if the browser have more than one key.

I just change the browse field condition from:
```SQL
(IsDisplayed='Y' OR IsQueryCriteria='Y' OR IsIdentifier = 'Y')
```
To
```SQL
(IsDisplayed='Y' OR IsQueryCriteria='Y' OR IsIdentifier = 'Y' OR IsKey = 'Y')
```
Also add a validation for isActive for ASPUtil class