### PR TITLE
Fixed error with StackOverFlow for MColumn

### DIFF
--- a/base/src/org/compiere/model/MColumn.java
+++ b/base/src/org/compiere/model/MColumn.java
@@ -329,25 +329,23 @@ public class MColumn extends X_AD_Column
 	{
 		//set column default based in element when is a new column FR [ 3426134 ]
 		if(newRecord) {
-			setAD_Column(getCtx(), this, get_TrxName());
-			//Create Document No or Value sequence
-			if (!isDirectLoad() && "DocumentNo".equals(getColumnName()) || !isDirectLoad() && "Value".equals(getColumnName()))
-			{
-				String tableName = MTable.getTableName(getCtx(), getAD_Table_ID());
-				final String whereClause = MSequence.COLUMNNAME_AD_Client_ID + "=? AND " + MSequence.COLUMNNAME_Name + "=? ";
-				//	Sequence for DocumentNo/Value
-				Arrays.stream(MClient.getAll(getCtx())).forEach( client -> {
-					MSequence sequence = new Query(getCtx(), MSequence.Table_Name, whereClause, get_TrxName())
-							.setParameters(client.getAD_Client_ID() , MSequence.PREFIX_DOCSEQ + tableName )
-							.first();
-					if (sequence == null || sequence.getAD_Sequence_ID() <= 0) {
-						sequence = new MSequence(getCtx(), client.getAD_Client_ID(), tableName , get_TrxName());
-						sequence.saveEx();
-					}
-				});
-			}
-			//	For Is Allow Copy
 			if(!isDirectLoad()) {
+				setAD_Column(getCtx(), this, get_TrxName());
+				//Create Document No or Value sequence
+				if ("DocumentNo".equals(getColumnName()) || !isDirectLoad() && "Value".equals(getColumnName())) {
+					String tableName = MTable.getTableName(getCtx(), getAD_Table_ID());
+					final String whereClause = MSequence.COLUMNNAME_AD_Client_ID + "=? AND " + MSequence.COLUMNNAME_Name + "=? ";
+					//	Sequence for DocumentNo/Value
+					Arrays.stream(MClient.getAll(getCtx())).forEach( client -> {
+						MSequence sequence = new Query(getCtx(), MSequence.Table_Name, whereClause, get_TrxName())
+								.setParameters(client.getAD_Client_ID() , MSequence.PREFIX_DOCSEQ + tableName )
+								.first();
+						if (sequence == null || sequence.getAD_Sequence_ID() <= 0) {
+							sequence = new MSequence(getCtx(), client.getAD_Client_ID(), tableName , get_TrxName());
+							sequence.saveEx();
+						}
+					});
+				}
 				setIsAllowCopy(MColumn.isAllowCopy(getColumnName(), getAD_Reference_ID()));
 			}
 		}


### PR DESCRIPTION
This pull request resolve a problem with StackOverFlow when a column is inserted from XML Migration.

The problem is that by default the column attributes is created from element definition, if a column is created as new and the element is defined like Search in reference the reference value on column is setted from element and it generate a recursive search for reference.