### PR TITLE
Fixed error with process infom for selection keys:

### DIFF
--- a/base/src/org/compiere/process/ProcessInfo.java
+++ b/base/src/org/compiere/process/ProcessInfo.java
@@ -718,7 +718,8 @@ public class ProcessInfo implements Serializable
 	 */
 	public void setSelectionValues(LinkedHashMap<Integer, LinkedHashMap<String, Object>> selection) {
 		this.selection = selection;
-		setIsSelection(selection != null && selection.size() > 0);
+		setIsSelection(selection != null && selection.size() > 0 
+				|| getSelectionKeys() != null && getSelectionKeys().size() > 0);
 		//	fill key
 		if(selection != null) {
 			List<Integer> keySelection = new ArrayList<Integer>();


### PR DESCRIPTION
Step by Step
- Call a process like Generate Shipments from Order using keys
- See it:

```Java
ProcessBuilder.create(commandReceiver.getCtx())
      	                	.process(InOutGenerate.getProcessId())
      	                	.withTitle(InOutGenerate.getProcessName())
      	                	.withParameter(InOutGenerate.M_WAREHOUSE_ID, sourceOrder.getM_Warehouse_ID())
      	                	.withParameter(InOutGenerate.DOCACTION, DocAction.ACTION_Complete)
      	                	.withSelectedRecordsIds(I_C_Order.Table_ID, Arrays.asList(order.getC_Order_ID()))
      	                	.withoutTransactionClose()
      	                	.execute(trxName);
```

When the process **InOutGenerate** is called, the flag isSelection is false because the selection keys is not used here:
```Java
	/**
	 * 	Generate Shipments
	 *	@return info
	 *	@throws Exception
	 */
	protected String doIt () throws Exception
	{
		log.info("Selection=" + isSelection()
			+ ", M_Warehouse_ID=" + getWarehouseId() 
			+ ", C_BPartner_ID=" + getBPartnerId() 
			+ ", Consolidate=" + isConsolidateDocument()
			+ ", IsUnconfirmed=" + isUnconfirmedInOut()
			+ ", Movement=" + getMovementDate());
		
		if (getWarehouseId() == 0)
			throw new AdempiereUserError("@NotFound@ @M_Warehouse_ID@");
		String message = null;
		if (isSelection()) {	//	VInOutGen
			message = generate(new Query(getCtx(), I_C_Order.Table_Name, 
					"DocStatus='CO' "
					+ "AND IsSOTrx='Y' "
					+ "AND C_Order_ID IN" + getSelectionKeys().toString().replace('[','(').replace(']',')'), get_TrxName())
				.setClient_ID()
				.setOrderBy("M_Warehouse_ID, PriorityRule, M_Shipper_ID, C_BPartner_ID, C_BPartner_Location_ID, C_Order_ID")
				.<MOrder>list());
		} else {
			List<Object> parameters = new ArrayList<>();
			parameters.add(getWarehouseId());
			StringBuffer whereAdded = new StringBuffer("AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.M_Warehouse_ID=?");
			if (getDatePromised() != null) {
				parameters.add(getDatePromised());
				whereAdded.append(" AND TRUNC(ol.DatePromised, 'DD') <= ?");
			}
			whereAdded.append(" AND C_Order.C_Order_ID= ol.C_Order_ID AND ol.QtyOrdered <> ol.QtyDelivered)");
			if (getBPartnerId() != 0) {
				parameters.add(getBPartnerId());
				whereAdded.append(" AND o.C_BPartner_ID = ?");
			}
			message = generate(new Query(getCtx(), I_C_Order.Table_Name, 
					"DocStatus='CO' "
					+ "AND IsSOTrx='Y' "
					+ "AND EXISTS(SELECT 1 FROM C_DocType dt WHERE dt.C_DocType_ID = C_Order.C_DocType_ID AND DocBaseType='SOO' AND DocSubTypeSO NOT IN ('ON','OB','WR')) "
					+ "AND IsDropShip='N' "
					//	No Manual
					+ "AND DeliveryRule<>'M' "
					//	Open Order Lines with Warehouse
					+ whereAdded, get_TrxName())
					.setParameters(parameters)
					.setOrderBy("M_Warehouse_ID, PriorityRule, M_Shipper_ID, C_BPartner_ID, C_BPartner_Location_ID, C_Order_ID")
				.setClient_ID()
				.<MOrder>list());
		}
		return message;
	}	//	doIt
```

The problem is here:

```Java
public void setSelectionValues(LinkedHashMap<Integer, LinkedHashMap<String, Object>> selection) {
		this.selection = selection;
		setIsSelection(selection != null && selection.size() > 0);
		//	fill key
		if(selection != null) {
			List<Integer> keySelection = new ArrayList<Integer>();
			for(Entry<Integer,LinkedHashMap<String, Object>> records : selection.entrySet()) {
				keySelection.add(records.getKey());
			}
			//	Set selections
			if(getSelectionKeys() == null
					|| getSelectionKeys().size() ==0) {
				setSelectionKeys(keySelection);
			}
		}
		//	Save it for DB
		saveSelec
```