### PR TITLE
Fixed error with for requery necessary for getLines Method

### DIFF
--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -687,7 +687,7 @@ public class MOrder extends X_C_Order implements DocAction
 	 */
 	public MOrderLine[] getLines (boolean requery, String orderBy)
 	{
-		if (m_lines != null && !requery) {
+		if (m_lines != null && m_lines.length > 0 && !requery) {
 			set_TrxName(m_lines, get_TrxName());
 			return m_lines;
 		}


### PR DESCRIPTION
Just a little change but very necessary for **getLines** helper method that prevent a bad calculation for taxes and others values when a order is created from a process and **setProcessed** method is not called for line