### PR TITLE
Fixed error with Replenish Warehouse when a product not have storage

### DIFF
--- a/db/ddlutils/oracle/views/RV_M_Replenish.sql
+++ b/db/ddlutils/oracle/views/RV_M_Replenish.sql
@@ -76,11 +76,11 @@ FROM (SELECT r.AD_Client_ID,
         COALESCE(CASE
             WHEN r.ReplenishType = '1' THEN 
                 CASE 
-                    WHEN s.QtyOnHand - s.QtyReserved + s.QtyOrdered <= r.Level_Min 
-                    THEN r.Level_Max - s.QtyOnHand + s.QtyReserved - s.QtyOrdered 
+                    WHEN COALESCE(s.QtyOnHand, 0) - COALESCE(s.QtyReserved, 0) + COALESCE(s.QtyOrdered, 0) <= r.Level_Min 
+                    THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0) 
                     ELSE 0 
                 END
-            WHEN r.ReplenishType = '2' THEN r.Level_Max - s.QtyOnHand + s.QtyReserved - s.QtyOrdered
+            WHEN r.ReplenishType = '2' THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0)
             ELSE 0
         END, 0) AS QtyToOrder,
         p.M_Product_Category_ID,

--- a/db/ddlutils/postgresql/views/RV_M_Replenish.sql
+++ b/db/ddlutils/postgresql/views/RV_M_Replenish.sql
@@ -76,11 +76,11 @@ FROM (SELECT r.AD_Client_ID,
         COALESCE(CASE
             WHEN r.ReplenishType = '1' THEN 
                 CASE 
-                    WHEN s.QtyOnHand - s.QtyReserved + s.QtyOrdered <= r.Level_Min 
-                    THEN r.Level_Max - s.QtyOnHand + s.QtyReserved - s.QtyOrdered 
+                    WHEN COALESCE(s.QtyOnHand, 0) - COALESCE(s.QtyReserved, 0) + COALESCE(s.QtyOrdered, 0) <= r.Level_Min 
+                    THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0) 
                     ELSE 0 
                 END
-            WHEN r.ReplenishType = '2' THEN r.Level_Max - s.QtyOnHand + s.QtyReserved - s.QtyOrdered
+            WHEN r.ReplenishType = '2' THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0)
             ELSE 0
         END, 0) AS QtyToOrder,
         p.M_Product_Category_ID,

