### PR TITLE
Add support to FileName or path for Migration Loader and change log

### DIFF
--- a/base/src/org/adempiere/process/ApplyMigrationScripts.java
+++ b/base/src/org/adempiere/process/ApplyMigrationScripts.java
@@ -65,7 +65,6 @@ public class ApplyMigrationScripts extends SvrProcess {
 				if (tmpSql.length() > 0) {
 					log.info("Executing script " + rs.getString(3));
 					execOk = executeScript(tmpSql.toString(), rs.getString(3));
-					System.out.println();
 				}
 			} catch (SQLException e) {
 				execOk = false;

--- a/base/src/org/adempiere/process/MigrationLoader.java
+++ b/base/src/org/adempiere/process/MigrationLoader.java
@@ -1,11 +1,32 @@
+/*************************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
 package org.adempiere.process;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Level;
 
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.Adempiere;
+import org.compiere.model.I_AD_Client;
+import org.compiere.model.MClient;
+import org.compiere.model.Query;
 import org.compiere.process.MigrationFromXML;
 import org.compiere.process.ProcessInfo;
 import org.compiere.process.SynchronizeTerminology;
@@ -22,34 +43,29 @@ public class MigrationLoader {
 	/**	Logger	*/
 	private static CLogger	log	= CLogger.getCLogger (MigrationLoader.class);
 	
-
 	public static void main(String[] args) {
 		
-		boolean clean_arg = false;
-		boolean force_arg = false;
+		boolean isClean = false;
+		boolean isForce = false;
 		// If called with the argument "clean", the loader will apply any
 		// outstanding migrations, mark ALL applied dictionary migrations as processed
 		// and delete all the steps and data to save space.
 		//	Get Parameters
-		if(args != null) {
-			for(String arg : args) {
-				if(Util.isEmpty(arg)) {
-					continue;
-				}
-				//	
-				if(arg.equals("clean")) {
-					clean_arg = true;
-				} else if(arg.equals("force")) {
-					force_arg = true;
-				}
- 			}
+		List<String> arguments = Arrays.asList(args);
+		isClean = arguments.stream().filter(arg -> !Util.isEmpty(arg) && arg.matches(".*[/\n\r\t\0\f`?*\\<>|\":].*") && arg.equals("clean")).findFirst().isPresent();
+		isForce = arguments.stream().filter(arg -> !Util.isEmpty(arg) && arg.matches(".*[/\n\r\t\0\f`?*\\<>|\":].*") && arg.equals("force")).findFirst().isPresent();
+		//	Get path
+		Optional<String> optionalPath = arguments.stream().filter(arg -> !Util.isEmpty(arg) && !arg.equals("force") && !arg.equals("clean")).findFirst();
+		String fileName = null;
+		if(optionalPath.isPresent()
+				&& new File(optionalPath.get()).exists()) {
+			fileName = optionalPath.get();
 		}
-		
 		Adempiere.startupEnvironment(false);
-		CLogMgt.setLevel(Level.CONFIG);
+		CLogMgt.setLevel(Level.INFO);
 		
 		if (! DB.isConnected()) {
-			log.info("No DB Connection");
+			log.warning("No DB Connection");
 			System.exit(1);
 		}
 		
@@ -59,15 +75,15 @@ public class MigrationLoader {
 		
 		// Parameter values - these need to be final or effectively final
 		// Load migrations from the default location
-		String fileName = Adempiere.getAdempiereHome() + File.separator + "migration";
+		if(Util.isEmpty(fileName)) {
+			fileName = Adempiere.getAdempiereHome() + File.separator + "migration";
+		}
 		boolean apply = true;
 		boolean failOnError = true;
-		boolean clean = clean_arg;
 
 		Properties context = Env.getCtx();
 
 		try {
-			//Import Migration from XML
 			ProcessInfo processInfo = ProcessBuilder.create(context)
 			.process(org.compiere.process.MigrationFromXML.class)
 			.withTitle("Import Migration from XML")
@@ -75,11 +91,11 @@ public class MigrationLoader {
 			.withParameter(MigrationFromXML.FILEPATHORNAME, fileName) // Old parameter name
 			.withParameter(MigrationFromXML.FILENAME, fileName)  // New parameter name
 			.withParameter(MigrationFromXML.APPLY, apply)
-			.withParameter(MigrationFromXML.ISFORCE, force_arg)
-			.withParameter("Clean", clean)
+			.withParameter(MigrationFromXML.ISFORCE, isForce)
+			.withParameter("Clean", isClean)
 			.execute();
 
-			log.log(Level.CONFIG, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
+			log.log(Level.INFO, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
 			if (failOnError && processInfo.isError())
 				throw new AdempiereException(processInfo.getSummary());
 
@@ -87,7 +103,7 @@ public class MigrationLoader {
 					.process(org.compiere.process.SequenceCheck.class)
 					.withTitle("Sequence Check")
 					.execute();
-			log.log(Level.CONFIG, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
+			log.log(Level.INFO, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
 
 			processInfo = ProcessBuilder.create(context)
 					.process(org.compiere.process.SynchronizeTerminology.class)
@@ -95,20 +111,26 @@ public class MigrationLoader {
 					.withParameter(SynchronizeTerminology.ISCREATEELEMENT,false)
 					.withParameter(SynchronizeTerminology.ISDELETINGUNUSEDELEMENT, false)
 					.execute();
-			log.log(Level.CONFIG, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
-
-			processInfo = ProcessBuilder.create(context)
-					.process(org.compiere.process.RoleAccessUpdate.class)
-					.withTitle("Role Access Update")
-					.withParameter("AD_Client_ID", 0)
-					.executeUsingSystemRole();
-			log.log(Level.CONFIG, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
-
+			log.log(Level.INFO, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
+			
+			//	Role Access Update
+			new Query(context, I_AD_Client.Table_Name, null, null)
+			.setOrderBy(I_AD_Client.COLUMNNAME_AD_Client_ID)
+			.<MClient>list()
+			.forEach(client-> {
+				ProcessInfo processInfoRoleAccessUpdate = ProcessBuilder.create(context)
+						.process(org.compiere.process.RoleAccessUpdate.class)
+						.withTitle("Role Access Update")
+						.withParameter("AD_Client_ID", client.getAD_Client_ID())
+						.executeUsingSystemRole();
+				log.log(Level.INFO, "Process=" + processInfoRoleAccessUpdate.getTitle() + " Client=(" + client.getValue() + " - " + client.getName() + ") Error="+processInfoRoleAccessUpdate.isError() + " Summary=" + processInfoRoleAccessUpdate.getSummary());
+			});
+			//	
 			processInfo = ProcessBuilder.create(context)
 					.process(org.compiere.process.GardenWorldCleanUp.class)
 					.withTitle("Updating Garden World")
 					.executeUsingSystemRole();
-			log.log(Level.CONFIG, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
+			log.log(Level.INFO, "Process=" + processInfo.getTitle() + " Error="+processInfo.isError() + " Summary=" + processInfo.getSummary());
 		} catch (AdempiereException e) {
 			e.printStackTrace();
 			System.exit(1);

--- a/utils/RUN_MigrateXML.bat
+++ b/utils/RUN_MigrateXML.bat
@@ -17,6 +17,7 @@ REM Can be called with argument "clean" to mark the applied dictionary migration
 REM and delete the steps and data to reduce the database size.
 SET cleanMode=%1
 SET forceMode=%2
+SET migrationPath=%3
 
 REM change to directory in which this script resides
 SET DIR_SAV=%CD%
@@ -81,7 +82,7 @@ PAUSE
 Set JAVA=%JAVA_HOME%\bin\java
 SET CP=%ADEMPIERE_HOME%\lib\CInstall.jar;%ADEMPIERE_HOME%\lib\Adempiere.jar;%ADEMPIERE_HOME%\lib\CCTools.jar;%ADEMPIERE_HOME%\lib\oracle.jar;%ADEMPIERE_HOME%\lib\jboss.jar;%ADEMPIERE_HOME%\lib\postgresql.jar;
 
-"%JAVA%" -classpath %CP% -DADEMPIERE_HOME=%ADEMPIERE_HOME% org.adempiere.process.MigrationLoader %cleanMode% %forceMode%
+"%JAVA%" -classpath %CP% -DADEMPIERE_HOME=%ADEMPIERE_HOME% org.adempiere.process.MigrationLoader %cleanMode% %forceMode% %migrationPath%
 SET result=%ERRORLEVEL% 
 
 IF NOT %result%==%errorSuccess% GOTO :SANE

--- a/utils/RUN_MigrateXML.sh
+++ b/utils/RUN_MigrateXML.sh
@@ -21,6 +21,7 @@ echo
 # and delete the steps and data to reduce the database size.
 CLEAN_MODE=$1
 FORCE_MODE=$2
+MIGRATION_PATH=$3
 
 # change to directory in which this script resides
 DIR_SAV=$(pwd)
@@ -69,7 +70,7 @@ then
 	CP=$ADEMPIERE_HOME/lib/CInstall.jar:$ADEMPIERE_HOME/lib/Adempiere.jar:$ADEMPIERE_HOME/lib/CCTools.jar:$ADEMPIERE_HOME/lib/oracle.jar:$ADEMPIERE_HOME/lib/jboss.jar:$ADEMPIERE_HOME/lib/postgresql.jar:
 	JAVA=$JAVA_HOME/bin/java
 
-	$JAVA -classpath $CP -DADEMPIERE_HOME=$ADEMPIERE_HOME org.adempiere.process.MigrationLoader $CLEAN_MODE $FORCE_MODE
+	$JAVA -classpath $CP -DADEMPIERE_HOME=$ADEMPIERE_HOME org.adempiere.process.MigrationLoader $CLEAN_MODE $FORCE_MODE $MIGRATION_PATH
 	result=$? 
 		
 else


### PR DESCRIPTION
This pull request allows define a new parameter for custom migration path, for now exists the follow parameters:
```Java
clean
force
```
**clean**: remove all files after import
**force**: apply without rollback

The change allows define a filepath
```Java
clean
force
/tmp/migration/
```
