### PR TITLE
Add support to Corporate Branding Image for Organization Info

### DIFF
--- a/base/src/org/compiere/model/I_AD_Org.java
+++ b/base/src/org/compiere/model/I_AD_Org.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for AD_Org
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2
+ *  @version Release 3.9.3
  */
 public interface I_AD_Org 
 {
@@ -160,19 +160,6 @@ public interface I_AD_Org
 
 	public org.compiere.model.I_AD_Org getParent_Org() throws RuntimeException;
 
-    /** Column name UUID */
-    public static final String COLUMNNAME_UUID = "UUID";
-
-	/** Set Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public void setUUID (String UUID);
-
-	/** Get Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public String getUUID();
-
     /** Column name Updated */
     public static final String COLUMNNAME_Updated = "Updated";
 
@@ -188,6 +175,19 @@ public interface I_AD_Org
 	  * User who updated this records
 	  */
 	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
 
     /** Column name Value */
     public static final String COLUMNNAME_Value = "Value";

--- a/base/src/org/compiere/model/I_AD_OrgInfo.java
+++ b/base/src/org/compiere/model/I_AD_OrgInfo.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for AD_OrgInfo
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2
+ *  @version Release 3.9.3
  */
 public interface I_AD_OrgInfo 
 {
@@ -49,6 +49,19 @@ public interface I_AD_OrgInfo
 	  */
 	public int getAD_Client_ID();
 
+    /** Column name AD_Org_ID */
+    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/** Set Organization.
+	  * Organizational entity within client
+	  */
+	public void setAD_Org_ID (int AD_Org_ID);
+
+	/** Get Organization.
+	  * Organizational entity within client
+	  */
+	public int getAD_Org_ID();
+
     /** Column name AD_OrgType_ID */
     public static final String COLUMNNAME_AD_OrgType_ID = "AD_OrgType_ID";
 
@@ -63,19 +76,6 @@ public interface I_AD_OrgInfo
 	public int getAD_OrgType_ID();
 
 	public org.compiere.model.I_AD_OrgType getAD_OrgType() throws RuntimeException;
-
-    /** Column name AD_Org_ID */
-    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
-
-	/** Set Organization.
-	  * Organizational entity within client
-	  */
-	public void setAD_Org_ID (int AD_Org_ID);
-
-	/** Get Organization.
-	  * Organizational entity within client
-	  */
-	public int getAD_Org_ID();
 
     /** Column name C_Calendar_ID */
     public static final String COLUMNNAME_C_Calendar_ID = "C_Calendar_ID";
@@ -107,6 +107,19 @@ public interface I_AD_OrgInfo
 
 	public I_C_Location getC_Location() throws RuntimeException;
 
+    /** Column name CorporateBrandingImage_ID */
+    public static final String COLUMNNAME_CorporateBrandingImage_ID = "CorporateBrandingImage_ID";
+
+	/** Set Corporate Branding Image.
+	  * Corporate Branding Image
+	  */
+	public void setCorporateBrandingImage_ID (int CorporateBrandingImage_ID);
+
+	/** Get Corporate Branding Image.
+	  * Corporate Branding Image
+	  */
+	public int getCorporateBrandingImage_ID();
+
     /** Column name Created */
     public static final String COLUMNNAME_Created = "Created";
 
@@ -123,19 +136,6 @@ public interface I_AD_OrgInfo
 	  */
 	public int getCreatedBy();
 
-    /** Column name DUNS */
-    public static final String COLUMNNAME_DUNS = "DUNS";
-
-	/** Set D-U-N-S.
-	  * Dun & Bradstreet Number
-	  */
-	public void setDUNS (String DUNS);
-
-	/** Get D-U-N-S.
-	  * Dun & Bradstreet Number
-	  */
-	public String getDUNS();
-
     /** Column name DropShip_Warehouse_ID */
     public static final String COLUMNNAME_DropShip_Warehouse_ID = "DropShip_Warehouse_ID";
 
@@ -150,6 +150,19 @@ public interface I_AD_OrgInfo
 	public int getDropShip_Warehouse_ID();
 
 	public org.compiere.model.I_M_Warehouse getDropShip_Warehouse() throws RuntimeException;
+
+    /** Column name DUNS */
+    public static final String COLUMNNAME_DUNS = "DUNS";
+
+	/** Set D-U-N-S.
+	  * Dun & Bradstreet Number
+	  */
+	public void setDUNS (String DUNS);
+
+	/** Get D-U-N-S.
+	  * Dun & Bradstreet Number
+	  */
+	public String getDUNS();
 
     /** Column name EMail */
     public static final String COLUMNNAME_EMail = "EMail";
@@ -337,19 +350,6 @@ public interface I_AD_OrgInfo
 
 	public org.compiere.model.I_C_CashBook getTransferCashBook() throws RuntimeException;
 
-    /** Column name UUID */
-    public static final String COLUMNNAME_UUID = "UUID";
-
-	/** Set Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public void setUUID (String UUID);
-
-	/** Get Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public String getUUID();
-
     /** Column name UnidentifiedAPDocType_ID */
     public static final String COLUMNNAME_UnidentifiedAPDocType_ID = "UnidentifiedAPDocType_ID";
 
@@ -398,4 +398,17 @@ public interface I_AD_OrgInfo
 	  * User who updated this records
 	  */
 	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
 }

--- a/base/src/org/compiere/model/X_AD_Org.java
+++ b/base/src/org/compiere/model/X_AD_Org.java
@@ -23,14 +23,14 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Model for AD_Org
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2 - $Id$ */
+ *  @version Release 3.9.3 - $Id$ */
 public class X_AD_Org extends PO implements I_AD_Org, I_Persistent 
 {
 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20191120L;
+	private static final long serialVersionUID = 20201119L;
 
     /** Standard Constructor */
     public X_AD_Org (Properties ctx, int AD_Org_ID, String trxName)

--- a/base/src/org/compiere/model/X_AD_OrgInfo.java
+++ b/base/src/org/compiere/model/X_AD_OrgInfo.java
@@ -22,14 +22,14 @@ import java.util.Properties;
 
 /** Generated Model for AD_OrgInfo
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2 - $Id$ */
+ *  @version Release 3.9.3 - $Id$ */
 public class X_AD_OrgInfo extends PO implements I_AD_OrgInfo, I_Persistent 
 {
 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20191120L;
+	private static final long serialVersionUID = 20201119L;
 
     /** Standard Constructor */
     public X_AD_OrgInfo (Properties ctx, int AD_OrgInfo_ID, String trxName)
@@ -154,21 +154,27 @@ public class X_AD_OrgInfo extends PO implements I_AD_OrgInfo, I_Persistent
 		return ii.intValue();
 	}
 
-	/** Set D-U-N-S.
-		@param DUNS 
-		Dun & Bradstreet Number
+	/** Set Corporate Branding Image.
+		@param CorporateBrandingImage_ID 
+		Corporate Branding Image
 	  */
-	public void setDUNS (String DUNS)
+	public void setCorporateBrandingImage_ID (int CorporateBrandingImage_ID)
 	{
-		set_Value (COLUMNNAME_DUNS, DUNS);
+		if (CorporateBrandingImage_ID < 1) 
+			set_Value (COLUMNNAME_CorporateBrandingImage_ID, null);
+		else 
+			set_Value (COLUMNNAME_CorporateBrandingImage_ID, Integer.valueOf(CorporateBrandingImage_ID));
 	}
 
-	/** Get D-U-N-S.
-		@return Dun & Bradstreet Number
+	/** Get Corporate Branding Image.
+		@return Corporate Branding Image
 	  */
-	public String getDUNS () 
+	public int getCorporateBrandingImage_ID () 
 	{
-		return (String)get_Value(COLUMNNAME_DUNS);
+		Integer ii = (Integer)get_Value(COLUMNNAME_CorporateBrandingImage_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
 	}
 
 	public org.compiere.model.I_M_Warehouse getDropShip_Warehouse() throws RuntimeException
@@ -197,6 +203,23 @@ public class X_AD_OrgInfo extends PO implements I_AD_OrgInfo, I_Persistent
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
+	}
+
+	/** Set D-U-N-S.
+		@param DUNS 
+		Dun & Bradstreet Number
+	  */
+	public void setDUNS (String DUNS)
+	{
+		set_Value (COLUMNNAME_DUNS, DUNS);
+	}
+
+	/** Get D-U-N-S.
+		@return Dun & Bradstreet Number
+	  */
+	public String getDUNS () 
+	{
+		return (String)get_Value(COLUMNNAME_DUNS);
 	}
 
 	/** Set EMail Address.
@@ -486,23 +509,6 @@ public class X_AD_OrgInfo extends PO implements I_AD_OrgInfo, I_Persistent
 		return ii.intValue();
 	}
 
-	/** Set Immutable Universally Unique Identifier.
-		@param UUID 
-		Immutable Universally Unique Identifier
-	  */
-	public void setUUID (String UUID)
-	{
-		set_Value (COLUMNNAME_UUID, UUID);
-	}
-
-	/** Get Immutable Universally Unique Identifier.
-		@return Immutable Universally Unique Identifier
-	  */
-	public String getUUID () 
-	{
-		return (String)get_Value(COLUMNNAME_UUID);
-	}
-
 	public org.compiere.model.I_C_DocType getUnidentifiedAPDocType() throws RuntimeException
     {
 		return (org.compiere.model.I_C_DocType)MTable.get(getCtx(), org.compiere.model.I_C_DocType.Table_Name)
@@ -576,5 +582,22 @@ public class X_AD_OrgInfo extends PO implements I_AD_OrgInfo, I_Persistent
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
+	}
+
+	/** Set Immutable Universally Unique Identifier.
+		@param UUID 
+		Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID)
+	{
+		set_Value (COLUMNNAME_UUID, UUID);
+	}
+
+	/** Get Immutable Universally Unique Identifier.
+		@return Immutable Universally Unique Identifier
+	  */
+	public String getUUID () 
+	{
+		return (String)get_Value(COLUMNNAME_UUID);
 	}
 }

--- a/migration/393lts-394lts/06900_Add_Price_Checking_Image_for_Organization.xml
+++ b/migration/393lts-394lts/06900_Add_Price_Checking_Image_for_Organization.xml
@@ -6,14 +6,14 @@
         <Data AD_Column_ID="84316" Column="UUID">6f273521-eb84-4cdb-8a4f-39a550571c00</Data>
         <Data AD_Column_ID="2600" Column="Updated">2020-11-19 10:30:19.178</Data>
         <Data AD_Column_ID="2597" Column="IsActive">true</Data>
-        <Data AD_Column_ID="2603" Column="Name">Price Checking Image</Data>
-        <Data AD_Column_ID="2604" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="2603" Column="Name">Corporate Branding Image</Data>
+        <Data AD_Column_ID="2604" Column="Description">Corporate Branding Image</Data>
         <Data AD_Column_ID="2598" Column="Created">2020-11-19 10:30:19.178</Data>
-        <Data AD_Column_ID="2602" Column="ColumnName">PriceCheckingImage_ID</Data>
-        <Data AD_Column_ID="2605" Column="Help">Image for Price Checking</Data>
+        <Data AD_Column_ID="2602" Column="ColumnName">CorporateBrandingImage_ID</Data>
+        <Data AD_Column_ID="2605" Column="Help">Corporate Branding Image</Data>
         <Data AD_Column_ID="6284" Column="PO_Help" isNewNull="true"/>
         <Data AD_Column_ID="6285" Column="PO_Name" isNewNull="true"/>
-        <Data AD_Column_ID="4299" Column="PrintName">Price Checking Image</Data>
+        <Data AD_Column_ID="4299" Column="PrintName">Corporate Branding Image</Data>
         <Data AD_Column_ID="6286" Column="PO_PrintName" isNewNull="true"/>
         <Data AD_Column_ID="6283" Column="PO_Description" isNewNull="true"/>
         <Data AD_Column_ID="58589" Column="FieldLength">10</Data>
@@ -35,11 +35,11 @@
         <Data AD_Column_ID="2644" Column="Updated">2020-11-19 10:30:21.183</Data>
         <Data AD_Column_ID="2638" Column="AD_Language">es_MX</Data>
         <Data AD_Column_ID="6450" Column="PO_Name" isNewNull="true"/>
-        <Data AD_Column_ID="2648" Column="Help">Image for Price Checking</Data>
-        <Data AD_Column_ID="2646" Column="Name">Price Checking Image</Data>
-        <Data AD_Column_ID="2647" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="2648" Column="Help">Corporate Branding Image</Data>
+        <Data AD_Column_ID="2646" Column="Name">Corporate Branding Image</Data>
+        <Data AD_Column_ID="2647" Column="Description">Corporate Branding Image</Data>
         <Data AD_Column_ID="2649" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="4300" Column="PrintName">Price Checking Image</Data>
+        <Data AD_Column_ID="4300" Column="PrintName">Corporate Branding Image</Data>
         <Data AD_Column_ID="6451" Column="PO_PrintName" isNewNull="true"/>
         <Data AD_Column_ID="6448" Column="PO_Description" isNewNull="true"/>
         <Data AD_Column_ID="2640" Column="AD_Org_ID">0</Data>
@@ -53,17 +53,17 @@
     <Step SeqNo="30" StepType="AD">
       <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
         <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>
-        <Data AD_Column_ID="2648" Column="Help" oldValue="Image for Price Checking">Imagen de Consulta de Precios de Artículos</Data>
-        <Data AD_Column_ID="2646" Column="Name" oldValue="Price Checking Image">Imagen de Consulta de Precios</Data>
-        <Data AD_Column_ID="2647" Column="Description" oldValue="Price Checking Image">Imagen de Consulta de Precios</Data>
-        <Data AD_Column_ID="4300" Column="PrintName" oldValue="Price Checking Image">Imagen de Consulta de Precios</Data>
+        <Data AD_Column_ID="2648" Column="Help" oldValue="Corporate Branding Image">Imagen de Marca Corporativa, usada para consulta de precios, catálogos y demás</Data>
+        <Data AD_Column_ID="2646" Column="Name" oldValue="Corporate Branding Image">Imagen de Marca Corporativa</Data>
+        <Data AD_Column_ID="2647" Column="Description" oldValue="Corporate Branding Image">Imagen de Marca Corporativa</Data>
+        <Data AD_Column_ID="4300" Column="PrintName" oldValue="Corporate Branding Image">Imagen de Marca Corporativa</Data>
         <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="61553">61553</Data>
       </PO>
     </Step>
     <Step SeqNo="40" StepType="AD">
       <PO AD_Table_ID="101" Action="I" Record_ID="97393" Table="AD_Column">
         <Data AD_Column_ID="3360" Column="IsUpdateable">true</Data>
-        <Data AD_Column_ID="112" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="112" Column="Description">Corporate Branding Image</Data>
         <Data AD_Column_ID="548" Column="IsActive">true</Data>
         <Data AD_Column_ID="90939" Column="AD_Image_ID" isNewNull="true"/>
         <Data AD_Column_ID="549" Column="Created">2020-11-19 10:38:40.97</Data>
@@ -72,7 +72,7 @@
         <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
         <Data AD_Column_ID="109" Column="AD_Column_ID">97393</Data>
         <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
-        <Data AD_Column_ID="111" Column="Name">Price Checking Image</Data>
+        <Data AD_Column_ID="111" Column="Name">Corporate Branding Image</Data>
         <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
         <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
         <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
@@ -86,8 +86,8 @@
         <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
         <Data AD_Column_ID="110" Column="Version">0</Data>
         <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
-        <Data AD_Column_ID="116" Column="ColumnName">PriceCheckingImage_ID</Data>
-        <Data AD_Column_ID="113" Column="Help">Image for Price Checking</Data>
+        <Data AD_Column_ID="116" Column="ColumnName">CorporateBrandingImage_ID</Data>
+        <Data AD_Column_ID="113" Column="Help">Corporate Branding Image</Data>
         <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
         <Data AD_Column_ID="11617" Column="IsAlwaysUpdateable">false</Data>
         <Data AD_Column_ID="128" Column="IsEncrypted">N</Data>
@@ -122,7 +122,7 @@
         <Data AD_Column_ID="12952" Column="Updated">2020-11-19 10:38:42.219</Data>
         <Data AD_Column_ID="12955" Column="AD_Column_ID">97393</Data>
         <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="12957" Column="Name">Price Checking Image</Data>
+        <Data AD_Column_ID="12957" Column="Name">Corporate Branding Image</Data>
         <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="12958" Column="UpdatedBy">100</Data>
@@ -134,7 +134,7 @@
     <Step SeqNo="60" StepType="AD">
       <PO AD_Table_ID="107" Action="I" Record_ID="100049" Table="AD_Field">
         <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
-        <Data AD_Column_ID="170" Column="Help">Image for Price Checking</Data>
+        <Data AD_Column_ID="170" Column="Help">Corporate Branding Image</Data>
         <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
         <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
         <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
@@ -162,7 +162,7 @@
         <Data AD_Column_ID="172" Column="AD_Tab_ID">170</Data>
         <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
         <Data AD_Column_ID="84320" Column="UUID">2f7a1074-e588-412d-8bf3-7a23ab63bd48</Data>
-        <Data AD_Column_ID="168" Column="Name">Price Checking Image</Data>
+        <Data AD_Column_ID="168" Column="Name">Corporate Branding Image</Data>
         <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
         <Data AD_Column_ID="579" Column="Created">2020-11-19 10:39:19.231</Data>
         <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
@@ -173,7 +173,7 @@
         <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
         <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
         <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
-        <Data AD_Column_ID="169" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="169" Column="Description">Corporate Branding Image</Data>
         <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
         <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
         <Data AD_Column_ID="182" Column="SortNo">0</Data>
@@ -185,10 +185,10 @@
         <Data AD_Column_ID="672" Column="Created">2020-11-19 10:39:20.514</Data>
         <Data AD_Column_ID="674" Column="Updated">2020-11-19 10:39:20.514</Data>
         <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
-        <Data AD_Column_ID="287" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="287" Column="Description">Corporate Branding Image</Data>
         <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
-        <Data AD_Column_ID="286" Column="Name">Price Checking Image</Data>
-        <Data AD_Column_ID="288" Column="Help">Image for Price Checking</Data>
+        <Data AD_Column_ID="286" Column="Name">Corporate Branding Image</Data>
+        <Data AD_Column_ID="288" Column="Help">Corporate Branding Image</Data>
         <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="284" Column="AD_Field_ID">100049</Data>
         <Data AD_Column_ID="673" Column="CreatedBy">100</Data>

--- a/migration/393lts-394lts/06900_Add_Price_Checking_Image_for_Organization.xml
+++ b/migration/393lts-394lts/06900_Add_Price_Checking_Image_for_Organization.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add Price Checking  Image for Organization" ReleaseNo="3.9.4" SeqNo="6900">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="276" Action="I" Record_ID="61553" Table="AD_Element">
+        <Data AD_Column_ID="84316" Column="UUID">6f273521-eb84-4cdb-8a4f-39a550571c00</Data>
+        <Data AD_Column_ID="2600" Column="Updated">2020-11-19 10:30:19.178</Data>
+        <Data AD_Column_ID="2597" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2603" Column="Name">Price Checking Image</Data>
+        <Data AD_Column_ID="2604" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="2598" Column="Created">2020-11-19 10:30:19.178</Data>
+        <Data AD_Column_ID="2602" Column="ColumnName">PriceCheckingImage_ID</Data>
+        <Data AD_Column_ID="2605" Column="Help">Image for Price Checking</Data>
+        <Data AD_Column_ID="6284" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="6285" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="4299" Column="PrintName">Price Checking Image</Data>
+        <Data AD_Column_ID="6286" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="6283" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="58589" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="58588" Column="AD_Reference_ID">32</Data>
+        <Data AD_Column_ID="2594" Column="AD_Element_ID">61553</Data>
+        <Data AD_Column_ID="2596" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2595" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="6484" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="2599" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58590" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2601" Column="UpdatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="277" Action="I" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2642" Column="Created">2020-11-19 10:30:21.183</Data>
+        <Data AD_Column_ID="6449" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="2641" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2644" Column="Updated">2020-11-19 10:30:21.183</Data>
+        <Data AD_Column_ID="2638" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="6450" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="2648" Column="Help">Image for Price Checking</Data>
+        <Data AD_Column_ID="2646" Column="Name">Price Checking Image</Data>
+        <Data AD_Column_ID="2647" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="2649" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="4300" Column="PrintName">Price Checking Image</Data>
+        <Data AD_Column_ID="6451" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="6448" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="2640" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2639" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2645" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2643" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID">61553</Data>
+        <Data AD_Column_ID="84317" Column="UUID">b9d76433-1957-4b59-ad9e-eb61de5c6eee</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+        <Data AD_Column_ID="2648" Column="Help" oldValue="Image for Price Checking">Imagen de Consulta de Precios de Artículos</Data>
+        <Data AD_Column_ID="2646" Column="Name" oldValue="Price Checking Image">Imagen de Consulta de Precios</Data>
+        <Data AD_Column_ID="2647" Column="Description" oldValue="Price Checking Image">Imagen de Consulta de Precios</Data>
+        <Data AD_Column_ID="4300" Column="PrintName" oldValue="Price Checking Image">Imagen de Consulta de Precios</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="61553">61553</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="101" Action="I" Record_ID="97393" Table="AD_Column">
+        <Data AD_Column_ID="3360" Column="IsUpdateable">true</Data>
+        <Data AD_Column_ID="112" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="548" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90939" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="549" Column="Created">2020-11-19 10:38:40.97</Data>
+        <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="551" Column="Updated">2020-11-19 10:38:40.97</Data>
+        <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="109" Column="AD_Column_ID">97393</Data>
+        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="111" Column="Name">Price Checking Image</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="120" Column="IsParent">false</Data>
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
+        <Data AD_Column_ID="6483" Column="IsSyncDatabase">N</Data>
+        <Data AD_Column_ID="119" Column="IsKey">false</Data>
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="56352" Column="FormatPattern" isNewNull="true"/>
+        <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
+        <Data AD_Column_ID="110" Column="Version">0</Data>
+        <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
+        <Data AD_Column_ID="116" Column="ColumnName">PriceCheckingImage_ID</Data>
+        <Data AD_Column_ID="113" Column="Help">Image for Price Checking</Data>
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="11617" Column="IsAlwaysUpdateable">false</Data>
+        <Data AD_Column_ID="128" Column="IsEncrypted">N</Data>
+        <Data AD_Column_ID="54358" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="56187" Column="IsAllowLogging">true</Data>
+        <Data AD_Column_ID="56149" Column="IsAutocomplete">false</Data>
+        <Data AD_Column_ID="68024" Column="IsRange">false</Data>
+        <Data AD_Column_ID="62199" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="127" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="6482" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">228</Data>
+        <Data AD_Column_ID="550" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2608" Column="AD_Element_ID">61553</Data>
+        <Data AD_Column_ID="227" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="115" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="118" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="226" Column="AD_Reference_ID">32</Data>
+        <Data AD_Column_ID="552" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84306" Column="UUID">4e2953c2-693e-4d53-b2a0-0461069c1deb</Data>
+        <Data AD_Column_ID="3369" Column="AD_Process_ID" isNewNull="true"/>
+        <Data AD_Column_ID="92541" Column="RequiresSync">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="752" Action="I" Record_ID="97393" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12960" Column="Created">2020-11-19 10:38:42.219</Data>
+        <Data AD_Column_ID="12959" Column="IsActive">true</Data>
+        <Data AD_Column_ID="12952" Column="Updated">2020-11-19 10:38:42.219</Data>
+        <Data AD_Column_ID="12955" Column="AD_Column_ID">97393</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="12957" Column="Name">Price Checking Image</Data>
+        <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="12958" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="12956" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84310" Column="UUID">075a68be-f1b9-4e10-b495-aa7944e29154</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="100049" Table="AD_Field">
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">Image for Price Checking</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth">0</Data>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">100049</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">240</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID">50012</Data>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">97393</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">240</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">0</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">170</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">2f7a1074-e588-412d-8bf3-7a23ab63bd48</Data>
+        <Data AD_Column_ID="168" Column="Name">Price Checking Image</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2020-11-19 10:39:19.231</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2020-11-19 10:39:19.231</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="100049" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2020-11-19 10:39:20.514</Data>
+        <Data AD_Column_ID="674" Column="Updated">2020-11-19 10:39:20.514</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="287" Column="Description">Price Checking Image</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="286" Column="Name">Price Checking Image</Data>
+        <Data AD_Column_ID="288" Column="Help">Image for Price Checking</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">100049</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">b0031710-ba70-4981-b572-89b291b4371b</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Minor change for add price checking image for organization:
![Screenshot_20201119_104415](https://user-images.githubusercontent.com/2333092/99682818-0b4bc080-2a56-11eb-9ac0-24b75ffeb4eb.png)

This can be used for load some like this: https://docs.erpya.com/es/4.0.0/adempiere/quote-to-invoice/consultation-of-product-prices.html