--- a/migration/393lts-394lts/06450_Fixed_Error_with_Replenish_Browser.xml
+++ b/migration/393lts-394lts/06450_Fixed_Error_with_Replenish_Browser.xml
@@ -1,0 +1,445 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="ECA02" Name="Fixed Error with Replenish Browser" ReleaseNo="3.9.4" SeqNo="6450">
+    <Step DBType="Postgres" Parse="N" SeqNo="10" StepType="SQL">
+      <SQLStatement>-- View: RV_M_Replenish
+-- DROP VIEW RV_M_Replenish;
+/******************************************************************************
+ * Product: Adempiere ERP &amp; CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2015 E.R.P. Consultores y Asociados, C.A.               *
+ * All Rights Reserved.                                                       *
+ * Contributor(s): Yamel Senih www.erpya.com                                  *
+ ******************************************************************************
+ ***
+ * Title:	Warehouse Replenish
+ * Description:
+ *	Show all products for replenish
+ *
+ * Test:
+ * 	SELECT * FROM RV_Replenish WHERE M_Warehouse_ID=103;
+ ******************************************************************************/
+CREATE OR REPLACE VIEW RV_M_Replenish AS
+SELECT r.AD_Client_ID, 
+    r.AD_Org_ID, 
+    r.M_Product_ID, 
+    r.ReplenishType,                                                                                                                                                                                                                                                         
+    r.Level_Min,  
+    r.Level_Max,   
+    r.QtyAvailable,  
+    r.QtyOnHand,  
+    r.QtyReserved,  
+    r.QtyOrdered,
+    CASE 
+    	WHEN r.Order_Pack &gt; 0 AND MOD(CASE 
+    				WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    				THEN r.Order_Min 
+    				ELSE r.QtyToOrder 
+    			END, r.Order_Pack) &lt;&gt; 0 AND r.QtyToOrder &gt; 0 
+    	THEN CASE 
+    			WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    			THEN r.Order_Min 
+    			ELSE r.QtyToOrder 
+    		END - MOD(CASE 
+    					WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    					THEN r.Order_Min 
+    					ELSE r.QtyToOrder 
+    				END, r.Order_Pack) + r.Order_Pack 
+    	ELSE r.QtyToOrder 
+    END AS QtyToOrder,  
+    r.M_Product_Category_ID,
+    r.M_Product_Group_ID,
+    r.M_Product_Class_ID,
+    r.M_Product_Classification_ID,
+    r.C_UOM_ID,
+    r.M_Locator_ID,
+    r.M_Warehouse_ID, 
+    r.M_WarehouseSource_ID,
+    r.C_BPartner_ID, 
+    r.Order_Min, 
+    r.Order_Pack
+FROM (SELECT r.AD_Client_ID, 
+        r.AD_Org_ID, 
+        r.M_Product_ID, 
+        r.ReplenishType,
+        COALESCE(r.Level_Min, 0) AS Level_Min, 
+    	COALESCE(r.Level_Max, 0) AS Level_Max,  
+    	COALESCE(s.QtyAvailable, 0) AS QtyAvailable, 
+    	COALESCE(s.QtyOnHand, 0) AS QtyOnHand, 
+    	COALESCE(s.QtyReserved, 0) AS QtyReserved, 
+    	COALESCE(s.QtyOrdered, 0) AS QtyOrdered, 
+        COALESCE(CASE
+            WHEN r.ReplenishType = '1' THEN 
+                CASE 
+                    WHEN COALESCE(s.QtyOnHand, 0) - COALESCE(s.QtyReserved, 0) + COALESCE(s.QtyOrdered, 0) &lt;= r.Level_Min 
+                    THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0) 
+                    ELSE 0 
+                END
+            WHEN r.ReplenishType = '2' THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0)
+            ELSE 0
+        END, 0) AS QtyToOrder,
+        p.M_Product_Category_ID,
+        p.M_Product_Group_ID,
+        p.M_Product_Class_ID,
+        p.M_Product_Classification_ID,
+        p.C_UOM_ID,
+        r.M_Locator_ID,
+        r.M_Warehouse_ID, 
+        r.M_WarehouseSource_ID,
+        po.C_BPartner_ID, 
+        COALESCE(po.Order_Min, 0) AS Order_Min, 
+        COALESCE(po.Order_Pack, 0) AS Order_Pack
+    FROM M_Replenish r
+    INNER JOIN M_Product p ON(p.M_Product_ID = r.M_Product_ID)
+    LEFT JOIN M_Product_PO po ON(po.M_Product_ID = r.M_Product_ID AND po.IsActive = 'Y' AND po.IsCurrentVendor = 'Y')
+    LEFT JOIN (SELECT s.M_Product_ID, 
+                SUM(s.QtyOnHand) AS QtyOnHand, 
+                SUM(s.QtyOrdered) AS QtyOrdered, 
+                SUM(s.QtyReserved) AS QtyReserved, 
+                SUM(s.QtyAvailable) AS QtyAvailable 
+            FROM RV_Storage s
+            GROUP BY s.M_Product_ID) s ON(s.M_Product_ID = p.M_Product_ID)
+    WHERE r.IsActive = 'Y' AND p.IsActive = 'Y') r
+WHERE (r.QtyToOrder &gt; 0
+OR (r.ReplenishType IN('0', '9')));</SQLStatement>
+      <RollbackStatement>-- View: RV_M_Replenish
+-- DROP VIEW RV_M_Replenish;
+/******************************************************************************
+ * Product: Adempiere ERP &amp; CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2015 E.R.P. Consultores y Asociados, C.A.               *
+ * All Rights Reserved.                                                       *
+ * Contributor(s): Yamel Senih www.erpya.com                                  *
+ ******************************************************************************
+ ***
+ * Title:	Warehouse Replenish
+ * Description:
+ *	Show all products for replenish
+ *
+ * Test:
+ * 	SELECT * FROM RV_Replenish WHERE M_Warehouse_ID=103;
+ ******************************************************************************/
+CREATE OR REPLACE VIEW RV_M_Replenish AS
+SELECT r.AD_Client_ID, 
+    r.AD_Org_ID, 
+    r.M_Product_ID, 
+    r.ReplenishType,                                                                                                                                                                                                                                                         
+    r.Level_Min,  
+    r.Level_Max,   
+    r.QtyAvailable,  
+    r.QtyOnHand,  
+    r.QtyReserved,  
+    r.QtyOrdered,
+    CASE 
+    	WHEN r.Order_Pack &gt; 0 AND MOD(CASE 
+    				WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    				THEN r.Order_Min 
+    				ELSE r.QtyToOrder 
+    			END, r.Order_Pack) &lt;&gt; 0 AND r.QtyToOrder &gt; 0 
+    	THEN CASE 
+    			WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    			THEN r.Order_Min 
+    			ELSE r.QtyToOrder 
+    		END - MOD(CASE 
+    					WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    					THEN r.Order_Min 
+    					ELSE r.QtyToOrder 
+    				END, r.Order_Pack) + r.Order_Pack 
+    	ELSE r.QtyToOrder 
+    END AS QtyToOrder,  
+    r.M_Product_Category_ID,
+    r.M_Product_Group_ID,
+    r.M_Product_Class_ID,
+    r.M_Product_Classification_ID,
+    r.C_UOM_ID,
+    r.M_Locator_ID,
+    r.M_Warehouse_ID, 
+    r.M_WarehouseSource_ID,
+    r.C_BPartner_ID, 
+    r.Order_Min, 
+    r.Order_Pack
+FROM (SELECT r.AD_Client_ID, 
+        r.AD_Org_ID, 
+        r.M_Product_ID, 
+        r.ReplenishType,
+        COALESCE(r.Level_Min, 0) AS Level_Min, 
+    	COALESCE(r.Level_Max, 0) AS Level_Max,  
+    	COALESCE(s.QtyAvailable, 0) AS QtyAvailable, 
+    	COALESCE(s.QtyOnHand, 0) AS QtyOnHand, 
+    	COALESCE(s.QtyReserved, 0) AS QtyReserved, 
+    	COALESCE(s.QtyOrdered, 0) AS QtyOrdered, 
+        COALESCE(CASE
+            WHEN r.ReplenishType = '1' THEN 
+                CASE 
+                    WHEN s.QtyOnHand - s.QtyReserved + s.QtyOrdered &lt;= r.Level_Min 
+                    THEN r.Level_Max - s.QtyOnHand + s.QtyReserved - s.QtyOrdered 
+                    ELSE 0 
+                END
+            WHEN r.ReplenishType = '2' THEN r.Level_Max - s.QtyOnHand + s.QtyReserved - s.QtyOrdered
+            ELSE 0
+        END, 0) AS QtyToOrder,
+        p.M_Product_Category_ID,
+        p.M_Product_Group_ID,
+        p.M_Product_Class_ID,
+        p.M_Product_Classification_ID,
+        p.C_UOM_ID,
+        r.M_Locator_ID,
+        r.M_Warehouse_ID, 
+        r.M_WarehouseSource_ID,
+        po.C_BPartner_ID, 
+        COALESCE(po.Order_Min, 0) AS Order_Min, 
+        COALESCE(po.Order_Pack, 0) AS Order_Pack
+    FROM M_Replenish r
+    INNER JOIN M_Product p ON(p.M_Product_ID = r.M_Product_ID)
+    LEFT JOIN M_Product_PO po ON(po.M_Product_ID = r.M_Product_ID AND po.IsActive = 'Y' AND po.IsCurrentVendor = 'Y')
+    LEFT JOIN (SELECT s.M_Product_ID, 
+                SUM(s.QtyOnHand) AS QtyOnHand, 
+                SUM(s.QtyOrdered) AS QtyOrdered, 
+                SUM(s.QtyReserved) AS QtyReserved, 
+                SUM(s.QtyAvailable) AS QtyAvailable 
+            FROM RV_Storage s
+            GROUP BY s.M_Product_ID) s ON(s.M_Product_ID = p.M_Product_ID)
+    WHERE r.IsActive = 'Y' AND p.IsActive = 'Y') r
+WHERE (r.QtyToOrder &gt; 0
+OR (r.ReplenishType IN('0', '9')));</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="N" SeqNo="10" StepType="SQL">
+      <SQLStatement>-- View: RV_M_Replenish
+-- DROP VIEW RV_M_Replenish;
+/******************************************************************************
+ * Product: Adempiere ERP &amp; CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2015 E.R.P. Consultores y Asociados, C.A.               *
+ * All Rights Reserved.                                                       *
+ * Contributor(s): Yamel Senih www.erpya.com                                  *
+ ******************************************************************************
+ ***
+ * Title:	Warehouse Replenish
+ * Description:
+ *	Show all products for replenish
+ *
+ * Test:
+ * 	SELECT * FROM RV_Replenish WHERE M_Warehouse_ID=103;
+ ******************************************************************************/
+CREATE OR REPLACE VIEW RV_M_Replenish AS
+SELECT r.AD_Client_ID, 
+    r.AD_Org_ID, 
+    r.M_Product_ID, 
+    r.ReplenishType,                                                                                                                                                                                                                                                         
+    r.Level_Min,  
+    r.Level_Max,   
+    r.QtyAvailable,  
+    r.QtyOnHand,  
+    r.QtyReserved,  
+    r.QtyOrdered,
+    CASE 
+    	WHEN r.Order_Pack &gt; 0 AND MOD(CASE 
+    				WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    				THEN r.Order_Min 
+    				ELSE r.QtyToOrder 
+    			END, r.Order_Pack) &lt;&gt; 0 AND r.QtyToOrder &gt; 0 
+    	THEN CASE 
+    			WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    			THEN r.Order_Min 
+    			ELSE r.QtyToOrder 
+    		END - MOD(CASE 
+    					WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    					THEN r.Order_Min 
+    					ELSE r.QtyToOrder 
+    				END, r.Order_Pack) + r.Order_Pack 
+    	ELSE r.QtyToOrder 
+    END AS QtyToOrder,  
+    r.M_Product_Category_ID,
+    r.M_Product_Group_ID,
+    r.M_Product_Class_ID,
+    r.M_Product_Classification_ID,
+    r.C_UOM_ID,
+    r.M_Locator_ID,
+    r.M_Warehouse_ID, 
+    r.M_WarehouseSource_ID,
+    r.C_BPartner_ID, 
+    r.Order_Min, 
+    r.Order_Pack
+FROM (SELECT r.AD_Client_ID, 
+        r.AD_Org_ID, 
+        r.M_Product_ID, 
+        r.ReplenishType,
+        COALESCE(r.Level_Min, 0) AS Level_Min, 
+    	COALESCE(r.Level_Max, 0) AS Level_Max,  
+    	COALESCE(s.QtyAvailable, 0) AS QtyAvailable, 
+    	COALESCE(s.QtyOnHand, 0) AS QtyOnHand, 
+    	COALESCE(s.QtyReserved, 0) AS QtyReserved, 
+    	COALESCE(s.QtyOrdered, 0) AS QtyOrdered, 
+        COALESCE(CASE
+            WHEN r.ReplenishType = '1' THEN 
+                CASE 
+                    WHEN COALESCE(s.QtyOnHand, 0) - COALESCE(s.QtyReserved, 0) + COALESCE(s.QtyOrdered, 0) &lt;= r.Level_Min 
+                    THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0) 
+                    ELSE 0 
+                END
+            WHEN r.ReplenishType = '2' THEN r.Level_Max - COALESCE(s.QtyOnHand, 0) + COALESCE(s.QtyReserved, 0) - COALESCE(s.QtyOrdered, 0)
+            ELSE 0
+        END, 0) AS QtyToOrder,
+        p.M_Product_Category_ID,
+        p.M_Product_Group_ID,
+        p.M_Product_Class_ID,
+        p.M_Product_Classification_ID,
+        p.C_UOM_ID,
+        r.M_Locator_ID,
+        r.M_Warehouse_ID, 
+        r.M_WarehouseSource_ID,
+        po.C_BPartner_ID, 
+        COALESCE(po.Order_Min, 0) AS Order_Min, 
+        COALESCE(po.Order_Pack, 0) AS Order_Pack
+    FROM M_Replenish r
+    INNER JOIN M_Product p ON(p.M_Product_ID = r.M_Product_ID)
+    LEFT JOIN M_Product_PO po ON(po.M_Product_ID = r.M_Product_ID AND po.IsActive = 'Y' AND po.IsCurrentVendor = 'Y')
+    LEFT JOIN (SELECT s.M_Product_ID, 
+                SUM(s.QtyOnHand) AS QtyOnHand, 
+                SUM(s.QtyOrdered) AS QtyOrdered, 
+                SUM(s.QtyReserved) AS QtyReserved, 
+                SUM(s.QtyAvailable) AS QtyAvailable 
+            FROM RV_Storage s
+            GROUP BY s.M_Product_ID) s ON(s.M_Product_ID = p.M_Product_ID)
+    WHERE r.IsActive = 'Y' AND p.IsActive = 'Y') r
+WHERE (r.QtyToOrder &gt; 0
+OR (r.ReplenishType IN('0', '9')));</SQLStatement>
+      <RollbackStatement>-- View: RV_M_Replenish
+-- DROP VIEW RV_M_Replenish;
+/******************************************************************************
+ * Product: Adempiere ERP &amp; CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2015 E.R.P. Consultores y Asociados, C.A.               *
+ * All Rights Reserved.                                                       *
+ * Contributor(s): Yamel Senih www.erpya.com                                  *
+ ******************************************************************************
+ ***
+ * Title:	Warehouse Replenish
+ * Description:
+ *	Show all products for replenish
+ *
+ * Test:
+ * 	SELECT * FROM RV_Replenish WHERE M_Warehouse_ID=103;
+ ******************************************************************************/
+CREATE OR REPLACE VIEW RV_M_Replenish AS
+SELECT r.AD_Client_ID, 
+    r.AD_Org_ID, 
+    r.M_Product_ID, 
+    r.ReplenishType,                                                                                                                                                                                                                                                         
+    r.Level_Min,  
+    r.Level_Max,   
+    r.QtyAvailable,  
+    r.QtyOnHand,  
+    r.QtyReserved,  
+    r.QtyOrdered,
+    CASE 
+    	WHEN r.Order_Pack &gt; 0 AND MOD(CASE 
+    				WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    				THEN r.Order_Min 
+    				ELSE r.QtyToOrder 
+    			END, r.Order_Pack) &lt;&gt; 0 AND r.QtyToOrder &gt; 0 
+    	THEN CASE 
+    			WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    			THEN r.Order_Min 
+    			ELSE r.QtyToOrder 
+    		END - MOD(CASE 
+    					WHEN r.QtyToOrder &lt; r.Order_Min AND r.QtyToOrder &gt; 0 
+    					THEN r.Order_Min 
+    					ELSE r.QtyToOrder 
+    				END, r.Order_Pack) + r.Order_Pack 
+    	ELSE r.QtyToOrder 
+    END AS QtyToOrder,  
+    r.M_Product_Category_ID,
+    r.M_Product_Group_ID,
+    r.M_Product_Class_ID,
+    r.M_Product_Classification_ID,
+    r.C_UOM_ID,
+    r.M_Locator_ID,
+    r.M_Warehouse_ID, 
+    r.M_WarehouseSource_ID,
+    r.C_BPartner_ID, 
+    r.Order_Min, 
+    r.Order_Pack
+FROM (SELECT r.AD_Client_ID, 
+        r.AD_Org_ID, 
+        r.M_Product_ID, 
+        r.ReplenishType,
+        COALESCE(r.Level_Min, 0) AS Level_Min, 
+    	COALESCE(r.Level_Max, 0) AS Level_Max,  
+    	COALESCE(s.QtyAvailable, 0) AS QtyAvailable, 
+    	COALESCE(s.QtyOnHand, 0) AS QtyOnHand, 
+    	COALESCE(s.QtyReserved, 0) AS QtyReserved, 
+    	COALESCE(s.QtyOrdered, 0) AS QtyOrdered, 
+        COALESCE(CASE
+            WHEN r.ReplenishType = '1' THEN 
+                CASE 
+                    WHEN s.QtyOnHand - s.QtyReserved + s.QtyOrdered &lt;= r.Level_Min 
+                    THEN r.Level_Max - s.QtyOnHand + s.QtyReserved - s.QtyOrdered 
+                    ELSE 0 
+                END
+            WHEN r.ReplenishType = '2' THEN r.Level_Max - s.QtyOnHand + s.QtyReserved - s.QtyOrdered
+            ELSE 0
+        END, 0) AS QtyToOrder,
+        p.M_Product_Category_ID,
+        p.M_Product_Group_ID,
+        p.M_Product_Class_ID,
+        p.M_Product_Classification_ID,
+        p.C_UOM_ID,
+        r.M_Locator_ID,
+        r.M_Warehouse_ID, 
+        r.M_WarehouseSource_ID,
+        po.C_BPartner_ID, 
+        COALESCE(po.Order_Min, 0) AS Order_Min, 
+        COALESCE(po.Order_Pack, 0) AS Order_Pack
+    FROM M_Replenish r
+    INNER JOIN M_Product p ON(p.M_Product_ID = r.M_Product_ID)
+    LEFT JOIN M_Product_PO po ON(po.M_Product_ID = r.M_Product_ID AND po.IsActive = 'Y' AND po.IsCurrentVendor = 'Y')
+    LEFT JOIN (SELECT s.M_Product_ID, 
+                SUM(s.QtyOnHand) AS QtyOnHand, 
+                SUM(s.QtyOrdered) AS QtyOrdered, 
+                SUM(s.QtyReserved) AS QtyReserved, 
+                SUM(s.QtyAvailable) AS QtyAvailable 
+            FROM RV_Storage s
+            GROUP BY s.M_Product_ID) s ON(s.M_Product_ID = p.M_Product_ID)
+    WHERE r.IsActive = 'Y' AND p.IsActive = 'Y') r
+WHERE (r.QtyToOrder &gt; 0
+OR (r.ReplenishType IN('0', '9')));</RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Hey guys just a error is fixedx here:

