### PR TITLE
This change allows define a dynamic column of smart browser based on any

### DIFF
--- a/base/src/org/adempiere/model/MBrowseField.java
+++ b/base/src/org/adempiere/model/MBrowseField.java
@@ -25,6 +25,7 @@ import org.compiere.model.GridFieldVO;
 import org.compiere.model.M_Element;
 import org.compiere.model.Query;
 import org.compiere.util.DB;
+import org.compiere.util.Util;
 
 /**
  * Class Model for Browse Field
@@ -46,6 +47,27 @@ public class MBrowseField extends X_AD_Browse_Field {
 	private static final long serialVersionUID = 3076943543303710639L;
 
 	private static final String CONTEXT_TABLE_PREFIX = "Table_";
+	/**	Optional Column Name for Save Selection	*/
+	private String columnNameForSelection = null;
+	
+	/**
+	 * @return the columnNameForSelection
+	 */
+	public final String getColumnNameForSelection() {
+		if(!Util.isEmpty(columnNameForSelection)) {
+			return columnNameForSelection;
+		}
+		//	Default
+		return getAD_View_Column().getColumnName();
+	}
+
+	/**
+	 * @param columnNameForSelection the columnNameForSelection to set
+	 */
+	public final void setColumnNameForSelection(String columnNameForSelection) {
+		this.columnNameForSelection = columnNameForSelection;
+	}
+
 	/**
 	 *
 	 * @param field
@@ -199,8 +221,12 @@ public class MBrowseField extends X_AD_Browse_Field {
 		setAD_Browse_ID(browse.getAD_Browse_ID());
 		if (column.get_ID() > 0 )
 			setAD_View_Column_ID(column.getAD_View_Column_ID());
-		if (column.getAD_Element_ID() > 0 )
+		if (column.getAD_Element_ID() > 0) {
 			setAD_Element_ID(column.getAD_Element_ID());
+			setAD_Reference_ID(column.getAD_Reference_ID());
+			setAD_Reference_Value_ID(column.getAD_Column().getAD_Reference_Value_ID());
+			setFieldLength(column.getAD_Column().getFieldLength());
+		}
 		setName(column.getName());
 		setDescription(column.getDescription());
 		setHelp(column.getHelp());
@@ -208,39 +234,9 @@ public class MBrowseField extends X_AD_Browse_Field {
 		setIsIdentifier(column.isIdentifier());
 		setIsRange(false);
 		setIsQueryCriteria(false);
-		if (column.get_ID() > 0)
-			setAD_Reference_ID(column.getAD_Reference_ID());
-		if (column.get_ID() > 0)
-			setAD_Reference_Value_ID(column.getAD_Column().getAD_Reference_Value_ID());
-		if (column.get_ID() > 0)
-			setFieldLength(column.getAD_Column().getFieldLength());
 		setIsKey(false);
 		setIsDisplayed(true);
 		m_view_column = column;
-	}
-
-	/**
-	 * Before Save
-	 * @param newRecord new
-	 * @return true
-	 */
-	protected boolean beforeSave(boolean newRecord) {
-		if (is_ValueChanged(COLUMNNAME_IsKey)) {
-			/*
-			 * if(getFieldKey() != null) { throw new
-			 * AdempiereException("Only can have one field as key"); }
-			 */
-		}
-		//
-		return true;
-	} // beforeSave
-
-	@Override
-	protected boolean afterSave(boolean newRecord, boolean success) {
-		if (!success) {
-			return false;
-		}
-		return success;
 	}
 	
 	/**

--- a/client/src/org/eevolution/grid/Browser.java
+++ b/client/src/org/eevolution/grid/Browser.java
@@ -29,6 +29,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.logging.Level;
 
 import org.adempiere.exceptions.AdempiereException;
@@ -667,7 +668,7 @@ public abstract class Browser {
 			BrowserRow browserRows = browseTable.getData();
 			values = new LinkedHashMap<Integer,LinkedHashMap<String,Object>>();
 			//	BR [ 257 ]
-			List <MBrowseField> fields = browseModel.getFields();
+			List <MBrowseField> fields = browserFields;
 			for (int row = 0; row < rows; row++) {
 				//Find the IDColumn Key
 				GridField selectedGridField = (GridField)browserRows.getValue(row,
@@ -694,7 +695,7 @@ public abstract class Browser {
 										value = new Timestamp(((Date) value).getTime());
 									}
 									//	Set
-									selectedValues.put(field.getAD_View_Column().getColumnName(), value);
+									selectedValues.put(field.getColumnNameForSelection(), value);
 								}
 							}
 						}
@@ -1134,115 +1135,173 @@ public abstract class Browser {
 			xcol = field.getAD_View_Column();
 			pcol = field.getAxis_Parent_Column();
 			ycol = field.getAxis_Column();
-
+			//	Validate Type
 			String columnName = xcol.getAD_Column().getColumnName();
+			Optional<MBrowseField> maybeField = browseModel.getFields()
+					.stream()
+					.filter(fieldToFind -> fieldToFind.getAD_View_Column_ID() == ycol.getAD_View_Column_ID())
+					.findFirst();
+			//	Validate
+			if(maybeField.isPresent()) {
+				MBrowseField yField = maybeField.get();
+				MBrowseField fieldKey = getFieldKey();
+				String yColumnName = null;
+				int yReferenceId = 0;
+				int yReferenceValueId = 0;
+				if(ycol.getAD_Column_ID() > 0) {
+					MColumn column = MColumn.get(field.getCtx(), ycol.getAD_Column_ID());
+					yColumnName = column.getColumnName();
+					yReferenceId = column.getAD_Reference_ID();
+					yReferenceValueId = column.getAD_Reference_Value_ID();
+				} else {
+					yColumnName = yField.getAD_Element().getColumnName();
+					yReferenceId = yField.getAD_Reference_ID();
+					yReferenceValueId = yField.getAD_Reference_Value_ID();
+				}
+				if(fieldKey == null)
+					throw new AdempiereException("@NotFound@ @IsKey@");
 
-			MBrowseField fieldKey = ((MBrowse) field.getAD_Browse()).getFieldKey();
-			if(fieldKey == null)
-				throw new AdempiereException("@NotFound@ @IsKey@");
+				MTable xTable = MTable.get(field.getCtx(), ycol.getAD_View_Definition().getAD_Table_ID());
+				String xTableName = xTable.getTableName();
 
-			MTable xTable = (MTable) ycol.getAD_View_Definition().getAD_Table();
-			String xTableName = xTable.getTableName();
+				String keyColumn = MQuery.getZoomColumnName(columnName);
+				String tableName = MQuery.getZoomTableName(columnName);
 
-			String keyColumn = MQuery.getZoomColumnName(columnName);
-			String tableName = MQuery.getZoomTableName(columnName);
+				String whereClause =  "";
 
-			String whereClause =  "";
+				if (pcol != null && pcol.getAD_View_Column_ID() > 0) {
+					MTable parentTable = MTable.get(field.getCtx(), tableName);
+					MColumn parentColumn = getParentColumn(parentTable.getAD_Table_ID());
+					if (parentColumn == null)
+						throw new AdempiereException("@NotFound@ @IsParent@");
+					//	BR [ 242 ]
+					if(field.getAD_Val_Rule_ID() > 0) {
+						whereClause = Env.parseContext(Env.getCtx(), getWindowNo() , field.getAD_Val_Rule().getCode(), false);
+					}
+				}
+				//	Get Lookup
+				MLookup lookup = MLookupFactory.get(Env.getCtx(), 0,
+						xcol.getAD_Column_ID(), field.getAD_Reference_ID(),
+						m_language, keyColumn, field.getAD_Reference_Value_ID(), false, whereClause);
 
-			if (pcol != null && pcol.getAD_View_Column_ID() > 0)
-			{
-				MTable parentTable = MTable.get(field.getCtx(), tableName);
-				MColumn parentColumn = getParentColumn(parentTable.getAD_Table_ID());
-				if (parentColumn == null)
-					throw new AdempiereException("@NotFound@ @IsParent@");
-				//	BR [ 242 ]
-				if(field.getAD_Val_Rule_ID() > 0)
-					whereClause = Env.parseContext(Env.getCtx(), getWindowNo() , field.getAD_Val_Rule().getCode(), false);
+				String axisColumnName = ycol.getColumnSQL();
+				if(Util.isEmpty(axisColumnName)) {
+					axisColumnName = yColumnName;
+				}
+				//	Replace alias
+				StringBuilder axisSql = new StringBuilder(axisColumnName);
+				boolean isSQLAgregate = false;
+				if(DisplayType.isNumeric(yReferenceId)) {
+					isSQLAgregate = !isSQLAgregate;
+					axisColumnName = axisColumnName.replaceAll(ycol.getAD_View_Definition().getTableAlias(), ycol.getAD_View_Definition().getAD_Table().getTableName());
+					axisSql = new StringBuilder("(SELECT ");
+					axisSql.append("SUM(")
+							.append(axisColumnName)
+							.append(") FROM  ")
+							.append(ycol.getAD_View_Definition().getAD_Table().getTableName())
+							.append(" WHERE ")
+							.append(xTableName)
+							.append(".")
+							.append(fieldKey.getAD_View_Column().getAD_Column()
+									.getColumnName()).append("=")
+							.append(fieldKey.getAD_View_Column().getColumnSQL());
 
-			}
-
-
-			MLookup lookup = MLookupFactory.get(Env.getCtx(), 0,
-					xcol.getAD_Column_ID(), field.getAD_Reference_ID(),
-					m_language, keyColumn, field.getAD_Reference_Value_ID(), false, whereClause);
-
-			int cols = 0;
-
-			StringBuilder axisSql = new StringBuilder("(SELECT ");
-			String cummulativeColumnName = ycol.getColumnSQL();
-			if(Util.isEmpty(cummulativeColumnName)) {
-				cummulativeColumnName = ycol.getAD_Column().getColumnName();
-			}
-			//	Replace alias
-			cummulativeColumnName = cummulativeColumnName.replaceAll(ycol.getAD_View_Definition().getTableAlias(), ycol.getAD_View_Definition().getAD_Table().getTableName());
-			axisSql.append("SUM(")
-					.append(cummulativeColumnName)
-					.append(") FROM  ")
-					.append(ycol.getAD_View_Definition().getAD_Table().getTableName())
-					.append(" WHERE ")
-					.append(xTableName)
-					.append(".")
-					.append(fieldKey.getAD_View_Column().getAD_Column()
-							.getColumnName()).append("=")
-					.append(fieldKey.getAD_View_Column().getColumnSQL());
-
-			for (int id :  getAxisRecordIds(tableName, whereClause)) {
-				cols ++;
-				String display =  lookup.getDisplay(id).trim();
-				display = display.length() > 12 ? display.substring(1,12) + "_" + cols : display;
-				String joinColumn = Msg.translate(m_language, ycol.getAD_Column()
-						.getColumnName());
-				joinColumn = joinColumn.length() > 15 ? joinColumn.substring(1, 15) :  joinColumn;
-				String sqlColName = display + "/" + joinColumn;
-				String colName = lookup.getDisplay(id).trim() + "/" + Msg.translate(m_language, ycol.getAD_Column()
-						.getColumnName());
-
-				StringBuilder axisWhere = new StringBuilder(" ");
+					
+				}
+				//	For all
+				for (int recordId : getAxisRecordIds(tableName, whereClause)) {
+					String display = lookup.getDisplay(recordId).trim();
+					String colName = "";
+					String sqlColName = "";
+					if(isSQLAgregate) {
+						colName = display + "/" + Msg.translate(m_language, yColumnName);
+						String joinColumn = Msg.translate(m_language, yColumnName);
+						sqlColName = display + "/" + joinColumn;
+					} else { 
+						colName = display;
+						sqlColName = display;
+					}
+					//	
+					StringBuffer select = new StringBuffer(axisSql);
+					if(isSQLAgregate) {
+						StringBuilder axisWhere = new StringBuilder(" ");
 						axisWhere.append(getAxisSQLWhere(ycol))
-						.append(" AND ")
-						.append(xcol.getAD_View_Definition().getTableAlias()).append(".")
-						.append(xcol.getAD_Column().getColumnName());
+							.append(" AND ")
+							.append(xcol.getAD_View_Definition().getTableAlias()).append(".")
+							.append(xcol.getAD_Column().getColumnName());
 
-				StringBuffer select = new StringBuffer();
-				select.append(axisSql).append(axisWhere);
-				select.append("=").append(id).append(")");
-
-				MViewColumn viewColumn = new MViewColumn(field.getCtx() , 0 , field.get_TrxName());
-				MViewColumn.copyValues((MViewColumn) ycol, viewColumn);
-				viewColumn.setAD_View_Column_ID(ycol.getAD_View_Column_ID());
-				viewColumn.setAD_Column_ID(ycol.getAD_Column_ID());
-				viewColumn.setColumnSQL(select.toString());
-				viewColumn.setColumnName("\"" + sqlColName + "\"");
-
-				MBrowseField browseField = new MBrowseField((MBrowse)field.getAD_Browse() , viewColumn);
-				browseField.setAD_Browse_ID(field.getAD_Browse_ID());
-				browseField.setAD_Element_ID(field.getAD_Element_ID());
-				browseField.setName(colName);
-				browseField.setDescription(viewColumn.getDescription());
-				browseField.setHelp(viewColumn.getHelp());
-				if (viewColumn.get_ID() > 0)
-					browseField.setAD_View_Column_ID(viewColumn.getAD_View_Column_ID());
-				browseField.setIsActive(true);
-				browseField.setIsIdentifier(viewColumn.isIdentifier());
-				browseField.setIsRange(false);
-				browseField.setIsQueryCriteria(false);
-				browseField.setAD_Reference_ID(ycol.getAD_Column().getAD_Reference_ID());
-				browseField.setAD_Reference_Value_ID(ycol.getAD_Column().getAD_Reference_Value_ID());
-				browseField.setIsKey(false);
-				browseField.setIsDisplayed(true);
-				browseField.setAxis_Column_ID(field.getAxis_Column_ID());
-				browseField.setAxis_Parent_Column_ID(field.getAxis_Parent_Column_ID());
-				browseField.setIsReadOnly(field.isReadOnly());
-				browseField.setAD_Element_ID(field.getAD_Element_ID());
-
-				list.add(browseField);
-				log.finest("Added Column=" + sqlColName +  " SQL = " + select);
+						select = new StringBuffer();
+						select.append(axisSql).append(axisWhere);
+						select.append("=").append(recordId).append(")");
+					}
+					
+					MViewColumn viewColumn = new MViewColumn(field.getCtx() , 0 , field.get_TrxName());
+					MViewColumn.copyValues((MViewColumn) ycol, viewColumn);
+					viewColumn.setAD_View_Column_ID(ycol.getAD_View_Column_ID());
+					if(ycol.getAD_Column_ID() > 0) {
+						viewColumn.setAD_Column_ID(ycol.getAD_Column_ID());
+					}
+					//	Replace @Axis_Record_ID@ for record ID
+					viewColumn.setColumnSQL(select.toString().replaceAll("@Axis_Record_ID@", "" + recordId));
+					viewColumn.setColumnName("\"" + sqlColName + "\"");
+					MBrowseField browseField = new MBrowseField((MBrowse)field.getAD_Browse() , viewColumn);
+					browseField.setAD_Browse_ID(field.getAD_Browse_ID());
+					browseField.setAD_Element_ID(field.getAD_Element_ID());
+					browseField.setName(colName);
+					browseField.setDescription(viewColumn.getDescription());
+					browseField.setHelp(viewColumn.getHelp());
+					if (viewColumn.get_ID() > 0)
+						browseField.setAD_View_Column_ID(viewColumn.getAD_View_Column_ID());
+					browseField.setIsActive(true);
+					browseField.setIsIdentifier(field.isIdentifier());
+					browseField.setIsRange(false);
+					browseField.setIsQueryCriteria(false);
+					browseField.setAD_Reference_ID(yReferenceId);
+					browseField.setAD_Reference_Value_ID(yReferenceValueId);
+					browseField.setIsKey(false);
+					browseField.setIsDisplayed(true);
+					browseField.setAxis_Column_ID(field.getAxis_Column_ID());
+					browseField.setAxis_Parent_Column_ID(field.getAxis_Parent_Column_ID());
+					browseField.setIsReadOnly(field.isReadOnly());
+					browseField.setAD_Element_ID(field.getAD_Element_ID());
+					browseField.setColumnNameForSelection(getColumnNameForSelection(tableName, recordId, yColumnName));
+					list.add(browseField);
+					log.finest("Added Column=" + sqlColName +  " SQL = " + select);
+				}
 			}
 
 		} catch (Exception e) {
 			throw new AdempiereException(e);
 		}
 		return list;
+	}
+	
+	/**
+	 * Get Column Name for Selection based on Axis
+	 * @param tableName
+	 * @param recordId
+	 * @param axisColumnName
+	 * @return
+	 */
+	private String getColumnNameForSelection(String tableName, int recordId, String axisColumnName) {
+		String defaultColumn = "Value";
+		String columnName = axisColumnName + "_" + recordId;
+		MTable table = MTable.get(Env.getCtx(), tableName);
+		if(table.getColumn(defaultColumn) != null) {
+			try {
+				PO wrapper = table.getPO(recordId, null);
+				if(wrapper != null
+						&& wrapper.get_ID() > 0) {
+					if(!Util.isEmpty(wrapper.get_ValueAsString(defaultColumn))) {
+						columnName = axisColumnName + "_" + wrapper.get_ValueAsString(defaultColumn).replaceAll(" ", "").trim();
+					}
+				}
+			} catch (Exception e) {
+				log.severe(e.getLocalizedMessage());
+			}
+		}
+		//	Default
+		return columnName;
 	}
 
 	/**

--- a/client/src/org/eevolution/grid/Browser.java
+++ b/client/src/org/eevolution/grid/Browser.java
@@ -1264,7 +1264,7 @@ public abstract class Browser {
 					browseField.setAxis_Parent_Column_ID(field.getAxis_Parent_Column_ID());
 					browseField.setIsReadOnly(field.isReadOnly());
 					browseField.setAD_Element_ID(field.getAD_Element_ID());
-					browseField.setColumnNameForSelection(getColumnNameForSelection(tableName, recordId, yColumnName));
+					browseField.setColumnNameForSelection(yColumnName + "_" + recordId);
 					list.add(browseField);
 					log.finest("Added Column=" + sqlColName +  " SQL = " + select);
 				}
@@ -1274,34 +1274,6 @@ public abstract class Browser {
 			throw new AdempiereException(e);
 		}
 		return list;
-	}
-	
-	/**
-	 * Get Column Name for Selection based on Axis
-	 * @param tableName
-	 * @param recordId
-	 * @param axisColumnName
-	 * @return
-	 */
-	private String getColumnNameForSelection(String tableName, int recordId, String axisColumnName) {
-		String defaultColumn = "Value";
-		String columnName = axisColumnName + "_" + recordId;
-		MTable table = MTable.get(Env.getCtx(), tableName);
-		if(table.getColumn(defaultColumn) != null) {
-			try {
-				PO wrapper = table.getPO(recordId, null);
-				if(wrapper != null
-						&& wrapper.get_ID() > 0) {
-					if(!Util.isEmpty(wrapper.get_ValueAsString(defaultColumn))) {
-						columnName = axisColumnName + "_" + wrapper.get_ValueAsString(defaultColumn).replaceAll(" ", "").trim();
-					}
-				}
-			} catch (Exception e) {
-				log.severe(e.getLocalizedMessage());
-			}
-		}
-		//	Default
-		return columnName;
 	}
 
 	/**


### PR DESCRIPTION
See it:
![Screenshot_20200707_145541](https://user-images.githubusercontent.com/2333092/86829186-1e8b6000-c062-11ea-81a5-2c4fdc6dfada.png)

Currently for a Smart Browser only is possible create dynamic columns based on Decimal Values, a example of it can be showed in **POS Cash Closing Smart** Browser see:
![77452044-d787a080-6dcb-11ea-94d4-64d8ff2a6879](https://user-images.githubusercontent.com/2333092/86828575-6f4e8900-c061-11ea-9358-63536c3169ee.png)

But what happens if I want to show any column type?
I have a change for it. See the gif:
![Peek 2020-07-07 14-54](https://user-images.githubusercontent.com/2333092/86829111-061b4580-c062-11ea-8193-24bf67e77401.gif)
