### PR TITLE
Add Support to Parent Column on Sort Tab

### DIFF
--- a/base/src/org/adempiere/controller/SortTabController.java
+++ b/base/src/org/adempiere/controller/SortTabController.java
@@ -43,17 +43,28 @@ import org.compiere.util.Language;
 public abstract class SortTabController {
 	
 	/**
-	 * Standard constructor
+	 * Overload Constructor
 	 * @param windowNo
 	 * @param tableId
 	 * @param columnSortOrderId
 	 * @param columnSortYesNoId
 	 */
 	public SortTabController(int windowNo, int tableId, int columnSortOrderId, int columnSortYesNoId) {
+		this(windowNo, tableId, columnSortOrderId, columnSortYesNoId, 0);
+	}
+	/**
+	 * Standard constructor
+	 * @param windowNo
+	 * @param tableId
+	 * @param columnSortOrderId
+	 * @param columnSortYesNoId
+	 */
+	public SortTabController(int windowNo, int tableId, int columnSortOrderId, int columnSortYesNoId, int parentColumn_ID) {
 		this.m_WindowNo = windowNo;
 		this.tableId = tableId;
 		this.columnSortOrderId = columnSortOrderId;
 		this.columnSortYesNoId = columnSortYesNoId;
+		this.m_ParentColumn_ID = parentColumn_ID;
 		//	
 		dynInit();
 	}
@@ -72,6 +83,7 @@ public abstract class SortTabController {
 	private int			m_WindowNo;
 	private String		m_ParentColumnName = null;
 	private boolean 	isReadWrite = true;
+	private int			m_ParentColumn_ID = 0;
 	
 	
 	
@@ -184,6 +196,10 @@ public abstract class SortTabController {
 		if (m_IdentifierTranslated)
 			sql.append(", ").append(tableName).append("_Trl tt");
 		//	Where
+		if (m_ParentColumnName ==null 
+				&& m_ParentColumn_ID!=0)
+			m_ParentColumnName = MColumn.getColumnName(Env.getCtx(), m_ParentColumn_ID);
+		
 		//FR [ 2826406 ]
 		if(m_ParentColumnName != null)
 		{

--- a/base/src/org/compiere/model/GridTab.java
+++ b/base/src/org/compiere/model/GridTab.java
@@ -3083,5 +3083,13 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 	}
 	public int getCurrentCol(){
 		return m_currentCol;
-}
+	}
+	
+	/**
+	 * Get Parent Column
+	 * @return
+	 */
+	public int getParent_Column_ID() {
+		return m_vo.Parent_Column_ID;
+	}
 }	//	GridTab

--- a/client/src/org/compiere/apps/APanel.java
+++ b/client/src/org/compiere/apps/APanel.java
@@ -801,7 +801,7 @@ public final class APanel extends CPanel
 					if (gTab.isSortTab())
 					{
 						VSortTab st = new VSortTab(m_curWindowNo, gTab.getAD_Table_ID(),
-							gTab.getAD_ColumnSortOrder_ID(), gTab.getAD_ColumnSortYesNo_ID());
+							gTab.getAD_ColumnSortOrder_ID(), gTab.getAD_ColumnSortYesNo_ID(), gTab.getParent_Column_ID());
 						st.setTabLevel(gTab.getTabLevel());
 						tabElement = st;
 					}

--- a/client/src/org/compiere/grid/VSortTab.java
+++ b/client/src/org/compiere/grid/VSortTab.java
@@ -83,6 +83,16 @@ public class VSortTab extends CPanel implements APanelTab {
 	private static final long serialVersionUID = -2133358506913610514L;
 
 	/**
+	 * Overload Constructor
+	 * @param windowNo
+	 * @param tableId
+	 * @param columnSortOrderId
+	 * @param columnSortYesNoId
+	 */
+	public VSortTab(int windowNo, int tableId, int columnSortOrderId, int columnSortYesNoId) {
+		this(windowNo, tableId, columnSortOrderId, columnSortYesNoId, 0);
+	}
+	/**
 	 *	Tab Order Constructor
 	 *
 	 *  @param WindowNo Window No
@@ -90,11 +100,11 @@ public class VSortTab extends CPanel implements APanelTab {
 	 *  @param AD_ColumnSortOrder_ID Sort Column
 	 *  @param AD_ColumnSortYesNo_ID YesNo Column
 	 */
-	public VSortTab(int windowNo, int tableId, int columnSortOrderId, int columnSortYesNoId) {
+	public VSortTab(int windowNo, int tableId, int columnSortOrderId, int columnSortYesNoId, int parentColumnId) {
 		log.config("SortOrder=" + columnSortOrderId + ", SortYesNo=" + columnSortYesNoId);
 		this.windowNo = windowNo;
 		try {
-			sortTabController = new SortTabController(windowNo, tableId, columnSortOrderId, columnSortYesNoId) {
+			sortTabController = new SortTabController(windowNo, tableId, columnSortOrderId, columnSortYesNoId, parentColumnId) {
 				
 				@Override
 				public void addItem(ListElement item) {

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/panel/WSortTab.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/panel/WSortTab.java
@@ -512,7 +512,7 @@ public class WSortTab extends Panel implements IADTabPanel {
 		{
 			init();
 			sortTabController = new SortTabController(windowNo, gridTab.getAD_Table_ID(), 
-					gridTab.getAD_ColumnSortOrder_ID(), gridTab.getAD_ColumnSortYesNo_ID()) {
+					gridTab.getAD_ColumnSortOrder_ID(), gridTab.getAD_ColumnSortYesNo_ID(), gridTab.getParent_Column_ID()) {
 				
 				@Override
 				public void addItem(ListElement item) {


### PR DESCRIPTION
Currently, the sort tab only filter records by parent link column, even being available the parent column on sort tab definition.

My purpose is support the parent column of the tab if this is defined.

View this example:

Table definition to be sorted:
![image](https://user-images.githubusercontent.com/1847863/89577669-07759480-d7ff-11ea-86f9-ab01a63abdeb.png)

Table definition for filter table sorted:
![image](https://user-images.githubusercontent.com/1847863/89577843-473c7c00-d7ff-11ea-81d3-3388f9623adc.png)

Window definition for sorted records
![image](https://user-images.githubusercontent.com/1847863/89577953-6f2bdf80-d7ff-11ea-8952-c45dd73fc501.png)

Use this parent column instead of parent link column on table sorted definition.
![image](https://user-images.githubusercontent.com/1847863/89578206-cc279580-d7ff-11ea-8ea0-79bfdd4ba802.png)
![image](https://user-images.githubusercontent.com/1847863/89578506-38a29480-d800-11ea-84e7-72b2d19f756b.png)
If the parent column on the tab is not defined use the parent link column defined on the table.

Final sorted window:
![image](https://user-images.githubusercontent.com/1847863/89579230-6b995800-d801-11ea-8751-cb82d05bc6a1.png)
![image](https://user-images.githubusercontent.com/1847863/89579308-8ec40780-d801-11ea-8104-9482776f0012.png)
![image](https://user-images.githubusercontent.com/1847863/89579364-a56a5e80-d801-11ea-8d83-24acc5b49d6e.png)


