### PR TITLE
Fixed error with bad index for whole word on column names for query and

### DIFF
--- a/base/src/org/compiere/model/MRole.java
+++ b/base/src/org/compiere/model/MRole.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import java.util.Vector;
 import java.util.Map.Entry;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.util.CCache;
@@ -2206,7 +2208,7 @@ public final class MRole extends X_AD_Role
 				 if (column == null || column.isVirtualColumn() || !column.isActive())
 					 continue;
 			} else {
-				int posColumn = mainSql.indexOf(columnName);
+				int posColumn = getIndexOfColumn(mainSql, columnName);
 				if (posColumn == -1)
 					continue;
 				//	we found the column name - make sure it's a column name
@@ -2247,6 +2249,21 @@ public final class MRole extends X_AD_Role
 		log.finest(retSQL.toString());
 		return retSQL.toString();
 	}	//	addAccessSQL
+	
+	/**
+	 * Get Index of column from SQL finding with whole word
+	 * @param sql
+	 * @param columnName
+	 * @return
+	 */
+	private int getIndexOfColumn(String sql, String columnName) {
+		Matcher matcher = Pattern.compile("\\b" + columnName + "\\b").matcher(sql);
+		while (matcher.find()) {
+		    return matcher.start();
+		}
+		//	it not found
+		return -1;
+	}
 
 	/**
 	 * 	Get Dependent Access 
@@ -2311,7 +2328,7 @@ public final class MRole extends X_AD_Role
 	private String getDependentRecordWhereColumn (String mainSql, String columnName)
 	{
 		String retValue = columnName;	//	if nothing else found
-		int index = mainSql.indexOf(columnName);
+		int index = getIndexOfColumn(mainSql, columnName);
 		if (index == -1)
 			return retValue;
 		//	see if there are table synonym


### PR DESCRIPTION
Just a minor change but is a big error and it can cause that you see data without access, see the problem:
Test case:
Role to lock: Garden User
I only can see records of **Seed Farm Inc.** and dependents entities

Data:
BP Value: SeedFarm
BP Name: Seed Farm Inc.

## Test:
- With Garden Admin Role:
  - Go to Open Item Report
  - Uncheck Sales transaction flag
  - Run report: Note that all business partners are showed
  - Go to Role and enable **Personal Lock**
  - Logout
  - Go to Business Partner window and find **Seed Farm Inc.**
  - Lock it for **Garden User** role:
    - Exclude: false
    - Dependent entities: true
  - Logout
- With Garden User
 - Go to Open Item Report
 - Uncheck sales transaction flag
 - Run report

## Expected Result:
Only **Seed Farm Inc.** should be showed

## Result:
It show all business partners instead

## Some help definition:
- Record Access Setup
![Screenshot_20200615_222640](https://user-images.githubusercontent.com/2333092/84724909-5158a180-af57-11ea-8bfd-8198e63001e5.png)

## What is the error?
The problem is that this resport have a injectec column as sub-query before real column **C_BPartner_ID** (used for determinate if is elegible for lock a record), see the query:

```Java
SELECT A.Name AS AName,RV_OpenItem.SalesRep_ID AS SalesRep_ID,
(SELECT COALESCE(C_BPartner.Name,'') FROM C_BPartner WHERE RV_OpenItem.C_BPartner_ID=C_BPartner.C_BPartner_ID) AS BC_BPartner_ID,
RV_OpenItem.C_BPartner_ID AS C_BPartner_ID,(SELECT COALESCE(C_Invoice.DocumentNo,'')||' - '||COALESCE(CAST (C_Invoice.DateInvoiced AS Text),'')||' - '||COALESCE(CAST (C_Invoice.GrandTotal AS Text),'') 
FROM C_Invoice 
WHERE RV_OpenItem.C_Invoice_ID=C_Invoice.C_Invoice_ID) AS CC_Invoice_ID,
RV_OpenItem.C_Invoice_ID AS C_Invoice_ID,RV_OpenItem.DateInvoiced,RV_OpenItem.DaysDue,RV_OpenItem.GrandTotal,RV_OpenItem.PaidAmt,RV_OpenItem.OpenAmt 
FROM RV_OpenItem 
LEFT OUTER JOIN AD_User A ON (RV_OpenItem.SalesRep_ID=A.AD_User_ID) 
WHERE (RV_OpenItem.IsSOTrx='N' 
AND RV_OpenItem.DaysDue BETWEEN -99999.0 AND 99999.0) AND RV_OpenItem.AD_Client_ID IN (0,1000000) AND C_BPartner_ID=1000781
```

Note that exist **(SELECT COALESCE(C_BPartner.Name,'') FROM C_BPartner WHERE RV_OpenItem.C_BPartner_ID=C_BPartner.C_BPartner_ID) AS BC_BPartner_ID** before **RV_OpenItem.C_BPartner_ID**

The method that search index of C_BPartner_ID only search without whole word and it find **BC_BPartner_ID** instead **C_BPartner_ID**


## How to resolve it?
Using a regular expression with whole word instead indexOf method of String

Just is change:

```Java
int posColumn = mainSql.indexOf(columnName);
```

For:

```Java
int posColumn = getIndexOfColumn(mainSql, columnName);
//  Using the follow method for match case with whole word
	/**
	 * Get Index of column from SQL finding with whole word
	 * @param sql
	 * @param columnName
	 * @return
	 */
	private int getIndexOfColumn(String sql, String columnName) {
		Matcher matcher = Pattern.compile("\\b" + columnName + "\\b").matcher(sql);
		while (matcher.find()) {
		    return matcher.start();
		}
		//	it not found
		return -1;
	}
```

## Before change:
![Before_Record_Access_Change](https://user-images.githubusercontent.com/2333092/84724787-02127100-af57-11ea-8e25-e01e43ac7f35.gif)

## After Change:
![After_Role_Access_Change](https://user-images.githubusercontent.com/2333092/84724795-076fbb80-af57-11ea-9755-9486c6152ce4.gif)
