### PR TITLE
Fixed error when a po is save using saveReplica instead save

### DIFF
--- a/base/src/org/compiere/model/PO.java
+++ b/base/src/org/compiere/model/PO.java
@@ -2775,7 +2775,7 @@ public abstract class PO
 		columnName = I_AD_Element.COLUMNNAME_UUID;
 		if (p_info.getColumnIndex(columnName) != -1) {
 			String value = get_ValueAsString(columnName);
-			if (Util.isEmpty(value) || !isDirectLoad) {
+			if (Util.isEmpty(value) || (!isDirectLoad && !isReplication())) {
 				value = DB.getUUID(m_trxName);
 				set_ValueNoCheck(columnName, value);
 			}


### PR DESCRIPTION
## The problem
When a replication is enabled for import data from other process the UUID is generated internally instead sed from replication source

## Source
The problem is before save using saveReplica method instead save

```Java
columnName = I_AD_Element.COLUMNNAME_UUID;
if (p_info.getColumnIndex(columnName) != -1) {
	String value = get_ValueAsString(columnName);
	if (Util.isEmpty(value) || !isDirectLoad) {
		value = DB.getUUID(m_trxName);
		set_ValueNoCheck(columnName, value);
	}
}
```

## Patch:
Just add support to replication flag before generate UUID
```Java
columnName = I_AD_Element.COLUMNNAME_UUID;
if (p_info.getColumnIndex(columnName) != -1) {
	String value = get_ValueAsString(columnName);
	if (Util.isEmpty(value) || (!isDirectLoad && !isReplication())) {
		value = DB.getUUID(m_trxName);
		set_ValueNoCheck(columnName, value);
	}
}
```