### PR TITLE
Fix Landed Costs Accounting, when Vendor invoice is in another currency

### DIFF
--- a/base/src/org/adempiere/engine/CostEngine.java
+++ b/base/src/org/adempiere/engine/CostEngine.java
@@ -509,11 +509,9 @@ public class CostEngine {
 				model.getC_Currency_ID(), acctSchema.getC_Currency_ID() ,
 				model.getDateAcct(), model.getC_ConversionType_ID() ,
 				model.getAD_Client_ID(), model.getAD_Org_ID());
-		if (rate != null) {
+		if (rate != null) 
 			costThisLevel = cost.multiply(rate);
-			if (costThisLevel.scale() > acctSchema.getCostingPrecision())
-				costThisLevel = costThisLevel.setScale(acctSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
-		}
+
 		return costThisLevel;
 	}
 

--- a/base/src/org/compiere/acct/Doc_Invoice.java
+++ b/base/src/org/compiere/acct/Doc_Invoice.java
@@ -859,13 +859,14 @@ public class Doc_Invoice extends Doc
 						as.getC_AcctSchema_ID(),
 						costType.get_ID())).orElseGet(() -> BigDecimal.ZERO);
 				//cost to Cost Adjustment
-				BigDecimal costAdjustment = landedCostAllocation.getAmt().subtract(assetAmount);
+				BigDecimal costAdjustment = landedCostAllocation.getAmt(true,true).subtract(assetAmount);
+				setIsMultiCurrency(landedCostAllocation.getC_Currency_ID()!=as.getC_Currency_ID());
 				if (assetAmount.signum() != 0)
 				{
 					if (isDebit)
 						debitAmount = assetAmount;
 					else
-						creditAmount = assetAmount;
+						creditAmount = assetAmount.negate();
 
 					factLine = fact.createLine(line, productCost.getAccount(ProductCost.ACCTTYPE_P_Asset, as),
 							as.getC_Currency_ID(), debitAmount, creditAmount);

--- a/base/src/org/compiere/model/MLandedCostAllocation.java
+++ b/base/src/org/compiere/model/MLandedCostAllocation.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -42,7 +43,9 @@ public class MLandedCostAllocation extends X_C_LandedCostAllocation implements I
 	 * 
 	 */
 	private static final long serialVersionUID = -8645283018475474574L;
-
+	
+	private MInvoiceLine invoiceLine = null;
+	private MInvoice invoice = null;
 
 	/**
 	 * 	Get Cost Allocations for invoice Line
@@ -244,34 +247,91 @@ public class MLandedCostAllocation extends X_C_LandedCostAllocation implements I
 	}
 
 	public BigDecimal getPriceActualCurrency() {
-		MInvoiceLine invoiceLine = (MInvoiceLine) getC_InvoiceLine();
-		MCurrency currency = MCurrency.get(getCtx(), getC_Currency_ID());
-		BigDecimal amount = getAmt().divide(getQty() , currency.getCostingPrecision() ,  RoundingMode.HALF_UP);
-		if (MDocType.DOCBASETYPE_APCreditMemo.equals(invoiceLine.getParent().getC_DocType().getDocBaseType()))
-			amount = amount.negate();
+		BigDecimal amount = getAmt(true, false).divide(getQty() , MathContext.DECIMAL128);
 		return  amount;
 	}
 
 	@Override
 	public int getC_Currency_ID ()
 	{
-		return DB.getSQLValue(get_TrxName() ,
-				"SELECT i.C_Currency_ID FROM C_InvoiceLine il INNER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID) WHERE il.C_InvoiceLine_ID = ? ",
-				getC_InvoiceLine_ID());
+		if (getInvoice()!=null)
+			return getInvoice().getC_Currency_ID();
+		else
+			return 0;
 	}
 
 	@Override
 	public int getC_ConversionType_ID()
 	{
-		return DB.getSQLValue(get_TrxName() ,
-				"SELECT i.C_ConversionType_ID FROM C_InvoiceLine il INNER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID) WHERE il.C_InvoiceLine_ID = ? ",
-				getC_InvoiceLine_ID());
+		if (getInvoice()!=null)
+			return getInvoice().getC_ConversionType_ID();
+		else
+			return 0;
 	}
 
 	@Override
 	public boolean isReversalParent() {
 		// TODO Auto-generated method stub
 		return false;
+	}
+	
+	/**
+	 * getAmt 
+	 * Get Amount without Adjusted Credit Memo
+	 */
+	@Override
+	public BigDecimal getAmt() {
+		return getAmt(false, false);
+	}
+	
+	/**
+	 * Get Amount with Adjusted Credit Memo parameter
+	 * @param creditMemoAdjusted
+	 * @return
+	 */
+	public BigDecimal getAmt(boolean creditMemoAdjusted, boolean converted) {
+		BigDecimal amount = super.getAmt();
+		MInvoiceLine invoiceLine = (MInvoiceLine) getC_InvoiceLine();
+		if (creditMemoAdjusted 
+				&& MDocType.DOCBASETYPE_APCreditMemo.equals(invoiceLine.getParent().getC_DocTypeTarget().getDocBaseType()))
+			amount = amount.negate();
+		if (converted
+				&& getC_Currency_ID() > 0)
+			amount = MConversionRate.convertBase(getCtx(), amount, getC_Currency_ID(), getInvoice().getDateAcct(), getC_ConversionType_ID(), getAD_Client_ID(), getAD_Org_ID());
+		return  amount;
+	}
+	
+	/**
+	 * Set Invoice Line
+	 * @param invoiceLine
+	 */
+	public void setInvoiceLine(MInvoiceLine invoiceLine) {
+		this.invoiceLine = invoiceLine;
+	}
+	/**
+	 * Set Invoice
+	 * @param invoice
+	 */
+	public void setInvoice(MInvoiceLine invoiceLine) {
+		if (invoiceLine!=null)
+			this.invoice = (MInvoice) invoiceLine.getC_Invoice();
+	}
+	
+	/**
+	 * Get Invoice Line
+	 * @return
+	 */
+	public MInvoiceLine getInvoiceLine() {
+		if (invoiceLine==null)
+			setInvoiceLine((MInvoiceLine)getC_InvoiceLine());
+		return invoiceLine;
+	}
+	
+	public MInvoice getInvoice() {
+		if (invoice==null) {
+			setInvoice(getInvoiceLine());
+		}
+		return invoice;
 	}
 	
 }	//	MLandedCostAllocation


