### PR TITLE
Fixed error with price list conversion when it does not exist on map

### DIFF
--- a/base/src/org/compiere/process/M_PriceList_Create.java
+++ b/base/src/org/compiere/process/M_PriceList_Create.java
@@ -315,7 +315,7 @@ public class M_PriceList_Create extends M_PriceList_CreateAbstract {
 						String conversionRateKey = discountSchemaLine.getC_ConversionType_ID()  + "|" + productPurchasing.getC_Currency_ID() + "|" + priceList.getC_Currency_ID();
 						BigDecimal conversionRate = null;
 						if(!conversionRateMap.containsKey(conversionRateKey)) {
-							MConversionRate.getRate(productPurchasing.getC_Currency_ID(), 
+							conversionRate = MConversionRate.getRate(productPurchasing.getC_Currency_ID(), 
 									priceList.getC_Currency_ID(), 
 									priceListVersion.getValidFrom(), 
 									discountSchemaLine.getC_ConversionType_ID(), 


### PR DESCRIPTION
Fixed error with price list conversion when it does not exist on map
Just a little change bus is a bug:
```Java
BigDecimal conversionRate = null;
						if(!conversionRateMap.containsKey(conversionRateKey)) {
							conversionRate = MConversionRate.getRate(productPurchasing.getC_Currency_ID(), 
									priceList.getC_Currency_ID(), 
									priceListVersion.getValidFrom(), 
									discountSchemaLine.getC_ConversionType_ID(), 
									getAD_Client_ID(), 
									priceListVersion.getAD_Org_ID());
							if(conversionRate == null) {
								conversionRate = Env.ZERO;
							}
							//	Set
							conversionRateMap.put(conversionRateKey, conversionRate);
						} else {
							conversionRate = conversionRateMap.get(conversionRateKey);
						}
```