### PR TITLE
Fixed error with setup file when it is getted from external storage

### DIFF
--- a/base/src/org/spin/process/SetupFileStorageSystem.java
+++ b/base/src/org/spin/process/SetupFileStorageSystem.java
@@ -83,11 +83,11 @@ public class SetupFileStorageSystem extends SetupFileStorageSystemAbstract {
 									if(attachmentReferenceId < 0) {
 										try {
 											AttachmentUtil.getInstance(getCtx())
+												.withData(entry.getData())
 												.withFileHandlerId(getFileHandlerId())
 												.withAttachmentId(attachmentPair.getKey())
 												.withFileName(entry.getName())
 												.withDescription(Msg.getMsg(getCtx(), "CreatedFromSetupExternalStorage"))
-												.withData(entry.getData())
 												.saveAttachment();
 											addLog(entry.getName() + ": @Ok@");
 											processed.incrementAndGet();
@@ -122,11 +122,11 @@ public class SetupFileStorageSystem extends SetupFileStorageSystemAbstract {
 						MImage image = MImage.get(getCtx(), imagePair.getKey());
 						try {
 							AttachmentUtil.getInstance(getCtx())
+								.withData(image.getData())
 								.withFileHandlerId(getFileHandlerId())
 								.withImageId(image.getAD_Image_ID())
 								.withFileName(image.getName())
 								.withDescription(Msg.getMsg(getCtx(), "CreatedFromSetupExternalStorage"))
-								.withData(image.getData())
 								.saveAttachment();
 							addLog(image.getName() + ": @Ok@");
 							processed.incrementAndGet();
@@ -157,11 +157,11 @@ public class SetupFileStorageSystem extends SetupFileStorageSystemAbstract {
 						try {
 							String fileName = archive.getName() + ".pdf";
 							AttachmentUtil.getInstance(getCtx())
+								.withData(archive.getBinaryData())
 								.withFileHandlerId(getFileHandlerId())
 								.withArchiveId(archive.getAD_Archive_ID())
 								.withFileName(fileName)
 								.withDescription(Msg.getMsg(getCtx(), "CreatedFromSetupExternalStorage"))
-								.withData(archive.getBinaryData())
 								.saveAttachment();
 							addLog(fileName + ": @Ok@");
 							processed.incrementAndGet();


### PR DESCRIPTION
Fixed error with setup file when it is getted from external storage
When a storage alredy configured is change to other exist the follow error inserting data:
```Java
===========> DB.executeUpdate: INSERT INTO AD_AttachmentReference (AD_Client_ID,AD_Org_ID,IsActive,Created,Updated,CreatedBy,UpdatedBy,UUID,AD_Archive_ID,FileHandler_ID,AD_AttachmentReference_ID) VALUES (1000000,1000000,'Y',TO_TIMESTAMP('2020-09-14 18:08:34','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2020-09-14 18:08:34','YYYY-MM-DD HH24:MI:SS'),1000017,1000017,'32176d82-68ac-40d5-b5c3-f7676fb3f605',1000184,1000015,1002374) [POSave_b8257369-e070-43ec-9c8f-a67f31395e6f] [33]
org.postgresql.util.PSQLException: ERROR: null value in column "filename" violates not-null constraint
  Detail: Failing row contains (1000000, 1000000, 2020-09-14 18:08:34, 1000017, Y, 2020-09-14 18:08:34, 1000017, 32176d82-68ac-40d5-b5c3-f7676fb3f605, 1002374, null, 1000015, null, null, null, 1000184, null, null, null).; State=23502; ErrorCode=0
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2497)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2233)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:310)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:446)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:370)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:149)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:124)
	at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeUpdate(NewProxyPreparedStatement.java:105)
	at sun.reflect.GeneratedMethodAccessor15.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
	at com.sun.proxy.$Proxy2.executeUpdate(Unknown Source)
	at org.compiere.util.DB.executeUpdate(DB.java:1044)
	at org.compiere.util.DB.executeUpdate(DB.java:906)
	at org.compiere.util.DB.executeUpdate(DB.java:893)
	at org.compiere.model.PO.saveNew(PO.java:2917)
	at org.compiere.model.PO.save(PO.java:2231)
	at org.compiere.model.PO.saveEx(PO.java:2310)
	at org.spin.util.AttachmentUtil.saveAttachment(AttachmentUtil.java:417)
	at org.spin.process.SetupFileStorageSystem$3.run(SetupFileStorageSystem.java:165)
	at org.compiere.util.Trx.run(Trx.java:529)
	at org.compiere.util.Trx.run(Trx.java:497)
```