### PR TITLE
Prevent NPE for barcode report

### DIFF
--- a/base/src/org/compiere/print/layout/BarcodeElement.java
+++ b/base/src/org/compiere/print/layout/BarcodeElement.java
@@ -38,9 +38,16 @@ import org.compiere.print.MPrintFormatItem;
  * 
  * @author Teo Sarca, SC ARHIPAC SERVICE SRL
  * 			<li>FR [ 1803359 ] Migrate to barbecue 1.1
+ * @author Yamel Senih, ysenih@erpya.com, ERPCyA http://www.erpya.com
+ * 	Prevent NPE for barcode with undefined
  */
 public class BarcodeElement extends PrintElement
 {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -935853466496345172L;
+
 	/**
 	 * 	Barcode Element Constructor
 	 *	@param code barcode data string
@@ -142,13 +149,13 @@ public class BarcodeElement extends PrintElement
 			m_valid = false;
 		}
 		
-		if ( item.isPrintBarcodeText() )
-			m_barcode.setDrawingText(true);
-		else
-			m_barcode.setDrawingText(false);
-		
-		if (m_valid && m_barcode != null)
-		{
+		if (m_valid && m_barcode != null) {
+			if(item.isPrintBarcodeText()) {
+				m_barcode.setDrawingText(true);
+			} else {
+				m_barcode.setDrawingText(false);
+			}
+			//	
 			if (item.getAD_PrintFont_ID() != 0)
 			{
 				MPrintFont mFont = MPrintFont.get(item.getAD_PrintFont_ID());


### PR DESCRIPTION
When a Barcode is enable for a print format item it should generate according with barcode standard rules, the problem is that if a data used for generate barcode not have the minimum for create barcode then is generate a NPE when is running report. The follow is the trace:

```Java
-----------> BarcodeElement.createBarcode: 1000016 - net.sourceforge.barbecue.BarcodeException: Invalid data length [18]
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at org.compiere.print.layout.BarcodeElement.createBarcode(BarcodeElement.java:146)
	at org.compiere.print.layout.BarcodeElement.<init>(BarcodeElement.java:57)
	at org.compiere.print.layout.LayoutEngine.layoutTable(LayoutEngine.java:1823)
	at org.compiere.print.layout.LayoutEngine.layout(LayoutEngine.java:481)
	at org.compiere.print.layout.LayoutEngine.setPrintData(LayoutEngine.java:295)
	at org.compiere.print.ReportEngine.setPrintFormat(ReportEngine.java:229)
	at org.compiere.print.Viewer.cmd_report(Viewer.java:1300)
	at org.compiere.print.Viewer.cmd_report(Viewer.java:1207)
	at org.compiere.print.Viewer.actionPerformed(Viewer.java:853)
	at javax.swing.JComboBox.fireActionEvent(JComboBox.java:1258)
	at javax.swing.JComboBox.setSelectedItem(JComboBox.java:586)
	at javax.swing.JComboBox.setSelectedIndex(JComboBox.java:622)
	at javax.swing.plaf.basic.BasicComboPopup$Handler.mouseReleased(BasicComboPopup.java:852)
	at java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:290)
	at java.awt.Component.processMouseEvent(Component.java:6535)
	at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
	at javax.swing.plaf.basic.BasicComboPopup$1.processMouseEvent(BasicComboPopup.java:501)
	at java.awt.Component.processEvent(Component.java:6300)
	at java.awt.Container.processEvent(Container.java:2236)
	at java.awt.Component.dispatchEventImpl(Component.java:4891)
	at java.awt.Container.dispatchEventImpl(Container.java:2294)
	at java.awt.Component.dispatchEvent(Component.java:4713)
	at java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4888)
	at java.awt.LightweightDispatcher.processMouseEvent(Container.java:4525)
	at java.awt.LightweightDispatcher.dispatchEvent(Container.java:4466)
	at java.awt.Container.dispatchEventImpl(Container.java:2280)
	at java.awt.Window.dispatchEventImpl(Window.java:2750)
	at java.awt.Component.dispatchEvent(Component.java:4713)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.awt.EventQueue$4.run(EventQueue.java:731)
	at java.awt.EventQueue$4.run(EventQueue.java:729)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:76)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

```

Note that barcode hope a value with more length:

```Java
-----------> BarcodeElement.createBarcode: 1000016 - net.sourceforge.barbecue.BarcodeException: Invalid data length [18]
```

Is a minor change but very useful because a report is not showed to user when exist error like it