### PR TITLE
Fixed error with language for ASP

### DIFF
--- a/base/src/org/compiere/model/MProcess.java
+++ b/base/src/org/compiere/model/MProcess.java
@@ -194,7 +194,7 @@ public class MProcess extends X_AD_Process
 	 */
 	public List<MProcessPara> getASPParameters() {
 		MClient client = MClient.get(Env.getCtx());
-		String key = getAD_Process_ID() + "|" + client.getAD_Client_ID();
+		String key = getAD_Process_ID() + "|" + client.getAD_Client_ID() + "|" + Env.getAD_Language(getCtx());
 		List<MProcessPara> retValue = cacheASPParameters.get (key);
 		if (retValue != null)
 			return retValue;

--- a/base/src/org/compiere/model/MTab.java
+++ b/base/src/org/compiere/model/MTab.java
@@ -28,6 +28,7 @@ import org.adempiere.exceptions.FillMandatoryException;
 import org.compiere.util.CCache;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
+import org.compiere.util.Env;
 
 /**
  *	Tab Model
@@ -258,7 +259,7 @@ public class MTab extends X_AD_Tab
 	 */
 	public List<MField> getASPFields() {
 		MClient client = MClient.get(getCtx());
-		String key = getAD_Tab_ID() + "|" + client.getAD_Client_ID();
+		String key = getAD_Tab_ID() + "|" + client.getAD_Client_ID() + "|" + Env.getAD_Language(getCtx());
 		List<MField> retValue = cacheASPFields.get (key);
 		if (retValue != null) {
 			return retValue;

--- a/base/src/org/compiere/model/MWindow.java
+++ b/base/src/org/compiere/model/MWindow.java
@@ -27,6 +27,7 @@ import java.util.logging.Level;
 import org.compiere.util.CCache;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
+import org.compiere.util.Env;
 import org.compiere.wf.MWFNode;
 
 /**
@@ -120,7 +121,7 @@ public class MWindow extends X_AD_Window
 	 */
 	public List<MTab> getASPTabs() {
 		MClient client = MClient.get(getCtx());
-		String key = getAD_Window_ID() + "|" + client.getAD_Client_ID();
+		String key = getAD_Window_ID() + "|" + client.getAD_Client_ID() + "|" + Env.getAD_Language(getCtx());
 		List<MTab> retValue = cacheASPTabs.get (key);
 		if (retValue != null) {
 			return retValue;

--- a/base/src/org/spin/util/ASPUtil.java
+++ b/base/src/org/spin/util/ASPUtil.java
@@ -458,7 +458,7 @@ public class ASPUtil {
 		}
 		loadTranslation(process);
 		//	Save dictionary
-		processCache.put(getDictionaryKey(processId), process);
+		processCache.put(getDictionaryKey(processId), process.getDuplicated());
 		//	Old compatibility
 		MTable newTable = MTable.get(context, I_AD_ProcessCustom.Table_ID);
 		if(newTable == null
@@ -487,7 +487,7 @@ public class ASPUtil {
 			return browse;
 		}
 		//	Save dictionary
-		browseCache.put(getDictionaryKey(processId), browse);
+		browseCache.put(getDictionaryKey(processId), browse.getDuplicated());
 		//	Old compatibility
 		MTable newTable = MTable.get(context, I_AD_BrowseCustom.Table_ID);
 		if(newTable == null
@@ -513,7 +513,7 @@ public class ASPUtil {
 	private MWindow getWindowForASP(int windowId) {
 		MWindow window = MWindow.get(context, windowId);
 		//	Save dictionary
-		windowCache.put(getDictionaryKey(windowId), window);
+		windowCache.put(getDictionaryKey(windowId), window.getDuplicated());
 		//	Old compatibility
 		MTable newTable = MTable.get(context, I_AD_WindowCustom.Table_Name);
 		if(newTable == null


### PR DESCRIPTION
The problem is that ASP get values without distingue language, the follow is a step by step for replicated;

1. Open ADempiere with Garden and **en_US** language
2. Open a window
3. Go to Logout option
4. Login with Garden and **es_MX** language
5. Open the same window of previous session
6. See all field are on **en_US** language instead **es_MX**

The problem is that return the same object for **en_US** and **es_MX**