### PR TITLE
Remove unnecessary validation of cash tender type for Cash window

### DIFF
--- a/migration/393lts-394lts/07110_Remove_Cash_Validation.xml
+++ b/migration/393lts-394lts/07110_Remove_Cash_Validation.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Remove Cash Validation" ReleaseNo="3.9.4" SeqNo="7110">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="5046" Table="AD_Column">
+        <Data AD_Column_ID="115" Column="AD_Val_Rule_ID" isNewNull="true" oldValue="52078"/>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="4056" Table="AD_Field">
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isOldNull="true">17</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isOldNull="true">214</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isOldNull="true">52078</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
This pull request just remove a validation for filter tender types of Cash window when they are **Cash** or **Credit Memo** for Payment is keep this validation