### PR TITLE
Fixed error with axis column for Smart Browser

### DIFF
--- a/client/src/org/eevolution/grid/Browser.java
+++ b/client/src/org/eevolution/grid/Browser.java
@@ -60,6 +60,7 @@ import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Language;
 import org.compiere.util.Msg;
+import org.compiere.util.Util;
 import org.compiere.util.ValueNamePair;
 import org.spin.util.ASPUtil;
 
@@ -1168,9 +1169,14 @@ public abstract class Browser {
 			int cols = 0;
 
 			StringBuilder axisSql = new StringBuilder("(SELECT ");
+			String cummulativeColumnName = ycol.getColumnSQL();
+			if(Util.isEmpty(cummulativeColumnName)) {
+				cummulativeColumnName = ycol.getAD_Column().getColumnName();
+			}
+			//	Replace alias
+			cummulativeColumnName = cummulativeColumnName.replaceAll(ycol.getAD_View_Definition().getTableAlias(), ycol.getAD_View_Definition().getAD_Table().getTableName());
 			axisSql.append("SUM(")
-					.append(ycol.getAD_Column()
-							.getColumnName())
+					.append(cummulativeColumnName)
 					.append(") FROM  ")
 					.append(ycol.getAD_View_Definition().getAD_Table().getTableName())
 					.append(" WHERE ")


### PR DESCRIPTION
This problem just sucess with axis columns for Smart Browse, the problem is that axis column does not search by **ColumnSQL** or **ColumnName**, only search by **ColumnName**, see a definition:
Note that exist a **Column SQL** value
![Reason](https://user-images.githubusercontent.com/2333092/77235616-e1bc5b80-6b8d-11ea-9bcf-0ac245598d17.png)

The result before change:
![Bad](https://user-images.githubusercontent.com/2333092/77235629-fac50c80-6b8d-11ea-877d-01377db7e65c.png)

The result after change:
![Good](https://user-images.githubusercontent.com/2333092/77235634-07e1fb80-6b8e-11ea-9ffb-adf1dc3de563.png)
