### PR TITLE
Removing JBoss Wildfly 19 obstacles

### DIFF
--- a/zkwebui/WEB-INF/tld/web/core.dsp.tld
+++ b/zkwebui/WEB-INF/tld/web/core.dsp.tld
@@ -92,17 +92,6 @@ Copyright (C) 2005 Potix Corporation. All Rights Reserved.
 		<tag-class>org.zkoss.web.servlet.dsp.action.When</tag-class>
 	</tag>
 
-	<!--         -->
-	<!-- Imports -->
-	<!--         -->
-	<import>
-		<import-name>ServletFns</import-name>
-		<import-class>org.zkoss.web.fn.ServletFns</import-class>
-	</import>
-	<import>
-		<import-name>Labels</import-name>
-		<import-class>org.zkoss.util.resource.Labels</import-class>
-	</import>
 
 	<!--                 -->
 	<!-- Class Utilities -->
@@ -356,7 +345,7 @@ Copyright (C) 2005 Potix Corporation. All Rights Reserved.
 		Allowed values include "robot", "ie", "ie6", "ie6-", "ie7", "ie8",
 		"ie7-", "gecko", "gecko2", "gecko3", "gecko2-",
 		"opara", "safari",
-		"mil", "hil", "mil-".<br/>
+		"mil", "hil", "mil-".&lt;br/&gt;
 		Note: "ie6-" means Internet Explorer 6 only; not Internet Explorer 7
 		or other.
 		</description>

--- a/zkwebui/WEB-INF/tld/zk/core.dsp.tld
+++ b/zkwebui/WEB-INF/tld/zk/core.dsp.tld
@@ -17,13 +17,6 @@ Copyright (C) 2005 Potix Corporation. All Rights Reserved.
 	Methods and actions for ZK in DSP/ZUML
 	</description>
 
-	<!--         -->
-	<!-- Imports -->
-	<!--         -->
-	<import>
-		<import-name>ZkFns</import-name>
-		<import-class>org.zkoss.zk.fn.ZkFns</import-class>
-	</import>
 
 	<!--           -->
 	<!-- Functions -->

--- a/zkwebui/WEB-INF/tld/zul/core.dsp.tld
+++ b/zkwebui/WEB-INF/tld/zul/core.dsp.tld
@@ -17,13 +17,6 @@ Copyright (C) 2006 Potix Corporation. All Rights Reserved.
 	Methods and actions for ZUL in DSP/ZUML
 	</description>
 
-	<!--         -->
-	<!-- Imports -->
-	<!--         -->
-	<import>
-		<import-name>ZulFns</import-name>
-		<import-class>org.zkoss.zul.fn.ZulFns</import-class>
-	</import>
 
 	<!--           -->
 	<!-- Functions -->


### PR DESCRIPTION
This pull request removes just things which mess with newest JBoss. In tag lib there are some tags <import> which seems to be not strict schema. Removing them (and one <br/> in comment) makes it possible to deploy zkwebui on new JBoss. You need just to add Adempiere.jar and AdempiereSLib into WEB-INF/lib of zkwebui.war and set property PropertyFile pointing do Adempiere.properties of your Adempiere home. When starting JBoss (you need to download it and install) with -DPropertyFile=<Adempiere.properties location> you can deploy zkwebui.war from Jboss console (port 9990)
This pull request does not contain new ZK9 or replace default JBoss. It is just clean to make it work with new  JBoss

I have tested that removing <import> tags does not makes known problems. It deploys on JBoss and Tomcat and seems to work correctly