### PR TITLE
Fixed error with NPE for Token Definition

### DIFF
--- a/base/src/org/spin/model/MADTokenDefinition.java
+++ b/base/src/org/spin/model/MADTokenDefinition.java
@@ -67,7 +67,6 @@ public class MADTokenDefinition extends X_AD_TokenDefinition {
 			return definition;
 
 		definition = new Query(ctx , Table_Name , COLUMNNAME_AD_TokenDefinition_ID + "=?" , trxName)
-				.setClient_ID()
 				.setParameters(definitionId)
 				.first();
 		if (definition != null && definition.get_ID() > 0) {


### PR DESCRIPTION
When a token definition is default defined by System it can throw a NPE when a token is validate