### PR TITLE
Fixed error with commission group for commission run

### DIFF
--- a/base/src/org/compiere/model/MCommissionGroup.java
+++ b/base/src/org/compiere/model/MCommissionGroup.java
@@ -68,6 +68,7 @@ public class MCommissionGroup extends X_C_CommissionGroup {
 		List<MCommission> list = new Query(getCtx(), I_C_Commission.Table_Name, whereClauseFinal, get_TrxName())
 										.setParameters(getC_CommissionGroup_ID())
 										.setOrderBy(I_C_Commission.COLUMNNAME_C_BPartner_ID)
+										.setOnlyActiveRecords(true)
 										.list();
 		return list;
 	}

--- a/base/src/org/compiere/model/MCommissionRun.java
+++ b/base/src/org/compiere/model/MCommissionRun.java
@@ -264,7 +264,7 @@ public class MCommissionRun extends X_C_CommissionRun implements DocAction, DocO
 			}
 		} else if(getC_CommissionGroup_ID() != 0) {
 			MCommissionGroup group = new MCommissionGroup(getCtx(), getC_CommissionGroup_ID(), get_TrxName());
-			commissionList = group.getLines(MCommissionGroup.COLUMNNAME_IsActive + "Y");
+			commissionList = group.getLines(null);
 			frequencyType = group.getFrequencyType();
 		}
 		


### PR DESCRIPTION
Step by Step:
- Create a Commission Group
- Create (N) commission definition fromCommission group
- Create a commission Run
- Select previous commission group selected
- Run Document action to prepare

This pull request resolve a error when I try process a commission run based on commission group instead commission, the error is:

```SQL
===========> Query.list: SELECT Name,Processing,IsDaysDueFromPaymentTerm,Updated,Created,IsTotallyPaid,IsActive,IsAllowRMA,FrequencyType,CreateFrom,DateLastRun,Description,ListDetails,DocBasisType,C_CommissionGroup_ID,AD_Org_ID,C_Commission_ID,AD_Client_ID,C_BPartner_ID,C_Currency_ID,CreatedBy,UpdatedBy,C_Charge_ID,UUID,C_CommissionType_ID FROM C_Commission WHERE (C_CommissionGroup_ID=? IsActiveY) ORDER BY C_BPartner_ID [63]
org.postgresql.util.PSQLException: ERROR: syntax error at or near "IsActiveY"
  Position: 367; State=42601; ErrorCode=0
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2497)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2233)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:310)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:446)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:370)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:149)
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:108)
	at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeQuery(NewProxyPreparedStatement.java:76)
	at sun.reflect.GeneratedMethodAccessor7.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
	at com.sun.proxy.$Proxy2.executeQuery(Unknown Source)
	at org.compiere.model.Query.createResultSet(Query.java:780)
	at org.compiere.model.Query.list(Query.java:274)
	at org.compiere.model.Query.list(Query.java:255)
	at org.compiere.model.MCommissionGroup.getLines(MCommissionGroup.java:71)
	at org.compiere.model.MCommissionRun.createMovements(MCommissionRun.java:267)
	at org.compiere.model.MCommissionRun.prepareIt(MCommissionRun.java:219)
	at org.compiere.process.DocumentEngine.prepareIt(DocumentEngine.java:411)
	at org.compiere.process.DocumentEngine.processIt(DocumentEngine.java:280)
	at org.compiere.process.DocumentEngine.processIt(DocumentEngine.java:258)
	at org.compiere.model.MCommissionRun.processIt(MCommissionRun.java:164)
	at org.compiere.wf.MWFActivity.performWork(MWFActivity.java:904)
	at org.compiere.wf.MWFActivity.run(MWFActivity.java:794)
	at org.compiere.wf.MWFProcess.startNext(MWFProcess.java:370)
	at org.compiere.wf.MWFProcess.checkActivities(MWFProcess.java:280)
	at org.compiere.wf.MWFActivity.setWFState(MWFActivity.java:280)
	at org.compiere.wf.MWFActivity.run(MWFActivity.java:811)
	at org.compiere.wf.MWFProcess.startWork(MWFProcess.java:502)
	at org.compiere.wf.MWorkflow.start(MWorkflow.java:727)
	at org.compiere.wf.MWorkflow.startWait(MWorkflow.java:796)
```