### PR TITLE
Adding a clear method to empty the previous context in the MMailText

### DIFF
--- a/org.adempiere.request/src/main/java/org/compiere/model/MMailText.java
+++ b/org.adempiere.request/src/main/java/org/compiere/model/MMailText.java
@@ -458,4 +458,11 @@ public class MMailText extends X_R_MailText
 	public String toString() {
 		return "MMailText [getMailHeader()=" + getMailHeader() + ", getR_MailText_ID()=" + getR_MailText_ID() + "]";
 	}
+
+	/**
+	 * Clear the entityMap from the previous context
+	 */
+	public void clear() {
+		entityMap.clear();
+	}
 }	//	MMailText

--- a/org.adempiere.request/src/main/java/org/compiere/model/MRequest.java
+++ b/org.adempiere.request/src/main/java/org/compiere/model/MRequest.java
@@ -1044,6 +1044,7 @@ public class MRequest extends X_R_Request
 		if(!Util.isEmpty(eventType)) {
 			MMailText mailText = MRNoticeTemplate.getMailTemplate(getCtx(), MRNoticeTemplate.TEMPLATETYPE_Request, eventType);
 			if(mailText != null) {
+				mailText.clear(); // This can be a cached object with a previous context that may be messing up the data
 				mailText.setUser(from);
 				if(getC_BPartner_ID() != 0) {
 					mailText.setBPartner(getC_BPartner_ID());

--- a/org.adempiere.request/src/main/java/org/compiere/model/MRequest.java
+++ b/org.adempiere.request/src/main/java/org/compiere/model/MRequest.java
@@ -1044,7 +1044,6 @@ public class MRequest extends X_R_Request
 		if(!Util.isEmpty(eventType)) {
 			MMailText mailText = MRNoticeTemplate.getMailTemplate(getCtx(), MRNoticeTemplate.TEMPLATETYPE_Request, eventType);
 			if(mailText != null) {
-				mailText.clear(); // This can be a cached object with a previous context that may be messing up the data
 				mailText.setUser(from);
 				if(getC_BPartner_ID() != 0) {
 					mailText.setBPartner(getC_BPartner_ID());

--- a/org.adempiere.request/src/main/java/org/spin/model/MRNoticeTemplate.java
+++ b/org.adempiere.request/src/main/java/org/spin/model/MRNoticeTemplate.java
@@ -132,7 +132,8 @@ public class MRNoticeTemplate extends X_R_NoticeTemplate {
         final String key = clientId + "|" + templateType + "|" + eventType;
         MMailText mailTemplate = cacheMailTextValue.get(key);
         if (mailTemplate != null) {
-        	return mailTemplate;
+			mailTemplate.clear();
+			return mailTemplate;
         }
         String whereClause = COLUMNNAME_AD_Client_ID + " IN(?,?) "
         		+ "AND EXISTS(SELECT 1 FROM R_NoticeTemplate rt "


### PR DESCRIPTION
Fixes: #3239 