### PR TITLE
Remove saveError and throw exception

### DIFF
--- a/base/src/org/compiere/model/PO.java
+++ b/base/src/org/compiere/model/PO.java
@@ -2170,7 +2170,7 @@ public abstract class PO
 				log.warning("beforeSave failed - " + toString());
 				if (localTrx != null)
 				{
-					localTrx.rollback();
+					localTrx.rollback(true);
 					localTrx.close();
 					m_trxName = null;
 				}
@@ -2214,7 +2214,7 @@ public abstract class PO
 				log.saveError("Error", errorMsg);
 				if (localTrx != null)
 				{
-					localTrx.rollback();
+					localTrx.rollback(true);
 					m_trxName = null;
 				}
 				else
@@ -2230,14 +2230,14 @@ public abstract class PO
 				if (b)
 				{
 					if (localTrx != null)
-						return localTrx.commit();
+						return localTrx.commit(true);
 					else
 						return b;
 				}
 				else
 				{
 					if (localTrx != null)
-						localTrx.rollback();
+						localTrx.rollback(true);
 					else
 						trx.rollback(savepoint);
 					return b;
@@ -2249,14 +2249,14 @@ public abstract class PO
 				if (b)
 				{
 					if (localTrx != null)
-						return localTrx.commit();
+						return localTrx.commit(true);
 					else
 						return b;
 				}
 				else
 				{
 					if (localTrx != null)
-						localTrx.rollback();
+						localTrx.rollback(true);
 					else
 						trx.rollback(savepoint);
 					return b;
@@ -2280,25 +2280,20 @@ public abstract class PO
 			}
 			return false;
 		}
-		finally
-		{
-			if (localTrx != null)
-			{
-				localTrx.close();
-				m_trxName = null;
-			}
-			else
-			{
-				if (savepoint != null)
-				{
-					try {
+		finally {
+			try {
+				if (localTrx != null) {
+					localTrx.close();
+					m_trxName = null;
+				} else {
+					if (savepoint != null) {
 						trx.releaseSavepoint(savepoint);
-					} catch (SQLException e) {
-						e.printStackTrace();
 					}
+					savepoint = null;
+					trx = null;
 				}
-				savepoint = null;
-				trx = null;
+			} catch (SQLException e) {
+				log.saveError("Error", e);
 			}
 		}
 	}	//	save


### PR DESCRIPTION
The problem: 
When exists a error committing a change from database the user only can see a bad message "saveError", it is because the original error is not propagate to end user. A example is saving a product with a M_AttributeSetInstance_ID without reference.

The current message:
**saveError**

The real Message:
```SQL

ERROR: insert or update on table "m_product" violates foreign key constraint "mattrsetinst_mproduct"%0A Detail: Key (m_attributesetinstance_id)=(21545) is not present in table "m_attributesetinstance".%0AERROR: insert or update on table "m_product" violates foreign key constraint "mattrsetinst_mproduct"%0A Detail: Key (m_attributesetinstance_id)=(21545) is not present in table "m_attributesetinstance".
```