### PR TITLE
Allows a payment reference with payment amount as Zero

### DIFF
--- a/base/src/org/compiere/model/MBankStatementLine.java
+++ b/base/src/org/compiere/model/MBankStatementLine.java
@@ -248,7 +248,6 @@ import org.compiere.util.Msg;
 		// Un-link Payment if TrxAmt is zero - teo_sarca BF [ 1896880 ] 
 		if (getTrxAmt().signum() == 0 && getC_Payment_ID() > 0)
 		{
-			setC_Payment_ID(I_ZERO);
 			setC_Invoice_ID(I_ZERO);
 		}
 		//	Set Line No


### PR DESCRIPTION
Currently if a payment is with 0 amount and is added to bank statement line the reference is removed, this pull request allow keep reference with payment