### PR TITLE
Add cash closing correct values

### DIFF
--- a/migration/393lts-394lts/05790_Fixes_error_with_POS_Cash_Closing.xml
+++ b/migration/393lts-394lts/05790_Fixes_error_with_POS_Cash_Closing.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Fixes error with POS Cash Closing" ReleaseNo="3.9.4" SeqNo="5790">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="53224" Action="U" Record_ID="50057" Table="AD_Browse">
+        <Data AD_Column_ID="58000" Column="WhereClause" oldValue="pay.DocStatus IN ('CO','CL') AND bs.DocStatus NOT IN('CO', 'CL')">pay.DocStatus IN ('CO','CL') AND bs.DocStatus NOT IN('CO', 'CL','VO')</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55475" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57976" Column="IsDisplayed" oldValue="false">true</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="0">60</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55518" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="60">70</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55579" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="70">80</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55439" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57976" Column="IsDisplayed" oldValue="false">true</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="0">70</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55518" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="70">80</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55579" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="80">90</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="285" Action="U" Record_ID="55461" Table="AD_Process_Para">
+        <Data AD_Column_ID="3739" Column="DefaultValue" oldValue="@SQL= SELECT SUM(o.GrandTotal)  FROM C_Order o   WHERE o.C_POS_ID = @C_POS_ID@  AND o.DateOrdered BETWEEN TO_DATE('@DateTrx@','YYYY-MM-DD') AND TO_DATE('@DateTrx_To@','YYYY-MM-DD')   AND o.DocStatus IN ('CO','CL')  AND EXISTS(SELECT 1 FROM C_BankStatement st          INNER JOIN C_BankStatementLine stl ON(stl.C_BankStatement_ID = st.C_BankStatement_ID)          INNER JOIN C_Payment p ON(p.C_Payment_ID = stl.C_Payment_ID)         WHERE st.C_BankAccount_ID=@C_BankAccount_ID@          AND st.DocStatus NOT IN('CO', 'CL')          AND p.C_Order_ID = o.C_Order_ID)">@SQL= SELECT SUM(o.GrandTotal * (CASE WHEN dt.DocSubTypeSO = 'RM' THEN -1 ELSE 1 END))  FROM C_Order o  INNER JOIN C_DocType dt ON(dt.C_DocType_ID = o.C_DocType_ID) WHERE o.C_POS_ID = @C_POS_ID@  AND o.DateOrdered BETWEEN TO_DATE('@DateTrx@','YYYY-MM-DD') AND TO_DATE('@DateTrx_To@','YYYY-MM-DD')  AND o.DocStatus IN ('CO','CL')  AND EXISTS(SELECT 1 FROM C_BankStatement st                  INNER JOIN C_BankStatementLine stl ON(stl.C_BankStatement_ID = st.C_BankStatement_ID)                  INNER JOIN C_Payment p ON(p.C_Payment_ID = stl.C_Payment_ID)                  WHERE st.C_BankAccount_ID=@C_BankAccount_ID@                  AND st.DocStatus IN('DR', 'IP')                  AND p.C_Order_ID = o.C_Order_ID)</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="90" StepType="AD">
+      <PO AD_Table_ID="285" Action="U" Record_ID="55462" Table="AD_Process_Para">
+        <Data AD_Column_ID="3739" Column="DefaultValue" oldValue="@SQL=SELECT COALESCE(SUM(currencyconvert( p.PayAmt * (CASE WHEN p.IsReceipt = 'Y' THEN 1 ELSE -1 END), p.C_Currency_ID,ba.C_Currency_ID,p.DateAcct,pos.C_ConversionType_ID, p.AD_Client_ID, p.AD_Org_ID)),0) as PayAmt FROM C_Payment p LEFT JOIN C_Pos pos ON (p.C_POS_ID = pos.C_POS_ID) INNER JOIN C_BankAccount ba ON (ba.C_BankAccount_ID = pos.C_BankAccount_ID) WHERE p.C_POS_ID = @C_POS_ID@  and p.C_POS_ID=pos.C_POS_ID AND p.DateTrx  BETWEEN TO_DATE('@DateTrx@','YYYY-MM-DD') AND TO_DATE('@DateTrx_To@','YYYY-MM-DD') AND p.DocStatus IN ('CO','CL') AND EXISTS(SELECT 1 FROM C_BankStatement st INNER JOIN C_BankStatementLine stl ON(stl.C_BankStatement_ID = st.C_BankStatement_ID) WHERE st.C_BankAccount_ID=@C_BankAccount_ID@ and st.DocStatus NOT IN('CO', 'CL') AND stl.C_Payment_ID = p.C_Payment_ID) AND  p.C_Order_ID is not null">@SQL= SELECT COALESCE(SUM(currencyconvert(p.PayAmt * (CASE WHEN p.IsReceipt = 'Y' THEN 1 ELSE -1 END), p.C_Currency_ID, ba.C_Currency_ID, p.DateAcct, p.C_ConversionType_ID, p.AD_Client_ID, p.AD_Org_ID)), 0) AS PayAmt  FROM C_Payment p  INNER JOIN C_BankAccount ba ON(ba.C_BankAccount_ID = p.C_BankAccount_ID)  WHERE p.C_POS_ID = @C_POS_ID@  AND p.DateTrx BETWEEN TO_DATE('@DateTrx@','YYYY-MM-DD') AND TO_DATE('@DateTrx_To@','YYYY-MM-DD')  AND p.DocStatus IN ('CO','CL')  AND p.C_BankAccount_ID=@C_BankAccount_ID@ AND EXISTS(SELECT 1 FROM C_BankStatement st                  INNER JOIN C_BankStatementLine stl ON(stl.C_BankStatement_ID = st.C_BankStatement_ID)                  WHERE st.C_BankAccount_ID = p.C_BankAccount_ID                 AND st.DocStatus IN('DR', 'IP')                  AND stl.C_Payment_ID = p.C_Payment_ID)  AND p.C_Order_ID IS NOT NULL</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="100" StepType="AD">
+      <PO AD_Table_ID="285" Action="U" Record_ID="55463" Table="AD_Process_Para">
+        <Data AD_Column_ID="3739" Column="DefaultValue" oldValue="@SQL=Select SUM(o.Grandtotal) - COALESCE(SUM(currencyconvert( p.PayAmt * (CASE WHEN p.IsReceipt = 'Y' THEN 1 ELSE -1 END), p.C_Currency_ID,ba.C_Currency_ID,p.DateAcct,pos.C_ConversionType_ID, p.AD_Client_ID, p.AD_Org_ID)),0) FROM C_Payment p  LEFT JOIN C_Pos pos ON (p.C_POS_ID = pos.C_POS_ID) INNER JOIN C_Order o ON (p.C_Order_ID = o.C_Order_ID) INNER JOIN C_BankAccount ba ON (ba.C_BankAccount_ID = pos.C_BankAccount_ID)  WHERE p.C_POS_ID = @C_POS_ID@  and p.C_POS_ID=pos.C_POS_ID  AND p.DateTrx  BETWEEN TO_DATE('@DateTrx@','YYYY-MM-DD') AND TO_DATE('@DateTrx_To@','YYYY-MM-DD')  AND p.DocStatus IN ('CO','CL')  AND EXISTS(SELECT 1 FROM C_BankStatement st INNER JOIN C_BankStatementLine stl ON(stl.C_BankStatement_ID = st.C_BankStatement_ID) WHERE st.C_BankAccount_ID=@C_BankAccount_ID@ and st.DocStatus NOT IN('CO', 'CL') AND stl.C_Payment_ID = p.C_Payment_ID)  AND  p.C_Order_ID is not null">@SQL= SELECT SUM(o.GrandTotal * (CASE WHEN dt.DocSubTypeSO = 'RM' THEN -1 ELSE 1 END)) - COALESCE(SUM(pa.PayAmt), 0) AS OpenAmt FROM C_Order o  INNER JOIN C_DocType dt ON(dt.C_DocType_ID = o.C_DocType_ID) LEFT JOIN (         SELECT p.C_Order_ID, COALESCE(SUM(currencyconvert(p.PayAmt * (CASE WHEN p.IsReceipt = 'Y' THEN 1 ELSE -1 END), p.C_Currency_ID, ba.C_Currency_ID, p.DateAcct, p.C_ConversionType_ID, p.AD_Client_ID, p.AD_Org_ID)), 0) AS PayAmt          FROM C_Payment p          INNER JOIN C_BankAccount ba ON(ba.C_BankAccount_ID = p.C_BankAccount_ID)          WHERE p.C_POS_ID = @C_POS_ID@          AND p.DocStatus IN ('CO','CL')  GROUP BY p.C_Order_ID) pa ON(pa.C_Order_ID = o.C_Order_ID) WHERE o.C_POS_ID = @C_POS_ID@  AND o.DateOrdered BETWEEN TO_DATE('@DateTrx@','YYYY-MM-DD') AND TO_DATE('@DateTrx_To@','YYYY-MM-DD')  AND o.DocStatus IN ('CO','CL') AND o.PaymentRule = 'P'</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="110" StepType="AD">
+      <PO AD_Table_ID="285" Action="U" Record_ID="55464" Table="AD_Process_Para">
+        <Data AD_Column_ID="3739" Column="DefaultValue" oldValue="@SQL=SELECT COALESCE(SUM(currencyconvert( p.PayAmt * (CASE WHEN p.IsReceipt = 'Y' THEN 1 ELSE -1 END), p.C_Currency_ID,ba.C_Currency_ID,p.DateAcct,pos.C_ConversionType_ID, p.AD_Client_ID, p.AD_Org_ID)),0)  FROM C_Payment p INNER JOIN C_BankStatementLine bsl ON (p.C_Payment_ID = bsl.C_Payment_ID)  INNER JOIN C_BankStatement bs ON (bsl.C_BankStatement_ID=bs.C_BankStatement_ID) LEFT JOIN C_Pos pos ON (p.C_POS_ID = pos.C_POS_ID)  INNER JOIN C_BankAccount ba ON (ba.C_BankAccount_ID = pos.C_BankAccount_ID)  WHERE p.C_POS_ID = @C_POS_ID@  AND p.DateTrx BETWEEN TO_DATE('@DateTrx@','YYYY-MM-DD') AND TO_DATE('@DateTrx_To@','YYYY-MM-DD')  AND EXISTS(SELECT 1 FROM C_BankStatement st INNER JOIN C_BankStatementLine stl ON(stl.C_BankStatement_ID = st.C_BankStatement_ID) WHERE st.C_BankAccount_ID = @C_BankAccount_ID@ and st.DocStatus NOT IN('CO', 'CL') AND stl.C_Payment_ID = p.C_Payment_ID) ">@SQL= SELECT SUM(o.GrandTotal * (CASE WHEN dt.DocSubTypeSO = 'RM' THEN -1 ELSE 1 END)) - COALESCE(SUM(pa.PayAmt), 0) AS OpenAmt FROM C_Order o  INNER JOIN C_DocType dt ON(dt.C_DocType_ID = o.C_DocType_ID) LEFT JOIN (         SELECT p.C_Order_ID, COALESCE(SUM(currencyconvert(p.PayAmt * (CASE WHEN p.IsReceipt = 'Y' THEN 1 ELSE -1 END), p.C_Currency_ID, ba.C_Currency_ID, p.DateAcct, p.C_ConversionType_ID, p.AD_Client_ID, p.AD_Org_ID)), 0) AS PayAmt          FROM C_Payment p          INNER JOIN C_BankAccount ba ON(ba.C_BankAccount_ID = p.C_BankAccount_ID)          WHERE p.C_POS_ID = @C_POS_ID@          AND p.DocStatus IN ('CO','CL')  GROUP BY p.C_Order_ID) pa ON(pa.C_Order_ID = o.C_Order_ID) WHERE o.C_POS_ID = @C_POS_ID@  AND o.DateOrdered BETWEEN TO_DATE('@DateTrx@','YYYY-MM-DD') AND TO_DATE('@DateTrx_To@','YYYY-MM-DD')  AND o.DocStatus IN ('CO','CL')</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="120" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55448" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64222" Column="IsOrderBy" oldValue="false">true</Data>
+        <Data AD_Column_ID="64221" Column="SortNo" oldValue="0">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="130" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55502" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64222" Column="IsOrderBy" oldValue="false">true</Data>
+        <Data AD_Column_ID="64221" Column="SortNo" oldValue="0">20</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="140" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55518" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64221" Column="SortNo" oldValue="10">30</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="150" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55447" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57976" Column="IsDisplayed" oldValue="false">true</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="0">80</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="160" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55518" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="80">90</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="170" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55579" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="90">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="180" StepType="AD">
+      <PO AD_Table_ID="53232" Action="U" Record_ID="54113" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="pay.PayAmt">pay.PayAmt * (CASE WHEN pay.IsReceipt = 'Y' THEN 1 ELSE -1 END)</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
The problem:
The cash closing for POS is very useful, however, exists many problem with amounts from Smart Browser rows and process parameters values, see before change:
![Before](https://user-images.githubusercontent.com/2333092/77451977-c343a380-6dcb-11ea-83b7-f01981fd2d90.png)
Note that now is same values from query and parameters:
![After](https://user-images.githubusercontent.com/2333092/77452044-d787a080-6dcb-11ea-94d4-64d8ff2a6879.png)

Please this pull request have multi-currency related to #3071 pull request, should see first #3071

Best regard
