### PR TITLE
Fixed error with process builder when flag "IsManagedTransaction" is false

### DIFF
--- a/base/src/org/eevolution/service/dsl/ProcessBuilder.java
+++ b/base/src/org/eevolution/service/dsl/ProcessBuilder.java
@@ -64,7 +64,7 @@ public class ProcessBuilder {
     private ASyncProcess parent;
     private List<Integer> selectedRecordsIds;
     private int tableSelectionId;
-    private boolean isBatch = false;
+    private boolean isBatch = true;
     private boolean isPrintPreview = false;
     private String reportExportFormat = null;
 

--- a/base/src/org/eevolution/service/dsl/ProcessBuilder.java
+++ b/base/src/org/eevolution/service/dsl/ProcessBuilder.java
@@ -172,7 +172,7 @@ public class ProcessBuilder {
         processInfo = new ProcessInfo(title, processId, tableId , recordId, isManagedTransaction);
         processInfo.setAD_PInstance_ID(instance.getAD_PInstance_ID());
         processInfo.setClassName(MProcess.get(context , processId).getClassname());
-        if(isManagedTransaction) {
+        if(isBatch()) {
         	processInfo.setTransactionName(trxName);
         }
         processInfo.setIsSelection(isSelection);
@@ -219,9 +219,9 @@ public class ProcessBuilder {
     {
         Runnable processCtl;
         if (windowNo == 0)
-            processCtl = processCtl("org.compiere.process.ServerProcessCtl", parent, windowNo, processInfo, isManagedTransaction? Trx.get(trxName, false): null);
+            processCtl = processCtl("org.compiere.process.ServerProcessCtl", parent, windowNo, processInfo, isBatch()? Trx.get(trxName, false): null);
         else
-            processCtl = processCtl("org.compiere.apps.ProcessCtl", parent, windowNo, processInfo, isManagedTransaction? Trx.get(trxName, false): null);
+            processCtl = processCtl("org.compiere.apps.ProcessCtl", parent, windowNo, processInfo, isBatch()? Trx.get(trxName, false): null);
 
         processCtl.run();
     }

--- a/base/src/org/eevolution/service/dsl/ProcessBuilder.java
+++ b/base/src/org/eevolution/service/dsl/ProcessBuilder.java
@@ -172,7 +172,9 @@ public class ProcessBuilder {
         processInfo = new ProcessInfo(title, processId, tableId , recordId, isManagedTransaction);
         processInfo.setAD_PInstance_ID(instance.getAD_PInstance_ID());
         processInfo.setClassName(MProcess.get(context , processId).getClassname());
-        processInfo.setTransactionName(trxName);
+        if(isManagedTransaction) {
+        	processInfo.setTransactionName(trxName);
+        }
         processInfo.setIsSelection(isSelection);
         processInfo.setPrintPreview(isPrintPreview());
         if(!Util.isEmpty(getReportExportFormat())) {
@@ -217,9 +219,9 @@ public class ProcessBuilder {
     {
         Runnable processCtl;
         if (windowNo == 0)
-            processCtl = processCtl("org.compiere.process.ServerProcessCtl", parent, windowNo, processInfo, Trx.get(trxName, false));
+            processCtl = processCtl("org.compiere.process.ServerProcessCtl", parent, windowNo, processInfo, isManagedTransaction? Trx.get(trxName, false): null);
         else
-            processCtl = processCtl("org.compiere.apps.ProcessCtl", parent, windowNo, processInfo, Trx.get(trxName, false));
+            processCtl = processCtl("org.compiere.apps.ProcessCtl", parent, windowNo, processInfo, isManagedTransaction? Trx.get(trxName, false): null);
 
         processCtl.run();
     }


### PR DESCRIPTION
The problem: currently the **ProcessBuilder** class have a method for unhandle transaction from it, the flag is named **withoutBatchMode()** and the current behavior is not implemented correctly.

**What is the correct behavior?**
When a process builder is runned with **withoutBatchMode()** method called, it will should run the process without transaction and allows that transaction can generate and closed inside process.  