### PR TITLE
Add Validation Cost Element by Landed Cost Type

### DIFF
--- a/base/src/org/compiere/model/MLandedCost.java
+++ b/base/src/org/compiere/model/MLandedCost.java
@@ -131,6 +131,13 @@ public class MLandedCost extends X_C_LandedCost
 				"@NotFound@ @M_Product_ID@ | @M_InOut_ID@ | @M_InOutLine_ID@"));
 			return false;
 		}
+		
+		if (getM_CostElement_ID()!=0
+				&& !MCostElement.COSTELEMENTTYPE_LandedCost.equals(getM_CostElement().getCostElementType())) {
+			log.saveError("Error", Msg.parseTranslation(getCtx(), 
+					"@Invalid@ @M_CostElement_ID@"));
+				return false;
+		}
 		//	No Product if Line entered
 		if (getM_InOutLine_ID() != 0 && getM_Product_ID() != 0)
 			setM_Product_ID(0);

--- a/migration/393lts-394lts/05770_Add_Cost_Element_Validation_Landed_Cost.xml
+++ b/migration/393lts-394lts/05770_Add_Cost_Element_Validation_Landed_Cost.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Validate Cost Element on Landed Cost" ReleaseNo="3.9.3" SeqNo="5770">
+    <Comments>Add Validation Cost Element By Landed Cost Type</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="13451" Table="AD_Column">
+        <Data AD_Column_ID="117" Column="DefaultValue" isOldNull="true">-1</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">M_CostElement_ID</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="285" Action="U" Record_ID="54924" Table="AD_Process_Para">
+        <Data AD_Column_ID="3739" Column="DefaultValue" isOldNull="true">-1</Data>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID" isOldNull="true">222</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
When applied landed costs on Invoice Vendor, this set a default Cost Element that will could be not an Landed Cost type. Additionally if generated Landed Cost from the Smart Browse (Create Landed Cost From Receipt) this don't filter by Cost Element, merging Landed Cost with Material Cost type.

**Landed Cost Window:**
![LandedCostType_Window](https://user-images.githubusercontent.com/1847863/78169581-9de41480-741f-11ea-9354-8bc262f57ff9.png)

**Landed Cost Window Proposal:**
![LandedCostType_Window_After](https://user-images.githubusercontent.com/1847863/78169673-c2d88780-741f-11ea-9706-ff06b20afaa4.png)

**Smart Browse (Create Landed Cost From Receipt):**
![LandedCost-SB](https://user-images.githubusercontent.com/1847863/78169712-d71c8480-741f-11ea-8df1-de4ab8bb42c7.png)

**Smart Browse (Create Landed Cost From Receipt) Proposal:**
![LandedCost-SB-After](https://user-images.githubusercontent.com/1847863/78169731-df74bf80-741f-11ea-977b-ff94cf81a0a1.png)

**Additionaly, add code validation before save:**
```
if (getM_CostElement_ID()!=0
	&& !MCostElement.COSTELEMENTTYPE_LandedCost.equals(getM_CostElement().getCostElementType())) {
	log.saveError("Error", Msg.parseTranslation(getCtx(), 
		"@Invalid@ @M_CostElement_ID@"));
	return false;
}
```