### PR TITLE
Add support to Document types for Bank Transfer

### DIFF
--- a/base/src/org/eevolution/process/BankTransfer.java
+++ b/base/src/org/eevolution/process/BankTransfer.java
@@ -89,7 +89,11 @@ public class BankTransfer extends BankTransferAbstract {
 		}
 		paymentBankFrom.setPayAmt(getAmount());
 		paymentBankFrom.setOverUnderAmt(Env.ZERO);
-		paymentBankFrom.setC_DocType_ID(false);
+		if(getWithdrawalDocumentTypeId() != 0) {
+			paymentBankFrom.setC_DocType_ID(getWithdrawalDocumentTypeId());
+		} else {
+			paymentBankFrom.setC_DocType_ID(false);
+		}
 		paymentBankFrom.setC_Charge_ID(getChargeId());
 		paymentBankFrom.saveEx();
 		//	
@@ -105,13 +109,17 @@ public class BankTransfer extends BankTransferAbstract {
 		if(getConversionTypeId() > 0) {
 			paymentBankTo.setC_ConversionType_ID(getConversionTypeId());	
 		}
-		if(getPosId() > 0) {
-			paymentBankFrom.setC_POS_ID(getPosId());
-			paymentBankTo.setC_POS_ID(getPosId());
+		if(getPOSId() > 0) {
+			paymentBankFrom.setC_POS_ID(getPOSId());
+			paymentBankTo.setC_POS_ID(getPOSId());
 		}
 		paymentBankTo.setPayAmt(getAmount());
 		paymentBankTo.setOverUnderAmt(Env.ZERO);
-		paymentBankTo.setC_DocType_ID(true);
+		if(getDepositDocumentTypeId() != 0) {
+			paymentBankTo.setC_DocType_ID(getDepositDocumentTypeId());
+		} else {
+			paymentBankTo.setC_DocType_ID(true);
+		}
 		paymentBankTo.setC_Charge_ID(getChargeId());
 		paymentBankTo.saveEx();
 
@@ -119,6 +127,7 @@ public class BankTransfer extends BankTransferAbstract {
 		paymentBankFrom.saveEx();
 		paymentBankFrom.processIt(MPayment.DOCACTION_Complete);
 		paymentBankFrom.saveEx();
+		addLog("@C_Payment_ID@ @IsReceipt@: ");
 		//	Add to current bank statement for account
 		if(isAutoReconciled()) {
 			MBankStatementLine bsl = MBankStatement.addPayment(paymentBankFrom);

--- a/base/src/org/eevolution/process/BankTransferAbstract.java
+++ b/base/src/org/eevolution/process/BankTransferAbstract.java
@@ -21,27 +21,29 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import org.compiere.process.SvrProcess;
 
-/** Generated Process for (Bank Transfer)
+/** Generated Process for (POS Opening)
  *  @author ADempiere (generated) 
- *  @version Release 3.9.0
+ *  @version Release 3.9.3
  */
 public abstract class BankTransferAbstract extends SvrProcess {
 	/** Process Value 	*/
-	private static final String VALUE_FOR_PROCESS = "C_BankStatement BankTransfer";
+	private static final String VALUE_FOR_PROCESS = "C_POS_Opening";
 	/** Process Name 	*/
-	private static final String NAME_FOR_PROCESS = "Bank Transfer";
+	private static final String NAME_FOR_PROCESS = "POS Opening";
 	/** Process Id 	*/
-	private static final int ID_FOR_PROCESS = 53153;
-	/**	Parameter Name for Bank Account From	*/
+	private static final int ID_FOR_PROCESS = 54361;
+	/**	Parameter Name for POS Terminal	*/
+	public static final String C_POS_ID = "C_POS_ID";
+	/**	Parameter Name for Bank Account	*/
 	public static final String FROM_C_BANKACCOUNT_ID = "From_C_BankAccount_ID";
 	/**	Parameter Name for Bank Account To	*/
 	public static final String C_BANKACCOUNTTO_ID = "C_BankAccountTo_ID";
 	/**	Parameter Name for Business Partner 	*/
 	public static final String C_BPARTNER_ID = "C_BPartner_ID";
-	/**	Parameter Name for Currency	*/
-	public static final String C_CURRENCY_ID = "C_Currency_ID";
 	/**	Parameter Name for Currency Type	*/
 	public static final String C_CONVERSIONTYPE_ID = "C_ConversionType_ID";
+	/**	Parameter Name for Currency	*/
+	public static final String C_CURRENCY_ID = "C_Currency_ID";
 	/**	Parameter Name for Charge	*/
 	public static final String C_CHARGE_ID = "C_Charge_ID";
 	/**	Parameter Name for Document No	*/
@@ -56,20 +58,24 @@ public abstract class BankTransferAbstract extends SvrProcess {
 	public static final String STATEMENTDATE = "StatementDate";
 	/**	Parameter Name for Account Date	*/
 	public static final String DATEACCT = "DateAcct";
-	/**	Parameter Name for POS	*/
-	public static final String C_POS_ID = "C_POS_ID";
 	/**	Parameter Name for Reconcile Automatically	*/
 	public static final String ISAUTORECONCILED = "IsAutoReconciled";
-	/**	Parameter Value for Bank Account From	*/
+	/**	Parameter Name for Withdrawal Document Type	*/
+	public static final String WITHDRAWALDOCUMENTTYPE_ID = "WithdrawalDocumentType_ID";
+	/**	Parameter Name for Deposit Document Type	*/
+	public static final String DEPOSITDOCUMENTTYPE_ID = "DepositDocumentType_ID";
+	/**	Parameter Value for POS Terminal	*/
+	private int pOSId;
+	/**	Parameter Value for Bank Account	*/
 	private int cBankAccountId;
 	/**	Parameter Value for Bank Account To	*/
 	private int bankAccountToId;
 	/**	Parameter Value for Business Partner 	*/
 	private int bPartnerId;
-	/**	Parameter Value for Currency	*/
-	private int currencyId;
 	/**	Parameter Value for Currency Type	*/
 	private int conversionTypeId;
+	/**	Parameter Value for Currency	*/
+	private int currencyId;
 	/**	Parameter Value for Charge	*/
 	private int chargeId;
 	/**	Parameter Value for Document No	*/
@@ -86,16 +92,19 @@ public abstract class BankTransferAbstract extends SvrProcess {
 	private Timestamp dateAcct;
 	/**	Parameter Value for Reconcile Automatically	*/
 	private boolean isAutoReconciled;
-	/**	Parameter Value for POS	*/
-	private int posId;
+	/**	Parameter Value for Withdrawal Document Type	*/
+	private int withdrawalDocumentTypeId;
+	/**	Parameter Value for Deposit Document Type	*/
+	private int depositDocumentTypeId;
 
 	@Override
 	protected void prepare() {
+		pOSId = getParameterAsInt(C_POS_ID);
 		cBankAccountId = getParameterAsInt(FROM_C_BANKACCOUNT_ID);
 		bankAccountToId = getParameterAsInt(C_BANKACCOUNTTO_ID);
 		bPartnerId = getParameterAsInt(C_BPARTNER_ID);
-		currencyId = getParameterAsInt(C_CURRENCY_ID);
 		conversionTypeId = getParameterAsInt(C_CONVERSIONTYPE_ID);
+		currencyId = getParameterAsInt(C_CURRENCY_ID);
 		chargeId = getParameterAsInt(C_CHARGE_ID);
 		documentNo = getParameterAsString(DOCUMENTNO);
 		documentNoTo = getParameterAsString(DOCUMENTNOTO);
@@ -104,25 +113,26 @@ public abstract class BankTransferAbstract extends SvrProcess {
 		statementDate = getParameterAsTimestamp(STATEMENTDATE);
 		dateAcct = getParameterAsTimestamp(DATEACCT);
 		isAutoReconciled = getParameterAsBoolean(ISAUTORECONCILED);
-		posId = getParameterAsInt(C_POS_ID);
+		withdrawalDocumentTypeId = getParameterAsInt(WITHDRAWALDOCUMENTTYPE_ID);
+		depositDocumentTypeId = getParameterAsInt(DEPOSITDOCUMENTTYPE_ID);
 	}
 
-	/**	 Getter Parameter Value for Bank Account From	*/
+	/**	 Getter Parameter Value for POS Terminal	*/
+	protected int getPOSId() {
+		return pOSId;
+	}
+
+	/**	 Setter Parameter Value for POS Terminal	*/
+	protected void setPOSId(int pOSId) {
+		this.pOSId = pOSId;
+	}
+
+	/**	 Getter Parameter Value for Bank Account	*/
 	protected int getCBankAccountId() {
 		return cBankAccountId;
 	}
 
-	/**	 Setter Parameter Value for Bank Account From	*/
-	protected void setPosId(int posId) {
-		this.posId = posId;
-	}
-
-	/**	 Getter Parameter Value for Bank Account From	*/
-	protected int getPosId() {
-		return posId;
-	}
-
-	/**	 Setter Parameter Value for Bank Account From	*/
+	/**	 Setter Parameter Value for Bank Account	*/
 	protected void setCBankAccountId(int cBankAccountId) {
 		this.cBankAccountId = cBankAccountId;
 	}
@@ -147,16 +157,6 @@ public abstract class BankTransferAbstract extends SvrProcess {
 		this.bPartnerId = bPartnerId;
 	}
 
-	/**	 Getter Parameter Value for Currency	*/
-	protected int getCurrencyId() {
-		return currencyId;
-	}
-
-	/**	 Setter Parameter Value for Currency	*/
-	protected void setCurrencyId(int currencyId) {
-		this.currencyId = currencyId;
-	}
-
 	/**	 Getter Parameter Value for Currency Type	*/
 	protected int getConversionTypeId() {
 		return conversionTypeId;
@@ -165,6 +165,16 @@ public abstract class BankTransferAbstract extends SvrProcess {
 	/**	 Setter Parameter Value for Currency Type	*/
 	protected void setConversionTypeId(int conversionTypeId) {
 		this.conversionTypeId = conversionTypeId;
+	}
+
+	/**	 Getter Parameter Value for Currency	*/
+	protected int getCurrencyId() {
+		return currencyId;
+	}
+
+	/**	 Setter Parameter Value for Currency	*/
+	protected void setCurrencyId(int currencyId) {
+		this.currencyId = currencyId;
 	}
 
 	/**	 Getter Parameter Value for Charge	*/
@@ -245,6 +255,26 @@ public abstract class BankTransferAbstract extends SvrProcess {
 	/**	 Setter Parameter Value for Reconcile Automatically	*/
 	protected void setIsAutoReconciled(boolean isAutoReconciled) {
 		this.isAutoReconciled = isAutoReconciled;
+	}
+
+	/**	 Getter Parameter Value for Withdrawal Document Type	*/
+	protected int getWithdrawalDocumentTypeId() {
+		return withdrawalDocumentTypeId;
+	}
+
+	/**	 Setter Parameter Value for Withdrawal Document Type	*/
+	protected void setWithdrawalDocumentTypeId(int withdrawalDocumentTypeId) {
+		this.withdrawalDocumentTypeId = withdrawalDocumentTypeId;
+	}
+
+	/**	 Getter Parameter Value for Deposit Document Type	*/
+	protected int getDepositDocumentTypeId() {
+		return depositDocumentTypeId;
+	}
+
+	/**	 Setter Parameter Value for Deposit Document Type	*/
+	protected void setDepositDocumentTypeId(int depositDocumentTypeId) {
+		this.depositDocumentTypeId = depositDocumentTypeId;
 	}
 
 	/**	 Getter Parameter Value for Process ID	*/

--- a/migration/393lts-394lts/06460_Add_document_Type_for_bank_Transfer.xml
+++ b/migration/393lts-394lts/06460_Add_document_Type_for_bank_Transfer.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add document Type for Bank Transfer" ReleaseNo="3.9.4" SeqNo="6460">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="285" Action="I" Record_ID="57772" Table="AD_Process_Para">
+        <Data AD_Column_ID="2820" Column="Updated">2020-08-12 16:48:59.208</Data>
+        <Data AD_Column_ID="2822" Column="Name">Withdrawal Document Type</Data>
+        <Data AD_Column_ID="2817" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2830" Column="IsRange">false</Data>
+        <Data AD_Column_ID="2818" Column="Created">2020-08-12 16:48:59.208</Data>
+        <Data AD_Column_ID="3738" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="4017" Column="ColumnName">WithdrawalDocumentType_ID</Data>
+        <Data AD_Column_ID="2823" Column="Description">Withdrawal Document Type for Cash or bank</Data>
+        <Data AD_Column_ID="2824" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="3739" Column="DefaultValue">-1</Data>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="81287" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID">57772</Data>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="7728" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="3737" Column="FieldLength">0</Data>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID">53153</Data>
+        <Data AD_Column_ID="2819" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID">52457</Data>
+        <Data AD_Column_ID="2826" Column="SeqNo">140</Data>
+        <Data AD_Column_ID="2821" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID">170</Data>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID">61196</Data>
+        <Data AD_Column_ID="84385" Column="UUID">c95b86e6-7b31-4971-adce-4dd39926c316</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="286" Action="I" Record_ID="57772" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="2836" Column="Created">2020-08-12 16:49:00.58</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84386" Column="UUID">0db8dc7d-65f0-4aaf-b98f-6c2d1842628c</Data>
+        <Data AD_Column_ID="2835" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2838" Column="Updated">2020-08-12 16:49:00.58</Data>
+        <Data AD_Column_ID="2840" Column="Name">Withdrawal Document Type</Data>
+        <Data AD_Column_ID="2842" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2841" Column="Description">Withdrawal Document Type for Cash or bank</Data>
+        <Data AD_Column_ID="3743" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID">57772</Data>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2837" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2832" Column="AD_Language">es_MX</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="285" Action="I" Record_ID="57773" Table="AD_Process_Para">
+        <Data AD_Column_ID="2820" Column="Updated">2020-08-12 16:49:00.983</Data>
+        <Data AD_Column_ID="2822" Column="Name">Deposit Document Type</Data>
+        <Data AD_Column_ID="2817" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2830" Column="IsRange">false</Data>
+        <Data AD_Column_ID="2818" Column="Created">2020-08-12 16:49:00.983</Data>
+        <Data AD_Column_ID="3738" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="4017" Column="ColumnName">DepositDocumentType_ID</Data>
+        <Data AD_Column_ID="2823" Column="Description">Deposit Document Type for Cash or bank</Data>
+        <Data AD_Column_ID="2824" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="3739" Column="DefaultValue">-1</Data>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="81287" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID">57773</Data>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="7728" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="3737" Column="FieldLength">0</Data>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID">53153</Data>
+        <Data AD_Column_ID="2819" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID">52458</Data>
+        <Data AD_Column_ID="2826" Column="SeqNo">150</Data>
+        <Data AD_Column_ID="2821" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID">170</Data>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID">61197</Data>
+        <Data AD_Column_ID="84385" Column="UUID">2de5247b-1dd5-4f21-b3bc-128aedfc3975</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="286" Action="I" Record_ID="57773" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="2836" Column="Created">2020-08-12 16:49:01.886</Data>
+        <Data AD_Column_ID="2835" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2838" Column="Updated">2020-08-12 16:49:01.886</Data>
+        <Data AD_Column_ID="2840" Column="Name">Deposit Document Type</Data>
+        <Data AD_Column_ID="2842" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2841" Column="Description">Deposit Document Type for Cash or bank</Data>
+        <Data AD_Column_ID="3743" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID">57773</Data>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2837" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2832" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84386" Column="UUID">93a5aa6b-7782-4666-8661-629cebd3186a</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="285" Action="I" Record_ID="57774" Table="AD_Process_Para">
+        <Data AD_Column_ID="2820" Column="Updated">2020-08-12 16:52:05.296</Data>
+        <Data AD_Column_ID="2822" Column="Name">Withdrawal Document Type</Data>
+        <Data AD_Column_ID="2817" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2830" Column="IsRange">false</Data>
+        <Data AD_Column_ID="2818" Column="Created">2020-08-12 16:52:05.296</Data>
+        <Data AD_Column_ID="3738" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="4017" Column="ColumnName">WithdrawalDocumentType_ID</Data>
+        <Data AD_Column_ID="2823" Column="Description">Withdrawal Document Type for Cash or bank</Data>
+        <Data AD_Column_ID="2824" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="3739" Column="DefaultValue">-1</Data>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="81287" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID">57774</Data>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="7728" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="3737" Column="FieldLength">0</Data>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID">54361</Data>
+        <Data AD_Column_ID="2819" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID">52457</Data>
+        <Data AD_Column_ID="2826" Column="SeqNo">150</Data>
+        <Data AD_Column_ID="2821" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID">170</Data>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID">61196</Data>
+        <Data AD_Column_ID="84385" Column="UUID">0fe3a6bc-a350-4d10-ae22-1134475bdf35</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="286" Action="I" Record_ID="57774" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="2836" Column="Created">2020-08-12 16:52:06.704</Data>
+        <Data AD_Column_ID="2835" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2838" Column="Updated">2020-08-12 16:52:06.704</Data>
+        <Data AD_Column_ID="2840" Column="Name">Withdrawal Document Type</Data>
+        <Data AD_Column_ID="2842" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2841" Column="Description">Withdrawal Document Type for Cash or bank</Data>
+        <Data AD_Column_ID="3743" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID">57774</Data>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2837" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2832" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84386" Column="UUID">b271aa0f-3353-44ea-b86f-12899ffd870b</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="285" Action="I" Record_ID="57775" Table="AD_Process_Para">
+        <Data AD_Column_ID="2820" Column="Updated">2020-08-12 16:52:06.969</Data>
+        <Data AD_Column_ID="2822" Column="Name">Deposit Document Type</Data>
+        <Data AD_Column_ID="3739" Column="DefaultValue">-1</Data>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="81287" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID">57775</Data>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="7728" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="3737" Column="FieldLength">0</Data>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID">54361</Data>
+        <Data AD_Column_ID="2819" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID">52458</Data>
+        <Data AD_Column_ID="2826" Column="SeqNo">160</Data>
+        <Data AD_Column_ID="2821" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID">170</Data>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID">61197</Data>
+        <Data AD_Column_ID="84385" Column="UUID">17156499-0f1e-45ac-8db7-e2e0429def59</Data>
+        <Data AD_Column_ID="2817" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2830" Column="IsRange">false</Data>
+        <Data AD_Column_ID="2818" Column="Created">2020-08-12 16:52:06.969</Data>
+        <Data AD_Column_ID="3738" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="4017" Column="ColumnName">DepositDocumentType_ID</Data>
+        <Data AD_Column_ID="2823" Column="Description">Deposit Document Type for Cash or bank</Data>
+        <Data AD_Column_ID="2824" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="286" Action="I" Record_ID="57775" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="2836" Column="Created">2020-08-12 16:52:07.855</Data>
+        <Data AD_Column_ID="2835" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2838" Column="Updated">2020-08-12 16:52:07.855</Data>
+        <Data AD_Column_ID="2840" Column="Name">Deposit Document Type</Data>
+        <Data AD_Column_ID="2842" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2841" Column="Description">Deposit Document Type for Cash or bank</Data>
+        <Data AD_Column_ID="3743" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID">57775</Data>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2837" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2832" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84386" Column="UUID">249f4458-e645-4221-a8df-855be572a098</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Hey a simple change but very useful. Just add document type for bank transfer
See a example:
![Peek 2020-08-12 17-01](https://user-images.githubusercontent.com/2333092/90068478-b235f900-dcbe-11ea-84c3-0a3dbdf66dad.gif)
Here a result
![Screenshot_20200812_170516](https://user-images.githubusercontent.com/2333092/90068506-c0841500-dcbe-11ea-84b3-95b299b20e77.png)
![Screenshot_20200812_170530](https://user-images.githubusercontent.com/2333092/90068509-c11cab80-dcbe-11ea-8b5e-aab0fb17fc81.png)
