### PR TITLE
Fixed error with create customization from Menu when a menu is not

### DIFF
--- a/base/src/org/adempiere/process/CreateCustomizationFromASP.java
+++ b/base/src/org/adempiere/process/CreateCustomizationFromASP.java
@@ -83,13 +83,17 @@ public class CreateCustomizationFromASP extends CreateCustomizationFromASPAbstra
 		}
 			
 		// Navigate the menu and add every non-summary node
-		if (node != null && node.isSummary()) {
-			Enumeration<?> en = node.preorderEnumeration();
-			while (en.hasMoreElements()) {
-				MTreeNode nn = (MTreeNode)en.nextElement();
-				if (!nn.isSummary()) {
-					addNodeToLevel(nn);
+		if (node != null) {
+			if(node.isSummary()) {
+				Enumeration<?> en = node.preorderEnumeration();
+				while (en.hasMoreElements()) {
+					MTreeNode childNode = (MTreeNode)en.nextElement();
+					if (!childNode.isSummary()) {
+						addNodeToLevel(childNode);
+					}
 				}
+			} else {
+				addNodeToLevel(node);
 			}
 		}
 		if (noWindows > 0)


### PR DESCRIPTION
Step for reproduce:
- Create a ASP and Level
- Go to Menu
- Select a Folder or summary menu
- Go to process tool bar and select "**Create Customization from Menu**" process
- Fill parameters
- Run it

Result is ok and is generated all child of menu

Now:
- Go to Menu
- Select a non summary menu like **Sales Order**
- Go to process tool bar and select "**Create Customization from Menu**" process
- Fill parameters
- Run it
Result is nothing because only process summary menu instead items