### PR TITLE
Fixed error with transaction open and never closed for Trx.run method

### DIFF
--- a/base/src/org/compiere/util/Trx.java
+++ b/base/src/org/compiere/util/Trx.java
@@ -50,6 +50,8 @@ import org.adempiere.exceptions.AdempiereException;
  *  @author Teo Sarca, teo.sarca@gmail.com
  *  		<li>BF [ 2849122 ] PO.AfterSave is not rollback on error - add releaseSavepoint method
  *  			https://sourceforge.net/tracker/index.php?func=detail&aid=2849122&group_id=176962&atid=879332#
+ *  @author Yamel Senih, ysenih@erpya.com, ERPCyA http://www.erpya.com
+ *  		<li>Fixed error with connection without close after throw a exception from Trx.run
  */
 public class Trx implements VetoableChangeListener
 {
@@ -529,44 +531,28 @@ public class Trx implements VetoableChangeListener
 			if (localTrx)
 				trx.commit(true);
 		}
-		catch (Throwable e)
-		{
+		catch (Throwable e) {
 			// Rollback transaction
-			if (localTrx)
-			{
+			if (localTrx) {
 				trx.rollback();
-			}
-			else if (savepoint != null)
-			{
+			} else if (savepoint != null) {
 				try {
 					trx.rollback(savepoint);
 				}
 				catch (SQLException e2) {;}
 			}
-			trx = null;
 			// Throw exception
-			if (e instanceof RuntimeException)
-			{
+			if (e instanceof RuntimeException) {
 				throw (RuntimeException)e;
-			}
-			else
-			{
+			} else {
 				throw new AdempiereException(e);
 			}
 		}
 		finally {
-			if (localTrx && trx != null)
-			{
+			if (localTrx && trx != null) {
 				trx.close();
 				trx = null;
 			}
 		}
-	}
-
-	private boolean isLocalTrx(String trxName)
-	{
-		return trxName == null
-			|| trxName.startsWith("POSave") // TODO: hardcoded
-			;
 	}
 }	//	Trx


### PR DESCRIPTION
Hey guys this is a critical error when a process try run a separed transaction using Trx.run method like this:
## A example of code
```Java
Trx.run(trxName ->
	{
		MOrder order = new MOrder(getCtx(), orderId, trxName);
		log.info(order.toString());
		//
		order.setDocAction(getDocAction());
		if (order.processIt(getDocAction())) {
			order.saveEx();
			addLog(0, null, null, order.getDocumentNo() + ": @OK@");
		} else {
			addLog(0, null, null, order.getDocumentNo() + ": @Error@ " + order.getProcessMsg());
			throw new AdempiereException(order.getDocumentNo() + ": @Error@ " + order.getProcessMsg());
		}
	});
```
Note that if exist a error then is create a throw exception

## Inside Trx.run
when a exception happened then this method should will handle it and close connection:

```Java
public static void run(String trxName, TrxRunnable r)
	{
		boolean localTrx = false;
		if (trxName == null) {
			trxName = Trx.createTrxName("TrxRun");
			localTrx = true;
		}
		Trx trx = Trx.get(trxName, true);
		Savepoint savepoint = null;
		try
		{
			if (!localTrx)
				savepoint = trx.setSavepoint(null);
				
			r.run(trxName);
			
			if (localTrx)
				trx.commit(true);
		}
		catch (Throwable e)
		{
			// Rollback transaction
			if (localTrx)
			{
				trx.rollback();
			}
			else if (savepoint != null)
			{
				try {
					trx.rollback(savepoint);
				}
				catch (SQLException e2) {;}
			}
			trx = null;
			// Throw exception
			if (e instanceof RuntimeException)
			{
				throw (RuntimeException)e;
			}
			else
			{
				throw new AdempiereException(e);
			}
		}
		finally {
			if (localTrx && trx != null)
			{
				trx.close();
				trx = null;
			}
		}
	}
```
## The bug:
Thr finally instruction handle and close transaction but only if is a local transaction and the transaction is not null
```Java
finally {
	if (localTrx && trx != null)
	{
		trx.close();
		trx = null;
	}
}
```
The problem is that before it the transaction is et to null
```Java
catch (Throwable e)
		{
			// Rollback transaction
			if (localTrx)
			{
				trx.rollback();
			}
			else if (savepoint != null)
			{
				try {
					trx.rollback(savepoint);
				}
				catch (SQLException e2) {;}
			}
			trx = null;
			// Throw exception
			if (e instanceof RuntimeException)
			{
				throw (RuntimeException)e;
			}
			else
			{
				throw new AdempiereException(e);
			}
		}
```
## A example
Here a order for process:
![Screenshot_20200726_005758](https://user-images.githubusercontent.com/2333092/88472021-23af3280-cedd-11ea-8c06-9f85be05ea4d.png)

## The result
```
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> DB_PostgreSQL.getCachedConnection: # Connections: 10 , # Busy Connections: 10 , # Idle Connections: 0 , # Orphaned Connections: 0 [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> DB_PostgreSQL.getCachedConnection: # Connections: 13 , # Busy Connections: 11 , # Idle Connections: 2 , # Orphaned Connections: 0 [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> DB_PostgreSQL.getCachedConnection: # Connections: 13 , # Busy Connections: 12 , # Idle Connections: 1 , # Orphaned Connections: 0 [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> DB_PostgreSQL.getCachedConnection: # Connections: 13 , # Busy Connections: 13 , # Idle Connections: 0 , # Orphaned Connections: 0 [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> DB_PostgreSQL.getCachedConnection: # Connections: 15 , # Busy Connections: 14 , # Idle Connections: 1 , # Orphaned Connections: 0 [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
-----------> DB_PostgreSQL.getCachedConnection: # Connections: 15 , # Busy Connections: 15 , # Idle Connections: 0 , # Orphaned Connections: 0 [18]
-----------> OrderBatchProcess.process: Status=DR - Invalid Actions: Process=CL, Doc=CL [18]
```
## A gif of debug
![Peek 2020-07-26 00-56](https://user-images.githubusercontent.com/2333092/88472050-4fcab380-cedd-11ea-89a9-f68c7dbf050f.gif)

This error affect 63 references:
![Screenshot_20200726_212919](https://user-images.githubusercontent.com/2333092/88495329-9543bb00-cf87-11ea-904c-f00cef8a8bff.png)

