### PR TITLE
Fixed error with transaction without commit or rollback

### DIFF
--- a/base/src/org/compiere/wf/MWorkflow.java
+++ b/base/src/org/compiere/wf/MWorkflow.java
@@ -793,7 +793,7 @@ public class MWorkflow extends X_AD_Workflow
 		final int SLEEP = 500;		//	1/2 sec
 		final int MAXLOOPS = 30;	//	15 sec	
 		//
-		MWFProcess process = start(pi, pi.getTransactionName());
+		MWFProcess process = start(pi, pi.isBatch()? pi.getTransactionName(): null);
 		if (process == null)
 			return null;
 		Thread.yield();

--- a/base/src/org/spin/util/test/WFTestCase.java
+++ b/base/src/org/spin/util/test/WFTestCase.java
@@ -1,0 +1,60 @@
+/*************************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                              *
+ * This program is free software; you can redistribute it and/or modify it    		 *
+ * under the terms version 2 or later of the GNU General Public License as published *
+ * by the Free Software Foundation. This program is distributed in the hope   		 *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied 		 *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           		 *
+ * See the GNU General Public License for more details.                       		 *
+ * You should have received a copy of the GNU General Public License along    		 *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    		 *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     		 *
+ * For the text or an alternative of this public license, you may reach us    		 *
+ * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, S.A. All Rights Reserved. *
+ * Contributor(s): Yamel Senih www.erpya.com				  		                 *
+ *************************************************************************************/
+package org.spin.util.test;
+
+import org.compiere.model.MBPartner;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.util.Env;
+import org.eevolution.service.dsl.ProcessBuilder;
+
+/**
+ * Test case for Workflow with transaction
+ * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
+ */
+public class WFTestCase {
+
+	public static void main(String args[]) {
+		org.compiere.Adempiere.startup(true);
+		Env.setContext(Env.getCtx(), "#AD_Client_ID", 11);
+		MOrder order = new MOrder(Env.getCtx(), 0, null);
+		//	118 = Joe Block
+		order.setAD_Org_ID(11);
+		order.setC_DocTypeTarget_ID(132);
+		order.setBPartner(new MBPartner(Env.getCtx(), 118, null));
+		order.setM_Warehouse_ID(103);
+		order.setSalesRep_ID(101);
+		order.setDescription("Created From Test Case");
+		order.saveEx();
+		MOrderLine oneLine = new MOrderLine(order);
+		//	138 = Hoe_Hoe 4 ft
+		oneLine.setM_Product_ID(138, true);
+		oneLine.setQty(Env.ONE);
+		oneLine.setPrice();
+		oneLine.saveEx();
+		System.out.println(order);
+		//	Set document action and process it from a process
+		order.setDocAction(MOrder.DOCACTION_Complete);
+		order.saveEx();
+		//	Run process
+		//	104 = C_Order Process
+		ProcessBuilder.create(Env.getCtx())
+			.process(104)
+			.withRecordId(MOrder.Table_ID, order.getC_Order_ID())
+			.withoutBatchMode()
+			.execute();
+	}
+}


### PR DESCRIPTION
The problem: if a process is run with batch mode == false then the transaction should be handled locally but it is not applied for **start(ProcessInfo, String)** method. 

Then when the execution is finished the transaction is not committed or rolled back, this bug cause a big problem with database because a statement is loaded without confirm, a example is the update for **Processing** column:

```SQL
UPDATE C_Order SET Processing = 'N' WHERE C_Order_ID = 1000000;
```

Note that batch mode is validated from previous method:
```Java
public static MWFProcess startWorkFlow(Properties ctx, ProcessInfo pi, int AD_Workflow_ID) {
		MWorkflow wf = MWorkflow.get (ctx, AD_Workflow_ID);
		MWFProcess wfProcess = null;
		if (pi.isBatch())
			wfProcess = wf.start(pi, pi.getTransactionName());		//	may return null
		else {
			wfProcess = wf.startWait(pi);	//	may return null
		}
		log.fine(pi.toString());
		return wfProcess;
	}
```

But if you see called method when **pi.isBatch()** is false the transaction name is passed

```Java
public MWFProcess startWait (ProcessInfo pi)
	{
		final int SLEEP = 500;		//	1/2 sec
		final int MAXLOOPS = 30;	//	15 sec	
		//
		MWFProcess process = start(pi, pi.getTransactionName());
```

If a process is running like no batch mode and it have a transaction name the transaction never is commited or rollback.

A simple test case:

Without Change:
```Java
MWFProcess process = start(pi, pi.getTransactionName());
```
![Before_Change_WF_Batch_Mode](https://user-images.githubusercontent.com/2333092/78222372-23ed7300-7493-11ea-84a0-703c43010550.gif)

Note that exists a idle in transaction query:
```SQL
-- Query
#RCFT=# SELECT pid, datname, usename, xact_start, query_start, state, state_change, query, now() FROM pg_stat_activity WHERE datname = '#RCFT'; 
-- Result
 1011 | #RCFT   | adempiere | 2020-04-02 07:34:43.008398+00 | 2020-04-02 07:34:43.008692+00 | active              | 2020-04-02 07:34:43.008693+00 | UPDATE C_Order SET Processing='N' WHERE C_Order_ID=$1  
```

With Change:
```Java
MWFProcess process = start(pi, pi.isBatch()? pi.getTransactionName(): null);
```
![After_Change_WF_Batch_Mode](https://user-images.githubusercontent.com/2333092/78221697-dcb2b280-7491-11ea-878e-1cc2ae6faae7.gif)
