### PR TITLE
build dir="org.eevolution.fleet" prior to "org.eevolution.freight"

### DIFF
--- a/utils_dev/build.xml
+++ b/utils_dev/build.xml
@@ -37,8 +37,8 @@
 		<ant inheritAll="false" dir="org.eevolution.manufacturing"/>
 		<ant inheritAll="false" dir="org.eevolution.hr_and_payroll"/>
 		<ant inheritAll="false" dir="org.eevolution.warehouse"/>
-		<ant inheritAll="false" dir="org.eevolution.freight"/>
 		<ant inheritAll="false" dir="org.eevolution.fleet"/>
+		<ant inheritAll="false" dir="org.eevolution.freight"/>
         <ant inheritAll="false" dir="com.kkalice.adempiere.migrate"/>
 		<ant inheritAll="false" dir="org.adempiere.pos"/>
 		<ant inheritAll="false" dir="org.adempiere.production"/>


### PR DESCRIPTION
because freight depends on fleet:
class `CreateFreightOrderFromPackage` imports `MDDFreight`

Hi @yamelsenih 
in the current develop branch ther ist a prolmen when building from scratch.
This pull resolves it. A small change to ` utils_dev/build.xml `

there is no issue for that

regards EUGen