### PR DESCRIPTION
Currently, when you create a vendor invoice with associated costs in a different currency of purchase receipt, this generate an difference on costing amount and accounting amount.

Show this example:

**_Invoice Vendor info_**
![Invoice-Header](https://user-images.githubusercontent.com/1847863/78063218-dae7d280-735d-11ea-8fd7-9df5700303f0.png)
![Invoice Line](https://user-images.githubusercontent.com/1847863/78063289-f3f08380-735d-11ea-84b4-899bbe250d44.png)

|**_Invoice Currency:_** EUR|
|:---|
|**_Currency Rate:_** 1.249|
|**_Costing Precision:_** 4|
|**_Invoice Amount Allocation:_** 987.63|

**_Invoice Landed Cost Allocation_**
![LandedCost](https://user-images.githubusercontent.com/1847863/78063402-29956c80-735e-11ea-88cb-a1e22dbcf8a2.png)

|**Amount**|**Quantity Receipt**|
|---:|---:|
|123.45 €|27,653.00|
|123.45 €|30,000.00|
|123.45 €|30,000.00|
|123.45 €|29,986.00|
|123.45 €|26,780.00|
|123.45 €|28,632.00|
|123.45 €|6,949.00|
|123.48 €|30,000.00|
|**987.63€**|**210.000,00**|

**_Cost Generated_**
When generated costing at completing Invoice, this set current cost price   (costing amount / quantity receipt ), rounding to costing precision and then multiply by currency rate, rounding to costing precision, example: 123.45 / 27,653.00 rounding to 4 decimals =  0.0045 and the result is multiply by currency rate (1.249) and rounding to 4 decimals = 0.0056. Then the amount is calculated, multipling current cost price (0.0056) by quantity (27,653.00) = 154.8568

![CostGenerated](https://user-images.githubusercontent.com/1847863/78063602-7d07ba80-735e-11ea-8d54-d21efaa2933d.png)


|**Landed Cost Amount**|**Receipt Quantity**|**Current Cost Price**|**Amount**|
|---:|---:|---:|---:|
|123.45 €|27,653.00|0.0056 $|154.8568$|
|123.45 €|30,000.00|0.0051 $|153.0000$|
|123.45 €|30,000.00|0.0051 $|153.0000$|
|123.45 €|29,986.00|0.0051 $|152.9286$|
|123.45 €|26,780.00|0.0057 $|152.6460$|
|123.45 €|28,632.00|0.0054 $|154.6128$|
|123.45 €|6,949.00|0.0222 $|154.2678$|
|123.48 €|30,000.00|0.0051 $|153.0000$|
|**987.63€**|**210.000,00**|**--**|**1,228.312$**|

**_Accounting_**
When accounting, Product Asset is created from amount costing generated. The additional cost is subtracted of costing generated, the result is accounting Costs Adjustment. Example: Product Asset 154.8568, Cost Adjustment (Source Accounting 123.45 - 154.8568 = -31.41)  (Accounting -31.41 * Conversion Rate 1.249 = -39.23), the sum of differences generated an Currency Balancing Accounting.

![Accounting](https://user-images.githubusercontent.com/1847863/78063665-9446a800-735e-11ea-9aa2-aae5c18411df.png)


|**Account**|**Accounted Debit**|**Accounted Credit**|**Source Debit**|**Source Credit**|
|:---|---:|---:|---:|---:|
|Product Asset|154.86|0.00|154.86|0.00|
|Cost Adjustment|-39.23|0.00|-31.41|0.00|
|Product Asset|153.00|0.00|153.00|0.00|
|Cost Adjustment|-36.91|0.00|-29.55|0.00|
|Product Asset|153.00|0.00|153.00|0.00|
|Cost Adjustment|-36.91|0.00|-29.55|0.00|
|Product Asset|152.93|0.00|152.93|0.00|
|Cost Adjustment|-36.82|0.00|-29.48|0.00|
|Product Asset|152.65|0.00|152.65|0.00|
|Cost Adjustment|-36.47|0.00|-29.20|0.00|
|Product Asset|154.61|0.00|154.61|0.00|
|Cost Adjustment|-38.92|0.00|-31.16|0.00|
|Product Asset|154.27|0.00|154.27|0.00|
|Cost Adjustment|-38.49|0.00|-30.82|0.00|
|Product Asset|153.00|0.00|153.00|0.00|
|Cost Adjustment|-36.87|0.00|-29.52|0.00|
|Accounts Payable Trade|0.00|1,233.55|0.00|987.63|
|Currency Balancing|305.85|0.00|305.85|0.00|

**After the change it resolving: **

- **Precision of amount on costing generated**

![LandedCostAfterChange](https://user-images.githubusercontent.com/1847863/78064766-3b780f00-7360-11ea-916c-f6ef570339d2.png)

- **Accounting Differences**
![AccountingAfterChanged](https://user-images.githubusercontent.com/1847863/78064900-72e6bb80-7360-11ea-9505-abb9dd27d251.png)