## step by step for reproduce
1. As Garden World go to **Material Management** -> **Material Management Rules** -> **Product**
2. Go to product **Transplanter**
3. Duplicate it and change value to **Test1** Name to **Test 1**
![Screenshot_20200811_170743](https://user-images.githubusercontent.com/2333092/89950821-5c971900-dbf8-11ea-8377-83f7de77fb84.png)
4. Go to **Replenish** tab and set it with:
  - Warehouse: **HQ Warehouse**
  - Replenish Type: **Maintain Maximum Level**
  - Minimum Level: **20**
  - Maximum Level: **40**
![Screenshot_20200811_170800](https://user-images.githubusercontent.com/2333092/89950870-733d7000-dbf8-11ea-9db0-78088b42ed81.png)
5. Go to **Material Management** -> **Warehouse Replenish**
6. Set Warehouse (Search Criteria) to **HQ Warehouse** and run it:
  - Note that **Transplanter** product exist but **Test 1** no exist
7. Create a new **Physical Inventory** for **Test 1** in any warehouse with quantity counted **3**
![Screenshot_20200811_171154](https://user-images.githubusercontent.com/2333092/89950943-8e0fe480-dbf8-11ea-9d56-1f7c0a9bbd46.png)
8. Go to **Material Management** -> **Warehouse Replenish**
9. Set Warehouse (Search Criteria) to **HQ Warehouse** and run it:
  - Now already exist **Test 1** for browser

Here a gif before change it:
![Peek 2020-08-11 17-10](https://user-images.githubusercontent.com/2333092/89951004-a67fff00-dbf8-11ea-9840-51e0049eaf16.gif)
Here a gif with all changes applied:
![Peek 2020-08-11 17-12](https://user-images.githubusercontent.com/2333092/89951033-b13a9400-dbf8-11ea-85fb-fc9ba633082f.gif)

## What is the errror?
If a product not have records in M_Storage it never is showed for replenish browser