### PR TITLE
Fixed error with default value when a field is Date instead Date + Time

### DIFF
--- a/base/src/org/compiere/model/GridField.java
+++ b/base/src/org/compiere/model/GridField.java
@@ -43,6 +43,7 @@ import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Evaluatee;
 import org.compiere.util.Evaluator;
+import org.compiere.util.TimeUtil;
 import org.spin.util.ASPUtil;
 
 /**
@@ -811,6 +812,10 @@ public class GridField
 				} catch (java.text.ParseException e) {
 					date = DisplayType.getDateFormat_JDBC().parse (value);
 				}
+				if(DisplayType.Date == m_vo.displayType) {
+					return TimeUtil.getDay(date.getTime());
+				}
+				//	Default
 				return new Timestamp (date.getTime());
 			}
 			


### PR DESCRIPTION
when a Smart Browse have a default value for Date Field, the default value is taked as **Date + Time** instead **Date**.

A simple example:
For Bank Statement Closing of POS the filter is based on **DateTrx (Date)** the current behavior is that all date fields are **2020-03-20 00:00:00**.

When default value is loaded on gridfield have time also, then the value for **DateTrx (Date)** is **2020-03-20 23:13:00** and **DateTrx_To (Date)** is **2020-03-20 23:13:00** instead **2020-03-20 00:00:00** and filter is:
```SQL
DateTrx (**2020-03-20 00:00:00**) BETWEEN '2020-03-20 23:13:00' AND '2020-03-20 23:13:00'
```

Here some more graphic before change:
![Grid-Fixed-Error-with-Default-Value-for-Date-Before](https://user-images.githubusercontent.com/2333092/77218403-5ac1a180-6b01-11ea-8fc5-044a8931abc8.gif)
After change:
![Grid-Fixed-Error-with-Default-Value-for-Date-After](https://user-images.githubusercontent.com/2333092/77218405-601eec00-6b01-11ea-8d85-ee42b26c5cc1.gif)
