### PR TITLE
Fix bug on save attachment file

### DIFF
--- a/base/src/org/compiere/model/MAttachment.java
+++ b/base/src/org/compiere/model/MAttachment.java
@@ -523,12 +523,9 @@ public class MAttachment extends X_AD_Attachment
 				}
 			});
 			return true;
-		} else {
-			if(isStoreAttachmentsOnFileSystem){
-				return saveLOBDataToFileSystem();
-			}
-			return saveLOBDataToDB();
 		}
+		
+		return true;
 	}
 	
 	/**
@@ -901,6 +898,13 @@ public class MAttachment extends X_AD_Attachment
 			if (getTitle() == null || !getTitle().equals(ZIP)) {
 				setTitle (ZIP);
 			}
+		}
+		
+		if(!AttachmentUtil.getInstance().isValidForClient(getAD_Client_ID())) {
+			if(isStoreAttachmentsOnFileSystem){
+				return saveLOBDataToFileSystem();
+			}
+			return saveLOBDataToDB();
 		}
 		return super.beforeSave(newRecord);
 	}	//	beforeSave


### PR DESCRIPTION
Currently on save attachment file don't save file to database.

![Attachment](https://user-images.githubusercontent.com/1847863/87091699-1ec56000-c208-11ea-8239-e1745117219b.gif)

Add validation on beforesave method for fix the bug
```
protected boolean beforeSave (boolean newRecord)
	{
		if(isStoreAttachmentsOnFileSystem){
			if (getTitle() == null || !getTitle().equals(XML)) {
				setTitle (XML);
			}
		} else {
			if (getTitle() == null || !getTitle().equals(ZIP)) {
				setTitle (ZIP);
			}
		}
		
		if(!AttachmentUtil.getInstance().isValidForClient(getAD_Client_ID())) {
			if(isStoreAttachmentsOnFileSystem){
				return saveLOBDataToFileSystem();
			}
			return saveLOBDataToDB();
		}
		return super.beforeSave(newRecord);
	}	//	beforeSave
```