### PR TITLE
Fixed error with Save from PO when a error is created from a model

### DIFF
--- a/base/src/org/compiere/model/PO.java
+++ b/base/src/org/compiere/model/PO.java
@@ -2270,9 +2270,9 @@ public abstract class PO
 				}
 			}
 		}
-		catch (SQLException e)
+		catch (Exception e)
 		{
-			log.log(Level.WARNING, "afterSave - " + toString(), e);
+			log.saveError("Error", e);
 			if (localTrx != null)
 			{
 				localTrx.rollback();


### PR DESCRIPTION
**What is the bug?**
the try used for save a simple PO only validate SQLException instead any exception, then when exists a error that is not a SQL Exception the change is saved instead rollback, see old code:

```Java
try
		{
			// Call ModelValidators TYPE_NEW/TYPE_CHANGE
			String errorMsg = ModelValidationEngine.get().fireModelChange
				(this, newRecord ? ModelValidator.TYPE_NEW : ModelValidator.TYPE_CHANGE);
			if (errorMsg != null)
			{
				log.warning("Validation failed - " + errorMsg);
				log.saveError("Error", errorMsg);
				if (localTrx != null)
				{
					localTrx.rollback();
					m_trxName = null;
				}
				else
				{
					trx.rollback(savepoint);
				}
				return false;
			}
			//	Save
			if (newRecord)
			{
				boolean b = saveNew();
				if (b)
				{
					if (localTrx != null)
						return localTrx.commit();
					else
						return b;
				}
				else
				{
					if (localTrx != null)
						localTrx.rollback();
					else
						trx.rollback(savepoint);
					return b;
				}
			}
			else
			{
				boolean b = saveUpdate();
				if (b)
				{
					if (localTrx != null)
						return localTrx.commit();
					else
						return b;
				}
				else
				{
					if (localTrx != null)
						localTrx.rollback();
					else
						trx.rollback(savepoint);
					return b;
				}
			}
		}
		catch (SQLException e)
		{
			log.log(Level.WARNING, "afterSave - " + toString(), e);
			if (localTrx != null)
			{
				localTrx.rollback();
			}
			else if (savepoint != null)
			{
				try
				{
					trx.rollback(savepoint);
				} catch (SQLException e1){}
				savepoint = null;
			}
			return false;
		}
		finally
		{
			if (localTrx != null)
			{
				localTrx.close();
				m_trxName = null;
			}
			else
			{
				if (savepoint != null)
				{
					try {
						trx.releaseSavepoint(savepoint);
					} catch (SQLException e) {
						e.printStackTrace();
					}
				}
				savepoint = null;
				trx = null;
			}
		}
``` 

Now you can see a change:

```Java
try
		{
			// Call ModelValidators TYPE_NEW/TYPE_CHANGE
			String errorMsg = ModelValidationEngine.get().fireModelChange
				(this, newRecord ? ModelValidator.TYPE_NEW : ModelValidator.TYPE_CHANGE);
			if (errorMsg != null)
			{
				log.warning("Validation failed - " + errorMsg);
				log.saveError("Error", errorMsg);
				if (localTrx != null)
				{
					localTrx.rollback();
					m_trxName = null;
				}
				else
				{
					trx.rollback(savepoint);
				}
				return false;
			}
			//	Save
			if (newRecord)
			{
				boolean b = saveNew();
				if (b)
				{
					if (localTrx != null)
						return localTrx.commit();
					else
						return b;
				}
				else
				{
					if (localTrx != null)
						localTrx.rollback();
					else
						trx.rollback(savepoint);
					return b;
				}
			}
			else
			{
				boolean b = saveUpdate();
				if (b)
				{
					if (localTrx != null)
						return localTrx.commit();
					else
						return b;
				}
				else
				{
					if (localTrx != null)
						localTrx.rollback();
					else
						trx.rollback(savepoint);
					return b;
				}
			}
		}
		catch (Exception e)
		{
			log.saveError("Error", e);
			if (localTrx != null)
			{
				localTrx.rollback();
			}
			else if (savepoint != null)
			{
				try
				{
					trx.rollback(savepoint);
				} catch (SQLException e1){}
				savepoint = null;
			}
			return false;
		}
		finally
		{
			if (localTrx != null)
			{
				localTrx.close();
				m_trxName = null;
			}
			else
			{
				if (savepoint != null)
				{
					try {
						trx.releaseSavepoint(savepoint);
					} catch (SQLException e) {
						e.printStackTrace();
					}
				}
				savepoint = null;
				trx = null;
			}
		}
```

For all model validator of model change trigger never is rollback if return a error because all return value from **modelChange** method is convert to **throw Exception**, see fragment of code:

```Java
	private String fireModelChange(PO po, int changeType, List<ModelValidator> modelValidators)
	{
		Optional.ofNullable(modelValidators)
				.ifPresent(	modelValidatorList ->
							modelValidatorList.stream()
									.filter(modelValidator -> modelValidator.getAD_Client_ID() == po.getAD_Client_ID()
											|| globalValidators.contains(modelValidator))
									.forEach(modelValidator -> {
										try {
											String error = modelValidator.modelChange(po, changeType);
											if (error != null && error.length() > 0) {
												if (log.isLoggable(Level.FINE)) {
													log.log(Level.FINE, "po=" + po + " validator=" + modelValidator + " changeType=" + changeType);
												}
												throw new AdempiereException(error);
											}
										} catch (Exception e) {
											//log the exception
											log.log(Level.SEVERE, e.getLocalizedMessage(), e);
											String error = e.getLocalizedMessage();
											if (error == null)
												error = e.toString();
											throw new AdempiereException(error);
										}
									}));
		return null;
	}
``` 

Before change: Note that the error is showed but transaction is commited instead rollback.
![After_Save_Before_Change](https://user-images.githubusercontent.com/2333092/78054660-665a6700-7350-11ea-9dfd-ce88255dd45a.gif)

After change: The transaction is rollback and error is showed to user instead a generic error **Save Error** 
![After_Save_After_Change](https://user-images.githubusercontent.com/2333092/78054688-7114fc00-7350-11ea-9153-4fa0124af1fd.gif)
