### PR TITLE
Fixed error with dependences when a column is changed

### DIFF
--- a/db/ddlutils/postgresql/functions/get_all_views.sql
+++ b/db/ddlutils/postgresql/functions/get_all_views.sql
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION get_all_views(tablename varchar)  
+RETURNS TABLE (
+    view_name varchar, 
+    view_oid integer,
+    level integer
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY SELECT dependent_view.relname as view_name, dependent_view.oid, dependent_view.level FROM (WITH RECURSIVE views AS (
+				   -- get the directly depending views
+				   SELECT v.oid::regclass AS view,
+				          1 AS level, v.oid
+				   FROM pg_depend AS d
+				      JOIN pg_rewrite AS r
+				         ON r.oid = d.objid
+				      JOIN pg_class AS v
+				         ON v.oid = r.ev_class
+				   WHERE v.relkind = 'v'
+				     AND d.classid = 'pg_rewrite'::regclass
+				     AND d.refclassid = 'pg_class'::regclass
+				     AND d.deptype = 'n'
+				     AND d.refobjid = lower(tablename)::regclass
+				UNION ALL
+				   -- add the views that depend on these
+				   SELECT v.oid::regclass,
+				          views.level + 1, v.oid
+				   FROM views
+				      JOIN pg_depend AS d
+				         ON d.refobjid = views.view
+				      JOIN pg_rewrite AS r  
+				         ON r.oid = d.objid
+				      JOIN pg_class AS v    
+				         ON v.oid = r.ev_class
+				   WHERE v.relkind = 'v'   
+				     AND d.classid = 'pg_rewrite'::regclass
+				     AND d.refclassid = 'pg_class'::regclass
+				     AND d.deptype = 'n'   
+				     AND v.oid <> views.view  -- avoid loop
+				)
+				SELECT e.view::varchar as relname, e.oid::integer as oid, e.level::integer as level
+				FROM views e
+				GROUP BY e.view, e.oid, e.level
+				ORDER BY e.level DESC) as dependent_view;
+END $$;

--- a/migration/393lts-394lts/06420_Fixed_Error_with_Dependences_Alter_Column.xml
+++ b/migration/393lts-394lts/06420_Fixed_Error_with_Dependences_Alter_Column.xml
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="ECA02" Name="Allows change column definition" ReleaseNo="3.9.4" SeqNo="6420">
+    <Step DBType="Postgres" Parse="N" SeqNo="10" StepType="SQL">
+      <SQLStatement>CREATE OR REPLACE FUNCTION get_all_views(tablename varchar)  
+RETURNS TABLE (
+    view_name varchar, 
+    view_oid integer,
+    level integer
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RETURN QUERY SELECT dependent_view.relname as view_name, dependent_view.oid, dependent_view.level FROM (WITH RECURSIVE views AS (
+				   -- get the directly depending views
+				   SELECT v.oid::regclass AS view,
+				          1 AS level, v.oid
+				   FROM pg_depend AS d
+				      JOIN pg_rewrite AS r
+				         ON r.oid = d.objid
+				      JOIN pg_class AS v
+				         ON v.oid = r.ev_class
+				   WHERE v.relkind = 'v'
+				     AND d.classid = 'pg_rewrite'::regclass
+				     AND d.refclassid = 'pg_class'::regclass
+				     AND d.deptype = 'n'
+				     AND d.refobjid = lower(tablename)::regclass
+				UNION ALL
+				   -- add the views that depend on these
+				   SELECT v.oid::regclass,
+				          views.level + 1, v.oid
+				   FROM views
+				      JOIN pg_depend AS d
+				         ON d.refobjid = views.view
+				      JOIN pg_rewrite AS r  
+				         ON r.oid = d.objid
+				      JOIN pg_class AS v    
+				         ON v.oid = r.ev_class
+				   WHERE v.relkind = 'v'   
+				     AND d.classid = 'pg_rewrite'::regclass
+				     AND d.refclassid = 'pg_class'::regclass
+				     AND d.deptype = 'n'   
+				     AND v.oid &lt;&gt; views.view  -- avoid loop
+				)
+				SELECT e.view::varchar as relname, e.oid::integer as oid, e.level::integer as level
+				FROM views e
+				GROUP BY e.view, e.oid, e.level
+				ORDER BY e.level DESC) as dependent_view;
+END $$;</SQLStatement>
+      <RollbackStatement>DROP FUNCTION get_all_views</RollbackStatement>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="20" StepType="SQL">
+      <SQLStatement>DROP TABLE IF EXISTS t_alter_column;</SQLStatement>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="30" StepType="SQL">
+      <SQLStatement>create or replace function altercolumn(tablename name, columnname name, datatype name,
+nullclause varchar, defaultclause varchar) returns void as $$
+declare
+   command text;
+   viewtext text[];
+   viewname name[];
+   dropviews name[];
+   i int;
+   j int;
+   v record;
+   sqltype       text;
+   sqltype_short text;
+   typename name;
+begin
+   if datatype is not null then
+	select pg_type.typname, format_type(pg_type.oid, pg_attribute.atttypmod)
+        into typename, sqltype
+        from pg_class, pg_attribute, pg_type
+        where relname = lower(tablename)
+        and relkind = 'r'
+        and pg_class.oid = pg_attribute.attrelid
+        and attname = lower(columnname)
+        and atttypid = pg_type.oid;
+        sqltype_short := sqltype;
+        if typename = 'numeric' then
+	   sqltype_short := replace(sqltype, ',0', '');
+        elsif strpos(sqltype,'character varying') = 1 then
+	   sqltype_short := replace(sqltype, 'character varying', 'varchar');
+        elsif sqltype = 'timestamp without time zone' then
+           sqltype_short := 'timestamp';
+        end if;
+        if lower(datatype) &lt;&gt; sqltype and lower(datatype) &lt;&gt; sqltype_short then
+		i := 0;
+		for v in SELECT a.view_name as relname, a.view_oid as oid FROM get_all_views(tablename::varchar) as a
+		 loop
+		    i := i + 1;
+		    viewtext[i] := pg_get_viewdef(v.oid);
+		    viewname[i] := v.relname;
+		end loop;
+		if i &gt; 0 then
+		   begin
+		     for j in 1 .. i loop
+		        command := 'drop view ' || viewname[j];
+		        raise notice 'drop view %', viewname[j];
+		        execute command;
+		        dropviews[j] := viewname[j];
+		     end loop;
+                     exception
+                        when others then
+                          i := array_upper(dropviews, 1);
+                          if i &gt; 0 then
+                             for j in i .. 1 loop
+                             	raise notice 'create or replace view %', dropviews[j];
+                                command := 'create or replace view ' || dropviews[j] || ' as ' || viewtext[j];
+		                execute command;
+                             end loop;
+                          end if;
+                          raise exception 'Failed to recreate dependent view';
+                   end;
+		end if;
+		raise notice 'alter table % alter column % type %', lower(tablename), lower(columnname), lower(datatype);
+		command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' type ' || lower(datatype);
+		execute command;
+                i := array_upper(dropviews, 1);
+		if i &gt; 0 then
+		   for j in REVERSE i .. 1 loop
+		     raise notice 'create or replace view %', dropviews[j];
+		     command := 'create or replace view ' || dropviews[j] || ' as ' || viewtext[j];
+		     execute command;
+		   end loop;
+		end if;
+        end if;
+   end if;
+   
+   if defaultclause is not null then
+       if lower(defaultclause) = 'null' then
+	      raise notice 'alter table % alter column % drop default ', lower(tablename), lower(columnname);
+          command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' drop default ';
+       else
+      raise notice 'alter table % alter column % set default %', lower(tablename), lower(columnname), defaultclause;
+	  command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' set default ''' || defaultclause || '''';
+       end if;
+       execute command;
+   end if;
+   
+   if nullclause is not null then
+      if lower(nullclause) = 'not null' then
+	      raise notice 'alter table % alter column % set not null ', lower(tablename), lower(columnname);
+          command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' set not null';
+          execute command;
+      elsif lower(nullclause) = 'null' then
+      	  raise notice 'alter table % alter column % drop not null ', lower(tablename), lower(columnname);
+          command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' drop not null';
+          execute command;
+      end if;
+   end if;
+end;
+$$ language plpgsql;</SQLStatement>
+      <RollbackStatement>create or replace function altercolumn(tablename name, columnname name, datatype name,
+nullclause varchar, defaultclause varchar) returns void as $$
+declare
+   command text;
+   viewtext text[];
+   viewname name[];
+   dropviews name[];
+   i int;
+   j int;
+   v record;
+   sqltype       text;
+   sqltype_short text;
+   typename name;
+begin
+   if datatype is not null then
+	select pg_type.typname, format_type(pg_type.oid, pg_attribute.atttypmod)
+        into typename, sqltype
+        from pg_class, pg_attribute, pg_type
+        where relname = lower(tablename)
+        and relkind = 'r'
+        and pg_class.oid = pg_attribute.attrelid
+        and attname = lower(columnname)
+        and atttypid = pg_type.oid;
+        sqltype_short := sqltype;
+        if typename = 'numeric' then
+	   sqltype_short := replace(sqltype, ',0', '');
+        elsif strpos(sqltype,'character varying') = 1 then
+	   sqltype_short := replace(sqltype, 'character varying', 'varchar');
+        elsif sqltype = 'timestamp without time zone' then
+           sqltype_short := 'timestamp';
+        end if;
+        if lower(datatype) &lt;&gt; sqltype and lower(datatype) &lt;&gt; sqltype_short then
+		i := 0;
+		for v in select a.relname, a.oid 
+			from pg_class a, pg_depend b, pg_depend c, pg_class d, pg_attribute e
+			where a.oid = b.refobjid
+			and b.objid = c.objid
+			and b.refobjid &lt;&gt; c.refobjid
+			and b.deptype = 'n'
+			and c.refobjid = d.oid
+			and d.relname = lower(tablename)
+			and d.relkind = 'r'
+			and d.oid = e.attrelid
+			and e.attname = lower(columnname)
+			and c.refobjsubid = e.attnum
+			and a.relkind = 'v'
+		 loop
+		    i := i + 1;
+		    viewtext[i] := pg_get_viewdef(v.oid);
+		    viewname[i] := v.relname;
+		end loop;
+		if i &gt; 0 then
+		   begin
+		     for j in 1 .. i loop
+		        command := 'drop view ' || viewname[j];
+		        execute command;
+		        dropviews[j] := viewname[j];
+		     end loop;
+                     exception
+                        when others then
+                          i := array_upper(dropviews, 1);
+                          if i &gt; 0 then
+                             for j in 1 .. i loop
+                                command := 'create or replace view ' || dropviews[j] || ' as ' || viewtext[j];
+		                execute command;
+                             end loop;
+                          end if;
+                          raise exception 'Failed to recreate dependent view';
+                   end;
+		end if;
+		command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' type ' || lower(datatype);
+		execute command;
+                i := array_upper(dropviews, 1);
+		if i &gt; 0 then
+		   for j in 1 .. i loop
+		     command := 'create or replace view ' || dropviews[j] || ' as ' || viewtext[j];
+		     execute command;
+		   end loop;
+		end if;
+        end if;
+   end if;
+   
+   if defaultclause is not null then
+       if lower(defaultclause) = 'null' then
+          command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' drop default ';
+       else
+	  command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' set default ''' || defaultclause || '''';
+       end if;
+       execute command;
+   end if;
+   
+   if nullclause is not null then
+      if lower(nullclause) = 'not null' then
+          command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' set not null';
+          execute command;
+      elsif lower(nullclause) = 'null' then
+          command := 'alter table ' || lower(tablename) || ' alter column ' || lower(columnname) || ' drop not null';
+          execute command;
+      end if;
+   end if;
+end;
+$$ language plpgsql;</RollbackStatement>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="40" StepType="SQL">
+      <SQLStatement>create table t_alter_column
+( tablename name, columnname name, datatype name, nullclause varchar(10), defaultclause varchar(200));</SQLStatement>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="50" StepType="SQL">
+      <SQLStatement>create rule alter_column_rule as on insert to t_alter_column
+do instead select altercolumn(new.tablename, new.columnname, new.datatype, new.nullclause,
+new.defaultclause);</SQLStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
## The problem:
When a column definition is changed, example **C_Invoice.Description** and the table have dependences with view, only is used the first level for recereate views but if the table have more than one level the synchronization throw a error like this:
```Java
===========> DB.executeUpdate: INSERT INTO t_alter_column values('c_invoice','Description','TEXT',null,'NULL') [SvrProcess_2942fe33-6d68-4844-8b37-b762037ce560] [59]
org.postgresql.util.PSQLException: ERROR: Failed to recreate dependent view
  Where: PL/pgSQL function altercolumn(name,name,name,character varying,character varying) line 67 at RAISE; State=P0001; ErrorCode=0
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2497)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2233)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:310)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:446)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:370)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:149)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:124)
	at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeUpdate(NewProxyPreparedStatement.java:105)
	at sun.reflect.GeneratedMethodAccessor27.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
	at com.sun.proxy.$Proxy2.executeUpdate(Unknown Source)
	at org.compiere.util.DB.executeUpdate(DB.java:1044)
	at org.compiere.util.DB.executeUpdate(DB.java:1016)
	at org.compiere.util.DB.executeUpdateMultiple(DB.java:1150)
	at org.compiere.model.MColumn.syncDatabase(MColumn.java:1096)
	at org.compiere.model.MColumn.syncDatabase(MColumn.java:868)
	at org.compiere.model.MColumn.syncDatabase(MColumn.java:864)
	at org.compiere.process.ColumnSync.doIt(ColumnSync.java:78)
	at org.compiere.process.SvrProcess.process(SvrProcess.java:177)
	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:130)

===========> DB.saveError: DBExecuteError - ERROR: Failed to recreate dependent view
  Where: PL/pgSQL function altercolumn(name,name,name,character varying,character varying) line 67 at RAISE [59]
```

Here a gif:
![Peek 2020-08-07 15-11](https://user-images.githubusercontent.com/2333092/89681824-b11e5980-d8c3-11ea-8af2-0d7034199bbc.gif)

## Cause:
C_Invoice table have many dependences with many levels:
- C_Invoice
  - RV_C_Invoice

A simple query:
```SQL
          view_name           | level 
------------------------------+-------
 c_dunning_line_v             |     1
 rv_unposted                  |     1
 rv_invoice_createfrom        |     1
 rv_inout_createfrom          |     1
 rv_fm_loanamortization       |     1
 rv_commissionrundetail       |     1
 rv_c_invoicetax              |     1
 rv_c_invoice                 |     1
 rv_c_bankstatement           |     1
 c_payselection_remittance_vt |     1
 c_payselection_remittance_v  |     1
 c_invoice_v1                 |     1
 c_invoice_v                  |     1
 c_invoice_linetax_vt         |     1
 c_invoice_linetax_v          |     1
 c_invoice_header_vt          |     1
 c_invoice_header_v           |     1
 c_dunning_line_vt            |     1
 t_invoicegl_vt               |     1
 t_invoicegl_v                |     1
 rv_wm_inoutbounddetail       |     1
 rv_unprocessed               |     1
 rv_openitem                  |     2
 rv_fm_openloan               |     2
 rv_combinedopenitem          |     2
 rv_c_invoiceline             |     2
 rv_bpartneropen              |     2
 c_invoiceline_v              |     2
 rv_openitemtodate            |     2
 rv_c_invoice_customervendqtr |     3
 rv_c_invoice_customerprodqtr |     3
 rv_c_invoice_vendormonth     |     3
 rv_c_invoice_week            |     3
 rv_c_invoice_prodweek        |     3
 rv_c_invoice_productqtr      |     3
 rv_c_invoice_productmonth    |     3
 rv_c_invoice_prodmonth       |     3
 rv_c_invoice_month           |     3
 rv_c_invoice_day             |     3
(39 rows)
```
The problem is with **altercolumn** function.

## Solution:
Just implement a recursive query for get all dependence and definitions for table.

Here a result after change:
 
![Peek 2020-08-07 15-20](https://user-images.githubusercontent.com/2333092/89681711-76b4bc80-d8c3-11ea-9193-6d59df6268ff.gif)

## A Test
```SQL
#SQL=# INSERT INTO t_alter_column values('c_invoice','Description','TEXT',null,'NULL');
NOTICE:  drop view rv_c_invoice_customerprodqtr
NOTICE:  drop view rv_c_invoice_customervendqtr
NOTICE:  drop view rv_c_invoice_day
NOTICE:  drop view rv_c_invoice_month
NOTICE:  drop view rv_c_invoice_prodmonth
NOTICE:  drop view rv_c_invoice_productmonth
NOTICE:  drop view rv_c_invoice_productqtr
NOTICE:  drop view rv_c_invoice_prodweek
NOTICE:  drop view rv_c_invoice_vendormonth
NOTICE:  drop view rv_c_invoice_week
NOTICE:  drop view c_invoiceline_v
NOTICE:  drop view rv_bpartneropen
NOTICE:  drop view rv_c_invoiceline
NOTICE:  drop view rv_combinedopenitem
NOTICE:  drop view rv_fm_openloan
NOTICE:  drop view rv_openitem
NOTICE:  drop view rv_openitemtodate
NOTICE:  drop view c_dunning_line_v
NOTICE:  drop view c_dunning_line_vt
NOTICE:  drop view c_invoice_header_v
NOTICE:  drop view c_invoice_header_vt
NOTICE:  drop view c_invoice_linetax_v
NOTICE:  drop view c_invoice_linetax_vt
NOTICE:  drop view c_invoice_v
NOTICE:  drop view c_invoice_v1
NOTICE:  drop view c_payselection_remittance_v
NOTICE:  drop view c_payselection_remittance_vt
NOTICE:  drop view rv_c_bankstatement
NOTICE:  drop view rv_c_invoice
NOTICE:  drop view rv_c_invoicetax
NOTICE:  drop view rv_commissionrundetail
NOTICE:  drop view rv_fm_loanamortization
NOTICE:  drop view rv_inout_createfrom
NOTICE:  drop view rv_invoice_createfrom
NOTICE:  drop view rv_unposted
NOTICE:  drop view rv_unprocessed
NOTICE:  drop view rv_wm_inoutbounddetail
NOTICE:  drop view t_invoicegl_v
NOTICE:  drop view t_invoicegl_vt
NOTICE:  alter table c_invoice alter column description type text
NOTICE:  create or replace view t_invoicegl_vt
NOTICE:  create or replace view t_invoicegl_v
NOTICE:  create or replace view rv_wm_inoutbounddetail
NOTICE:  create or replace view rv_unprocessed
NOTICE:  create or replace view rv_unposted
NOTICE:  create or replace view rv_invoice_createfrom
NOTICE:  create or replace view rv_inout_createfrom
NOTICE:  create or replace view rv_fm_loanamortization
NOTICE:  create or replace view rv_commissionrundetail
NOTICE:  create or replace view rv_c_invoicetax
NOTICE:  create or replace view rv_c_invoice
NOTICE:  create or replace view rv_c_bankstatement
NOTICE:  create or replace view c_payselection_remittance_vt
NOTICE:  create or replace view c_payselection_remittance_v
NOTICE:  create or replace view c_invoice_v1
NOTICE:  create or replace view c_invoice_v
NOTICE:  create or replace view c_invoice_linetax_vt
NOTICE:  create or replace view c_invoice_linetax_v
NOTICE:  create or replace view c_invoice_header_vt
NOTICE:  create or replace view c_invoice_header_v
NOTICE:  create or replace view c_dunning_line_vt
NOTICE:  create or replace view c_dunning_line_v
NOTICE:  create or replace view rv_openitemtodate
NOTICE:  create or replace view rv_openitem
NOTICE:  create or replace view rv_fm_openloan
NOTICE:  create or replace view rv_combinedopenitem
NOTICE:  create or replace view rv_c_invoiceline
NOTICE:  create or replace view rv_bpartneropen
NOTICE:  create or replace view c_invoiceline_v
NOTICE:  create or replace view rv_c_invoice_week
NOTICE:  create or replace view rv_c_invoice_vendormonth
NOTICE:  create or replace view rv_c_invoice_prodweek
NOTICE:  create or replace view rv_c_invoice_productqtr
NOTICE:  create or replace view rv_c_invoice_productmonth
NOTICE:  create or replace view rv_c_invoice_prodmonth
NOTICE:  create or replace view rv_c_invoice_month
NOTICE:  create or replace view rv_c_invoice_day
NOTICE:  create or replace view rv_c_invoice_customervendqtr
NOTICE:  create or replace view rv_c_invoice_customerprodqtr
NOTICE:  alter table c_invoice alter column description drop default 
 altercolumn 
-------------
 
(1 row)
```