### PR TITLE
Fixed error with Copy values for UUID

### DIFF
--- a/base/src/org/compiere/model/M_Element.java
+++ b/base/src/org/compiere/model/M_Element.java
@@ -360,7 +360,8 @@ public class M_Element extends X_AD_Element
 			|| columnName.equals("IsPaid") || columnName.equals("IsAllocated")
 			// Bug [ 1807947 ] 
 			|| columnName.equals("C_DocType_ID")
-			|| (columnName.equals("Line"));
+			|| columnName.equals("Line")
+			|| columnName.equals("UUID");
 	}
 	
 	/**

--- a/base/src/org/compiere/model/PO.java
+++ b/base/src/org/compiere/model/PO.java
@@ -1345,14 +1345,7 @@ public abstract class PO
 					continue;
 				String colName = from.p_info.getColumnName(i1);
 				//  Ignore Standard Values
-				if (colName.startsWith("Created")
-					|| colName.startsWith("Updated")
-					|| colName.equals("IsActive")
-					|| colName.equals("AD_Client_ID")
-					|| colName.equals("AD_Org_ID")
-					|| colName.equals("Processing")
-					|| colName.equals("UUID")
-					)
+				if (M_Element.isReservedColumnName(colName))
 					;	//	ignore
 				else
 				{
@@ -2786,7 +2779,7 @@ public abstract class PO
 		columnName = I_AD_Element.COLUMNNAME_UUID;
 		if (p_info.getColumnIndex(columnName) != -1) {
 			String value = get_ValueAsString(columnName);
-			if (value == null || value.length() == 0) {
+			if (Util.isEmpty(value) || !isDirectLoad) {
 				value = DB.getUUID(m_trxName);
 				set_ValueNoCheck(columnName, value);
 			}


### PR DESCRIPTION
This pull request resolve a critical error with copy values method from **GridTab**. The problem is that it does not use UUID for compare column names and exclude.

The result is that if you use copy action button from a window then the **UUID** is copied also. 