### PR TITLE
Fixed errors on tree maintenance

### DIFF
--- a/base/src/org/compiere/model/MElement.java
+++ b/base/src/org/compiere/model/MElement.java
@@ -17,8 +17,10 @@
 package org.compiere.model;
 
 import java.sql.ResultSet;
+import java.util.Optional;
 import java.util.Properties;
 
+import org.compiere.util.CCache;
 import org.compiere.util.Msg;
 
 /**
@@ -34,6 +36,8 @@ public class MElement extends X_C_Element
 	 */
 	private static final long serialVersionUID = 7656092284157893366L;
 
+	private static CCache<Integer,MElement> s_cache = new CCache<Integer,MElement>("C_Element", 10);
+	
 	/**
 	 * 	Standard Constructor
 	 *	@param ctx context
@@ -135,4 +139,14 @@ public class MElement extends X_C_Element
 		return true;
 	}	//	beforeSave
 	
+	
+	public static MElement get (Properties ctx, int C_Element_ID, String trxName)
+	{
+		MElement retValue = Optional.ofNullable((MElement)s_cache.get (C_Element_ID))
+									.orElse(new MElement (ctx, C_Element_ID, trxName));
+		
+		s_cache.put(C_Element_ID, retValue);
+		
+		return retValue;
+	}	//	get	
 }	//	MElement

--- a/base/src/org/compiere/model/MTree.java
+++ b/base/src/org/compiere/model/MTree.java
@@ -717,6 +717,10 @@ public class MTree extends X_AD_Tree
 				&& whereClause.length() > 0)
 			sql.append(" AND ").append(whereClause);
 		//	End Yamel Senih
+		
+		//suppress duplicated items
+		sql.append(" GROUP BY tn.Node_ID,tn.Parent_ID,tn.SeqNo,tb.IsActive ");
+				
 		sql.append(" ORDER BY COALESCE(tn.Parent_ID, -1), tn.SeqNo");
 		log.finest(sql.toString());
 		//  The Node Loop

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/component/ADTreeOnDropListener.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/component/ADTreeOnDropListener.java
@@ -21,6 +21,7 @@ import org.compiere.model.PO;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
+import org.compiere.util.Msg;
 import org.compiere.util.Trx;
 import org.zkoss.zk.ui.event.DropEvent;
 import org.zkoss.zk.ui.event.Event;
@@ -106,18 +107,16 @@ public class ADTreeOnDropListener implements EventListener {
 			Treeitem toItem = tree.renderItemByPath(path);
 			
 			tree.setSelectedItem(toItem);
-			Events.sendEvent(tree, new Event(Events.ON_SELECT, tree));
 			
 			MenuListener listener = new MenuListener(movingNode, toNode);
 			
-			//TODO: translation
 			Menupopup popup = new Menupopup();
-			Menuitem menuItem = new Menuitem("Insert After");
+			Menuitem menuItem = new Menuitem(Msg.translate(Env.getCtx(), "insert.after"));
 			menuItem.setValue("InsertAfter");
 			menuItem.setParent(popup);
 			menuItem.addEventListener(Events.ON_CLICK, listener);
 			
-			menuItem = new Menuitem("Move Into");
+			menuItem = new Menuitem(Msg.translate(Env.getCtx(), "move.into"));
 			menuItem.setValue("MoveInto");
 			menuItem.setParent(popup);
 			menuItem.addEventListener(Events.ON_CLICK, listener);
@@ -192,7 +191,7 @@ public class ADTreeOnDropListener implements EventListener {
 							table.saveEx();
 						}
 					}
-				}else { 
+				}
 				StringBuffer sql = new StringBuffer("UPDATE ");
 					sql.append(mTree.getNodeTableName())
 						.append(" SET Parent_ID=").append(oldMParent.getNode_ID())
@@ -202,7 +201,6 @@ public class ADTreeOnDropListener implements EventListener {
 						.append(" AND Node_ID=").append(md.getNode_ID());
 					log.fine(sql.toString());
 					no = DB.executeUpdate(sql.toString(),trx.getTrxName());
-				}
 			}
 			if (oldParent != newParent) 
 			{
@@ -224,17 +222,17 @@ public class ADTreeOnDropListener implements EventListener {
 								table.saveEx();
 							}
 						}
-					}else {
-						StringBuffer sql = new StringBuffer("UPDATE ");
-						sql.append(mTree.getNodeTableName())
-							.append(" SET Parent_ID=").append(newMParent.getNode_ID())
-							.append(", SeqNo=").append(i)
-							.append(", Updated=SysDate")
-							.append(" WHERE AD_Tree_ID=").append(mTree.getAD_Tree_ID())
-							.append(" AND Node_ID=").append(md.getNode_ID());
-						log.fine(sql.toString());
-						no = DB.executeUpdate(sql.toString(),trx.getTrxName());
 					}
+					StringBuffer sql = new StringBuffer("UPDATE ");
+					sql.append(mTree.getNodeTableName())
+						.append(" SET Parent_ID=").append(newMParent.getNode_ID())
+						.append(", SeqNo=").append(i)
+						.append(", Updated=SysDate")
+						.append(" WHERE AD_Tree_ID=").append(mTree.getAD_Tree_ID())
+						.append(" AND Node_ID=").append(md.getNode_ID());
+					log.fine(sql.toString());
+					no = DB.executeUpdate(sql.toString(),trx.getTrxName());
+				
 				}
 			}
 			//	COMMIT          *********************


### PR DESCRIPTION
Hi, currently exists several errors on tree maintenance creating and moving items of tree, especifically on accounting tree elements.

With this pull request, it's resolve the next problems:

- Duplicities on favourites and recent items.
- Inserting items on same tree for differents account elements.
- Inserting items on differents tree for account elements of distincts tree types.
- Translating on popup for move and insert items of tree for the zk.

Please, check if this solution is applicable

Regards
