### PR TITLE
Add support to multi-currency to Payment Selection Create From:

### DIFF
--- a/base/src/org/compiere/model/MPaySelectionLine.java
+++ b/base/src/org/compiere/model/MPaySelectionLine.java
@@ -32,7 +32,6 @@ import org.compiere.util.Env;
 import org.eevolution.model.X_HR_Employee;
 import org.eevolution.model.X_HR_Movement;
 import org.eevolution.model.X_HR_Payroll;
-import org.eevolution.model.X_HR_Process;
 
 /**
  *	Payment Selection Line Model
@@ -199,13 +198,24 @@ public class MPaySelectionLine extends X_C_PaySelectionLine
 	}	//	setOrder
 	
 	/**
-	 * Set Payroll Movement Info
-	 * @param movementId
+	 * Based on movement
+	 * @param movement
 	 * @param sourceAmount
+	 * @param convertedAmount
 	 */
-	public void setHRMovement(int movementId, BigDecimal sourceAmount, BigDecimal convertedAmount) {
-		setHR_Movement_ID(movementId);
-		X_HR_Movement movement = new X_HR_Movement(getCtx(), movementId, get_TrxName());
+	public void setHRMovement(X_HR_Movement movement, BigDecimal sourceAmount, BigDecimal convertedAmount) {
+		Optional.ofNullable(movement.getHR_Process()).ifPresent(payrollProcess -> setHRMovement(movement, payrollProcess.getC_ConversionType_ID(), sourceAmount, convertedAmount));
+	}
+	
+	/**
+	 * Set Payroll Movement Info
+	 * @param movement
+	 * @param conversionTypeId
+	 * @param sourceAmount
+	 * @param convertedAmount
+	 */
+	public void setHRMovement(X_HR_Movement movement, int conversionTypeId, BigDecimal sourceAmount, BigDecimal convertedAmount) {
+		setHR_Movement_ID(movement.getHR_Movement_ID());
 		setC_BPartner_ID(movement.getC_BPartner_ID());
 		//	Set Payment Rule
 		X_HR_Employee employee = (X_HR_Employee) movement.getHR_Employee();
@@ -230,12 +240,11 @@ public class MPaySelectionLine extends X_C_PaySelectionLine
 			setPaymentRule(X_C_PaySelectionLine.PAYMENTRULE_Check);
 		}
 		//	Get Conversion Type
-		X_HR_Process process = new X_HR_Process(getCtx(), movement.getHR_Process_ID(), get_TrxName());
 		setIsSOTrx(false);
 		setAmtSource(sourceAmount);
 		setOpenAmt(Optional.ofNullable(convertedAmount).orElse(sourceAmount));
 		setPayAmt(Optional.ofNullable(convertedAmount).orElse(sourceAmount));
-		setC_ConversionType_ID(process.getC_ConversionType_ID());
+		setC_ConversionType_ID(conversionTypeId);
 		setDiscountAmt(Env.ZERO);
 		setDifferenceAmt(Env.ZERO);
 	}	//	setHRMovement

--- a/base/src/org/compiere/model/MPaySelectionLine.java
+++ b/base/src/org/compiere/model/MPaySelectionLine.java
@@ -23,6 +23,7 @@ package org.compiere.model;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
+import java.util.Optional;
 import java.util.Properties;
 
 import org.adempiere.exceptions.AdempiereException;
@@ -31,6 +32,7 @@ import org.compiere.util.Env;
 import org.eevolution.model.X_HR_Employee;
 import org.eevolution.model.X_HR_Movement;
 import org.eevolution.model.X_HR_Payroll;
+import org.eevolution.model.X_HR_Process;
 
 /**
  *	Payment Selection Line Model
@@ -189,9 +191,9 @@ public class MPaySelectionLine extends X_C_PaySelectionLine
 	/**
 	 * Set Payroll Movement Info
 	 * @param movementId
-	 * @param payAmt
+	 * @param sourceAmount
 	 */
-	public void setHRMovement(int movementId, BigDecimal payAmt) {
+	public void setHRMovement(int movementId, BigDecimal sourceAmount, BigDecimal convertedAmount) {
 		setHR_Movement_ID(movementId);
 		X_HR_Movement movement = new X_HR_Movement(getCtx(), movementId, get_TrxName());
 		setC_BPartner_ID(movement.getC_BPartner_ID());
@@ -217,11 +219,13 @@ public class MPaySelectionLine extends X_C_PaySelectionLine
 		if(getPaymentRule() == null) {
 			setPaymentRule(X_C_PaySelectionLine.PAYMENTRULE_Check);
 		}
-		//	
+		//	Get Conversion Type
+		X_HR_Process process = new X_HR_Process(getCtx(), movement.getHR_Process_ID(), get_TrxName());
 		setIsSOTrx(false);
-		setAmtSource(payAmt);
-		setOpenAmt(payAmt);
-		setPayAmt (payAmt);
+		setAmtSource(sourceAmount);
+		setOpenAmt(Optional.ofNullable(convertedAmount).orElse(sourceAmount));
+		setPayAmt(Optional.ofNullable(convertedAmount).orElse(sourceAmount));
+		setC_ConversionType_ID(process.getC_ConversionType_ID());
 		setDiscountAmt(Env.ZERO);
 		setDifferenceAmt(Env.ZERO);
 	}	//	setHRMovement

--- a/base/src/org/compiere/model/MPaySelectionLine.java
+++ b/base/src/org/compiere/model/MPaySelectionLine.java
@@ -131,6 +131,10 @@ public class MPaySelectionLine extends X_C_PaySelectionLine
 		setIsSOTrx(isSOTrx);
 		setOpenAmt(openAmt);
 		setPayAmt (payAmt);
+		MInvoice invoice = new MInvoice(getCtx(), invoiceId, get_TrxName());
+		if(invoice.getC_ConversionType_ID() > 0) {
+			setC_ConversionType_ID(order.getC_ConversionType_ID());
+		}
 		setDiscountAmt(discountAmt);
 		setDifferenceAmt(openAmt.subtract(payAmt).subtract(discountAmt));
 	}	//	setInvoive
@@ -157,6 +161,9 @@ public class MPaySelectionLine extends X_C_PaySelectionLine
 		setAmtSource(amtSource);
 		setOpenAmt(openAmt);
 		setPayAmt (payAmt);
+		if(invoice.getC_ConversionType_ID() > 0) {
+			setC_ConversionType_ID(order.getC_ConversionType_ID());
+		}
 		setDiscountAmt(discountAmt);
 		setDifferenceAmt(openAmt.subtract(payAmt).subtract(discountAmt));
 	}	//	setInvoice
@@ -184,6 +191,9 @@ public class MPaySelectionLine extends X_C_PaySelectionLine
 		setAmtSource(amtSource);
 		setOpenAmt(openAmt);
 		setPayAmt (payAmt);
+		if(order.getC_ConversionType_ID() > 0) {
+			setC_ConversionType_ID(order.getC_ConversionType_ID());
+		}
 		setDiscountAmt(discountAmt);
 		setDifferenceAmt(openAmt.subtract(payAmt).subtract(discountAmt));
 	}	//	setOrder

--- a/base/src/org/compiere/model/MPaySelectionLine.java
+++ b/base/src/org/compiere/model/MPaySelectionLine.java
@@ -162,7 +162,7 @@ public class MPaySelectionLine extends X_C_PaySelectionLine
 		setOpenAmt(openAmt);
 		setPayAmt (payAmt);
 		if(invoice.getC_ConversionType_ID() > 0) {
-			setC_ConversionType_ID(order.getC_ConversionType_ID());
+			setC_ConversionType_ID(invoice.getC_ConversionType_ID());
 		}
 		setDiscountAmt(discountAmt);
 		setDifferenceAmt(openAmt.subtract(payAmt).subtract(discountAmt));

--- a/base/src/org/compiere/process/PSCreateFromHRMovement.java
+++ b/base/src/org/compiere/process/PSCreateFromHRMovement.java
@@ -17,10 +17,16 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MPaySelection;
 import org.compiere.model.MPaySelectionLine;
+import org.eevolution.model.X_HR_Movement;
+import org.eevolution.model.X_HR_Process;
 
 /**
  * 	Payment Selection Create From Invoice, used for Smart Browse (Create From Payroll Movement)
@@ -31,8 +37,9 @@ import org.compiere.model.MPaySelectionLine;
 public class PSCreateFromHRMovement extends PSCreateFromHRMovementAbstract {
 
 	/**	Sequence			*/
-	private int				m_SeqNo = 10;
-	
+	private AtomicInteger sequence = new AtomicInteger(10);
+	/**	Process Cache	*/
+	private Map<Integer, X_HR_Process> payrollProcessMap = new HashMap<>();
 	@Override
 	protected void prepare() {
 		super.prepare();
@@ -45,21 +52,27 @@ public class PSCreateFromHRMovement extends PSCreateFromHRMovementAbstract {
 	protected String doIt() throws Exception {
 		//	Instance current Payment Selection
 		MPaySelection paySelection = new MPaySelection(getCtx(), getRecord_ID(), get_TrxName());
-		m_SeqNo = paySelection.getLastLineNo();
+		sequence.set(paySelection.getLastLineNo());
 		//	Loop for keys
-		for(Integer key : getSelectionKeys()) {
+		getSelectionKeys().forEach(key -> {
 			//	get values from result set
-			int HR_Movement_ID = key;
-			String PaymentRule = getSelectionAsString(key, "HRM_PaymentRule");
+			int movementId = key;
+			String paymentRule = getSelectionAsString(key, "HRM_PaymentRule");
 			BigDecimal sourceAmount = getSelectionAsBigDecimal(key, "HRM_Amount");
 			BigDecimal convertedAmount = getSelectionAsBigDecimal(key, "HRM_ConvertedAmount");
-			m_SeqNo += 10;
-			MPaySelectionLine line = new MPaySelectionLine(paySelection, m_SeqNo, PaymentRule);
+			MPaySelectionLine line = new MPaySelectionLine(paySelection, sequence.getAndAdd(10), paymentRule);
 			//	Add Order
-			line.setHRMovement(HR_Movement_ID, sourceAmount, convertedAmount);
+			X_HR_Movement payrollMovement = new X_HR_Movement(getCtx(), movementId, get_TrxName());
+			X_HR_Process payrollProcess = payrollProcessMap.get(payrollMovement.getHR_Process_ID());
+			if(!Optional.ofNullable(payrollProcess).isPresent()) {
+				payrollProcess = (X_HR_Process) payrollMovement.getHR_Process();
+				payrollProcessMap.put(payrollMovement.getHR_Process_ID(), payrollProcess);
+			}
+			//	Set from Payroll Movement and conversion type
+			line.setHRMovement(payrollMovement, payrollProcess.getC_ConversionType_ID(), sourceAmount, convertedAmount);
 			//	Save
 			line.saveEx();
-		}
+		});
 		//	Default Ok
 		return "@OK@";
 	}

--- a/base/src/org/compiere/process/PSCreateFromHRMovement.java
+++ b/base/src/org/compiere/process/PSCreateFromHRMovement.java
@@ -51,11 +51,12 @@ public class PSCreateFromHRMovement extends PSCreateFromHRMovementAbstract {
 			//	get values from result set
 			int HR_Movement_ID = key;
 			String PaymentRule = getSelectionAsString(key, "HRM_PaymentRule");
-			BigDecimal Amount = getSelectionAsBigDecimal(key, "HRM_Amount");
+			BigDecimal sourceAmount = getSelectionAsBigDecimal(key, "HRM_Amount");
+			BigDecimal convertedAmount = getSelectionAsBigDecimal(key, "HRM_ConvertedAmount");
 			m_SeqNo += 10;
 			MPaySelectionLine line = new MPaySelectionLine(paySelection, m_SeqNo, PaymentRule);
 			//	Add Order
-			line.setHRMovement(HR_Movement_ID, Amount);
+			line.setHRMovement(HR_Movement_ID, sourceAmount, convertedAmount);
 			//	Save
 			line.saveEx();
 		}

--- a/migration/393lts-394lts/07170_Add_Multi_Currency_support_to_Payment_Selection.xml
+++ b/migration/393lts-394lts/07170_Add_Multi_Currency_support_to_Payment_Selection.xml
@@ -429,10 +429,9 @@
     </Step>
     <Step SeqNo="540" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70857" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">8dabdf3e-9a39-4beb-b5f8-7b859e17dbb7</Data>
         <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:40.983</Data>
         <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:40.983</Data>
-        <Data AD_Column_ID="84462" Column="UUID">8dabdf3e-9a39-4beb-b5f8-7b859e17dbb7</Data>
-        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
         <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
         <Data AD_Column_ID="58104" Column="Help">The Document Status indicates the status of a document at this time.  If you want to change the document status, use the Document Action field</Data>
         <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.DocStatus</Data>
@@ -447,6 +446,7 @@
         <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
         <Data AD_Column_ID="58109" Column="AD_Column_ID">54869</Data>
         <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
       </PO>
     </Step>
     <Step SeqNo="550" StepType="AD">
@@ -549,6 +549,7 @@
     </Step>
     <Step SeqNo="600" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70860" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">46dfd72d-480d-4b9a-952e-1bc9fbbf9eb4</Data>
         <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:46.327</Data>
         <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:46.327</Data>
         <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
@@ -565,7 +566,6 @@
         <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
         <Data AD_Column_ID="58109" Column="AD_Column_ID">54857</Data>
         <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
-        <Data AD_Column_ID="84462" Column="UUID">46dfd72d-480d-4b9a-952e-1bc9fbbf9eb4</Data>
         <Data AD_Column_ID="58095" Column="IsActive">true</Data>
       </PO>
     </Step>
@@ -590,6 +590,7 @@
     <Step SeqNo="620" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70861" Table="AD_View_Column">
         <Data AD_Column_ID="58109" Column="AD_Column_ID">54870</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
         <Data AD_Column_ID="84462" Column="UUID">b3d4545a-3b7d-4ec8-9796-69f225bd49c0</Data>
         <Data AD_Column_ID="58095" Column="IsActive">true</Data>
         <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:47.553</Data>
@@ -608,7 +609,6 @@ If the document type of your document has no automatic document sequence defined
         <Data AD_Column_ID="58103" Column="EntityType">D</Data>
         <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
         <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
-        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
       </PO>
     </Step>
     <Step SeqNo="630" StepType="AD">
@@ -711,10 +711,8 @@ If the document type of your document has no automatic document sequence defined
     </Step>
     <Step SeqNo="680" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70864" Table="AD_View_Column">
-        <Data AD_Column_ID="84462" Column="UUID">9c447eb4-12bc-4f1a-bd9e-53be53973843</Data>
         <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
-        <Data AD_Column_ID="58109" Column="AD_Column_ID">54874</Data>
-        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84462" Column="UUID">9c447eb4-12bc-4f1a-bd9e-53be53973843</Data>
         <Data AD_Column_ID="58095" Column="IsActive">true</Data>
         <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:51.513</Data>
         <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:51.513</Data>
@@ -732,6 +730,8 @@ There are two reasons for de-activating and not deleting records:
         <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="58103" Column="EntityType">D</Data>
         <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54874</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
       </PO>
     </Step>
     <Step SeqNo="690" StepType="AD">
@@ -776,8 +776,8 @@ There are two reasons for de-activating and not deleting records:
     </Step>
     <Step SeqNo="710" StepType="AD">
       <PO AD_Table_ID="53228" Action="I" Record_ID="70865" Table="AD_View_Column_Trl">
-        <Data AD_Column_ID="84463" Column="UUID">b9876232-c745-4032-be37-760e4be90a96</Data>
         <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:53.727</Data>
+        <Data AD_Column_ID="84463" Column="UUID">b9876232-c745-4032-be37-760e4be90a96</Data>
         <Data AD_Column_ID="58042" Column="IsActive">true</Data>
         <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:53.727</Data>
         <Data AD_Column_ID="58049" Column="Description">Posting status</Data>
@@ -834,8 +834,8 @@ There are two reasons for de-activating and not deleting records:
     </Step>
     <Step SeqNo="740" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70867" Table="AD_View_Column">
-        <Data AD_Column_ID="84462" Column="UUID">4dcff1ee-0820-4b3a-a44b-2b44f2579538</Data>
         <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84462" Column="UUID">4dcff1ee-0820-4b3a-a44b-2b44f2579538</Data>
         <Data AD_Column_ID="58095" Column="IsActive">true</Data>
         <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:55.466</Data>
         <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:55.466</Data>
@@ -914,6 +914,7 @@ There are two reasons for de-activating and not deleting records:
     </Step>
     <Step SeqNo="780" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70869" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">fe5bd95c-a70f-4cf8-9304-8d6d750e190b</Data>
         <Data AD_Column_ID="58095" Column="IsActive">true</Data>
         <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:58.241</Data>
         <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:58.241</Data>
@@ -931,7 +932,6 @@ There are two reasons for de-activating and not deleting records:
         <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
         <Data AD_Column_ID="58109" Column="AD_Column_ID">54881</Data>
         <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
-        <Data AD_Column_ID="84462" Column="UUID">fe5bd95c-a70f-4cf8-9304-8d6d750e190b</Data>
       </PO>
     </Step>
     <Step SeqNo="790" StepType="AD">
@@ -1034,8 +1034,9 @@ There are two reasons for de-activating and not deleting records:
     </Step>
     <Step SeqNo="840" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70872" Table="AD_View_Column">
-        <Data AD_Column_ID="84462" Column="UUID">1c1fb9d0-229a-4fe0-b6fd-a8564a2674fa</Data>
         <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:01.732</Data>
+        <Data AD_Column_ID="84462" Column="UUID">1c1fb9d0-229a-4fe0-b6fd-a8564a2674fa</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
         <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:01.732</Data>
         <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
         <Data AD_Column_ID="58104" Column="Help" isNewNull="true"/>
@@ -1051,7 +1052,6 @@ There are two reasons for de-activating and not deleting records:
         <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
         <Data AD_Column_ID="58109" Column="AD_Column_ID">54860</Data>
         <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
-        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
       </PO>
     </Step>
     <Step SeqNo="850" StepType="AD">
@@ -1097,9 +1097,9 @@ There are two reasons for de-activating and not deleting records:
     <Step SeqNo="870" StepType="AD">
       <PO AD_Table_ID="53228" Action="I" Record_ID="70873" Table="AD_View_Column_Trl">
         <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:04.047</Data>
+        <Data AD_Column_ID="58049" Column="Description">Identifies a Business Partner</Data>
         <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:04.047</Data>
         <Data AD_Column_ID="58042" Column="IsActive">true</Data>
-        <Data AD_Column_ID="58049" Column="Description">Identifies a Business Partner</Data>
         <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
         <Data AD_Column_ID="58052" Column="Name">Business Partner </Data>
@@ -1275,11 +1275,6 @@ There are two reasons for de-activating and not deleting records:
     <Step SeqNo="960" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70878" Table="AD_View_Column">
         <Data AD_Column_ID="84462" Column="UUID">d041784d-5451-42de-8eba-f1d87ec709e9</Data>
-        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
-        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:09.004</Data>
-        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:09.004</Data>
-        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
-        <Data AD_Column_ID="58104" Column="Help">The Workflow field identifies a unique Workflow in the system.</Data>
         <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.AD_Workflow_ID</Data>
         <Data AD_Column_ID="58105" Column="Name">Workflow</Data>
         <Data AD_Column_ID="58107" Column="ColumnName">HRP_AD_Workflow_ID</Data>
@@ -1292,6 +1287,11 @@ There are two reasons for de-activating and not deleting records:
         <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
         <Data AD_Column_ID="58109" Column="AD_Column_ID">54883</Data>
         <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:09.004</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:09.004</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Workflow field identifies a unique Workflow in the system.</Data>
       </PO>
     </Step>
     <Step SeqNo="970" StepType="AD">
@@ -1336,6 +1336,7 @@ There are two reasons for de-activating and not deleting records:
     </Step>
     <Step SeqNo="990" StepType="AD">
       <PO AD_Table_ID="53228" Action="I" Record_ID="70879" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70879</Data>
         <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:11.063</Data>
         <Data AD_Column_ID="58042" Column="IsActive">true</Data>
         <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:11.063</Data>
@@ -1343,7 +1344,6 @@ There are two reasons for de-activating and not deleting records:
         <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
         <Data AD_Column_ID="58052" Column="Name">Payroll Employee</Data>
-        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70879</Data>
         <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
         <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
@@ -1395,6 +1395,12 @@ There are two reasons for de-activating and not deleting records:
     <Step SeqNo="1020" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70881" Table="AD_View_Column">
         <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.UUID</Data>
+        <Data AD_Column_ID="84462" Column="UUID">cf28cd96-1b71-41b5-a687-87e1887f9440</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:12.774</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:12.774</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
         <Data AD_Column_ID="58105" Column="Name">Immutable Universally Unique Identifier</Data>
         <Data AD_Column_ID="58107" Column="ColumnName">HRP_UUID</Data>
         <Data AD_Column_ID="58102" Column="Description">Immutable Universally Unique Identifier</Data>
@@ -1406,12 +1412,6 @@ There are two reasons for de-activating and not deleting records:
         <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
         <Data AD_Column_ID="58109" Column="AD_Column_ID">84845</Data>
         <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
-        <Data AD_Column_ID="84462" Column="UUID">cf28cd96-1b71-41b5-a687-87e1887f9440</Data>
-        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
-        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:12.774</Data>
-        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:12.774</Data>
-        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
-        <Data AD_Column_ID="58104" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
       </PO>
     </Step>
     <Step SeqNo="1030" StepType="AD">
@@ -1456,7 +1456,6 @@ There are two reasons for de-activating and not deleting records:
     </Step>
     <Step SeqNo="1050" StepType="AD">
       <PO AD_Table_ID="53228" Action="I" Record_ID="70882" Table="AD_View_Column_Trl">
-        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:17.791</Data>
         <Data AD_Column_ID="58052" Column="Name">Currency</Data>
         <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70882</Data>
         <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
@@ -1465,6 +1464,7 @@ There are two reasons for de-activating and not deleting records:
         <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
         <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
         <Data AD_Column_ID="84463" Column="UUID">e02e3f7d-5ccc-4a62-98b4-789b68bd2b1c</Data>
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:17.791</Data>
         <Data AD_Column_ID="58042" Column="IsActive">true</Data>
         <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:17.791</Data>
         <Data AD_Column_ID="58049" Column="Description">The Currency for this record</Data>
@@ -1514,6 +1514,7 @@ There are two reasons for de-activating and not deleting records:
     </Step>
     <Step SeqNo="1080" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70884" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">0060e0db-22b9-4a6b-8024-ce0202a1e525</Data>
         <Data AD_Column_ID="58107" Column="ColumnName">HRP_HR_Period_ID</Data>
         <Data AD_Column_ID="58102" Column="Description" isNewNull="true"/>
         <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70884</Data>
@@ -1524,7 +1525,6 @@ There are two reasons for de-activating and not deleting records:
         <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
         <Data AD_Column_ID="58109" Column="AD_Column_ID">54873</Data>
         <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
-        <Data AD_Column_ID="84462" Column="UUID">0060e0db-22b9-4a6b-8024-ce0202a1e525</Data>
         <Data AD_Column_ID="58095" Column="IsActive">true</Data>
         <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:19.018</Data>
         <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:19.018</Data>
@@ -1576,20 +1576,20 @@ There are two reasons for de-activating and not deleting records:
     </Step>
     <Step SeqNo="1110" StepType="AD">
       <PO AD_Table_ID="53228" Action="I" Record_ID="70885" Table="AD_View_Column_Trl">
-        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:21.185</Data>
         <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70885</Data>
-        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
-        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
-        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
-        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
-        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
-        <Data AD_Column_ID="84463" Column="UUID">c980ff68-ad51-4c3c-8cf5-9323f5e86c44</Data>
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:21.185</Data>
         <Data AD_Column_ID="58042" Column="IsActive">true</Data>
         <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:21.185</Data>
         <Data AD_Column_ID="58049" Column="Description">Accounting Date</Data>
         <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
         <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
         <Data AD_Column_ID="58052" Column="Name">Account Date</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">c980ff68-ad51-4c3c-8cf5-9323f5e86c44</Data>
       </PO>
     </Step>
     <Step SeqNo="1120" StepType="AD">
@@ -1754,15 +1754,8 @@ There are two reasons for de-activating and not deleting records:
     </Step>
     <Step SeqNo="1200" StepType="AD">
       <PO AD_Table_ID="53232" Action="I" Record_ID="70890" Table="AD_View_Column">
-        <Data AD_Column_ID="84462" Column="UUID">45815574-c7cb-44b5-9452-a39befd9a97a</Data>
         <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70890</Data>
-        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
-        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
-        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
-        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
-        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
-        <Data AD_Column_ID="58109" Column="AD_Column_ID">96198</Data>
-        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84462" Column="UUID">45815574-c7cb-44b5-9452-a39befd9a97a</Data>
         <Data AD_Column_ID="58095" Column="IsActive">true</Data>
         <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:27.047</Data>
         <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:27.047</Data>
@@ -1772,6 +1765,13 @@ There are two reasons for de-activating and not deleting records:
         <Data AD_Column_ID="58105" Column="Name">Activity</Data>
         <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_Activity_ID</Data>
         <Data AD_Column_ID="58102" Column="Description">Business Activity</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">96198</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
       </PO>
     </Step>
     <Step SeqNo="1210" StepType="AD">
@@ -1835,6 +1835,2981 @@ There are two reasons for de-activating and not deleting records:
     <Step SeqNo="1240" StepType="AD">
       <PO AD_Table_ID="53232" Action="U" Record_ID="53812" Table="AD_View_Column">
         <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="hrm.Amount">currencyConvert(hrm.Amount, hrp.C_Currency_ID, @C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), hrp.C_ConversionType_ID,hrp.AD_Client_ID, hrp.AD_Org_ID)</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1250" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70892" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">08eb369a-1a27-4633-b84e-86278b5d3b1d</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 10:02:55.28</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 10:02:55.28</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50100</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Amount indicates the amount for this document line.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">currencyConvert(hrm.Amount, hrp.C_Currency_ID, @C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), hrp.C_ConversionType_ID,hrp.AD_Client_ID, hrp.AD_Org_ID)</Data>
+        <Data AD_Column_ID="58105" Column="Name">Converted Amount</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRM_ConvertedAmount</Data>
+        <Data AD_Column_ID="58102" Column="Description">Amount in a defined currency</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70892</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1260" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70892" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 10:02:56.172</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 10:02:56.172</Data>
+        <Data AD_Column_ID="58049" Column="Description">Amount in a defined currency</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Converted Amount</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70892</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">17205097-e951-4ef2-8b86-9d1fe805d167</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1270" StepType="AD">
+      <PO AD_Table_ID="53228" Action="U" Record_ID="70892" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58049" Column="Description" oldValue="Amount in a defined currency">Monto Convertido en moneda de cuenta bancaria</Data>
+        <Data AD_Column_ID="58052" Column="Name" oldValue="Converted Amount">Monto Convertido</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID" oldValue="70892">70892</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1280" StepType="AD">
+      <PO AD_Table_ID="53232" Action="U" Record_ID="53812" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="currencyConvert(hrm.Amount, hrp.C_Currency_ID, @C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), hrp.C_ConversionType_ID,hrp.AD_Client_ID, hrp.AD_Org_ID)">hrm.Amount</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1290" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70128" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:01.214</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Amount in a defined currency</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Amount indicates the amount for this document line.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">true</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Amount</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70128</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">110</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">1555</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70892</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">22</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength" isNewNull="true"/>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">14bb6779-5aeb-4eb7-b418-296bb43c560e</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:01.214</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1300" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70128</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84297" Column="UUID">e49bf8d0-2663-4351-8650-9b4834667fca</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:02.284</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:02.284</Data>
+        <Data AD_Column_ID="58036" Column="Description">Amount in a defined currency</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Amount indicates the amount for this document line.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Amount</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1310" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55168" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57977" Column="IsIdentifier" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1320" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70129" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:42.596</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:42.596</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Invoice Detail Line</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Invoice Line uniquely identifies a single line of an Invoice.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Invoice Line</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70129</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">10</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">1076</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">54813</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">2ae07e6d-8b74-40fe-ad7e-b481e8fb65a8</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1330" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">d53d1967-110f-4b62-9943-96fdc1952888</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Invoice Line</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70129</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:43.591</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:43.591</Data>
+        <Data AD_Column_ID="58036" Column="Description">Invoice Detail Line</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Invoice Line uniquely identifies a single line of an Invoice.</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1340" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70130" Table="AD_Browse_Field">
+        <Data AD_Column_ID="84296" Column="UUID">2cb906ec-d979-4932-aaa6-e27e75ca0b95</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:43.828</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:43.828</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">User defined list element #3</Data>
+        <Data AD_Column_ID="57974" Column="Help">The user defined element displays the optional elements that have been defined for this account combination.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">User List 3</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70130</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">11</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">53336</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">54080</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">54814</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1350" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">0592eb69-ef7b-4214-9d3b-8687607a6694</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:44.885</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:44.885</Data>
+        <Data AD_Column_ID="58036" Column="Description">User defined list element #3</Data>
+        <Data AD_Column_ID="58037" Column="Help">The user defined element displays the optional elements that have been defined for this account combination.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">User List 3</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70130</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1360" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70131" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:45.129</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:45.129</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">User defined list element #4</Data>
+        <Data AD_Column_ID="57974" Column="Help">The user defined element displays the optional elements that have been defined for this account combination.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">User List 4</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70131</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">12</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">53337</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">54081</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">54815</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">0dacc0b5-3832-4c7f-b645-9b09bbec985a</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1370" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">6c7f1975-6725-4de3-98ce-a7538a0cec66</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:46.008</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:46.008</Data>
+        <Data AD_Column_ID="58036" Column="Description">User defined list element #4</Data>
+        <Data AD_Column_ID="58037" Column="Help">The user defined element displays the optional elements that have been defined for this account combination.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">User List 4</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70131</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1380" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70132" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70132</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">13</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">2372</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">54816</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">affa3a56-d233-4985-979a-98915f813f4f</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:46.332</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:46.332</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Business Partner Relation</Data>
+        <Data AD_Column_ID="57974" Column="Help">Business Partner Relation allow to maintain Third Party Relationship rules: who receives invoices for shipments or pays for invoices.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Partner Relation</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1390" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">31a6f8e4-9e31-4376-99cd-6683b083bb50</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:47.144</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:47.144</Data>
+        <Data AD_Column_ID="58036" Column="Description">Business Partner Relation</Data>
+        <Data AD_Column_ID="58037" Column="Help">Business Partner Relation allow to maintain Third Party Relationship rules: who receives invoices for shipments or pays for invoices.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Partner Relation</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70132</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1400" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70133" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70133</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">14</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">131</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">289</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70857</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">17</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">2</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">0d0a385c-3253-4c79-a4da-625ecb7cd644</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:47.369</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:47.369</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">The current status of the document</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Document Status indicates the status of a document at this time.  If you want to change the document status, use the Document Action field</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Document Status</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="1410" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">67b86067-8e5d-4ac0-be8d-96e135fcc005</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:48.034</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:48.034</Data>
+        <Data AD_Column_ID="58036" Column="Description">The current status of the document</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Document Status indicates the status of a document at this time.  If you want to change the document status, use the Document Action field</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Document Status</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70133</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1420" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70134" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:48.324</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:48.324</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Alphanumeric identifier of the entity</Data>
+        <Data AD_Column_ID="57974" Column="Help">The name of an entity (record) is used as an default search option in addition to the search key. The name is up to 60 characters in length.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">true</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Name</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70134</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">15</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">469</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70858</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">10</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">60</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">04025731-31d1-4ee9-928f-407a799f81ae</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1430" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">6cf103ef-eae9-441e-b6ff-29168208e867</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:49.07</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:49.07</Data>
+        <Data AD_Column_ID="58036" Column="Description">Alphanumeric identifier of the entity</Data>
+        <Data AD_Column_ID="58037" Column="Help">The name of an entity (record) is used as an default search option in addition to the search key. The name is up to 60 characters in length.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Name</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70134</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1440" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70135" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:49.301</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:49.301</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Target document type for conversing documents</Data>
+        <Data AD_Column_ID="57974" Column="Help">You can convert document types (e.g. from Offer to Order or Invoice).  The conversion is then reflected in the current type.  This processing is initiated by selecting the appropriate Document Action.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Target Document Type</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70135</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">16</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">170</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">197</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70859</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">72d6f9ef-2efe-4b8a-9241-d03704a24d78</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1450" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="84297" Column="UUID">fbef5938-72ec-4495-9ea1-818d45d2a5c1</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:50.269</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:50.269</Data>
+        <Data AD_Column_ID="58036" Column="Description">Target document type for conversing documents</Data>
+        <Data AD_Column_ID="58037" Column="Help">You can convert document types (e.g. from Offer to Order or Invoice).  The conversion is then reflected in the current type.  This processing is initiated by selecting the appropriate Document Action.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Target Document Type</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70135</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1460" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70136" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:50.579</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:50.579</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57974" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Payroll Job</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70136</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">17</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">53392</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70860</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">6f4045e0-39d9-4c42-947d-beeec507fae8</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1470" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:51.627</Data>
+        <Data AD_Column_ID="84297" Column="UUID">404e3cc6-31f2-473e-8aa5-5f8fb9402276</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:51.627</Data>
+        <Data AD_Column_ID="58036" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58037" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Payroll Job</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70136</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1480" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70137" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:51.821</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:51.821</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Document sequence number of the document</Data>
+        <Data AD_Column_ID="57974" Column="Help">The document number is usually automatically generated by the system and determined by the document type of the document. If the document is not saved, the preliminary number is displayed in "&lt;&gt;".
+
+If the document type of your document has no automatic document sequence defined, the field is empty if you create a new document. This is for documents which usually have an external number (like vendor invoice).  If you leave the field empty, the system will generate a document number for you. The document sequence used for this fallback number is defined in the "Maintain Sequence" window with the name "DocumentNo_&lt;TableName&gt;", where TableName is the actual name of the table (e.g. C_Order).</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">true</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Document No</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70137</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">18</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">290</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70861</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">10</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">90</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">f1dde84f-09e3-4734-9809-1d5b9a14268f</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1490" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">b50ae020-17c6-4de5-829a-80cb41996005</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:52.671</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:52.671</Data>
+        <Data AD_Column_ID="58036" Column="Description">Document sequence number of the document</Data>
+        <Data AD_Column_ID="58037" Column="Help">The document number is usually automatically generated by the system and determined by the document type of the document. If the document is not saved, the preliminary number is displayed in "&lt;&gt;".
+
+If the document type of your document has no automatic document sequence defined, the field is empty if you create a new document. This is for documents which usually have an external number (like vendor invoice).  If you leave the field empty, the system will generate a document number for you. The document sequence used for this fallback number is defined in the "Maintain Sequence" window with the name "DocumentNo_&lt;TableName&gt;", where TableName is the actual name of the table (e.g. C_Order).</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Document No</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70137</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1500" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70138" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:52.904</Data>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70138</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">19</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">524</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70862</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">28</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">82674e3c-155d-44a8-9443-5fd1e7e014bc</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:52.904</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57974" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Process Now</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="1510" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">2879c1ee-83e1-48ad-b0b4-642c7f05e1c7</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:53.764</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:53.764</Data>
+        <Data AD_Column_ID="58036" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58037" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Process Now</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70138</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1520" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70139" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70139</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">20</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">1047</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70863</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">20</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">2f536060-139f-41ce-8b1f-39bb8928433f</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:54.092</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:54.092</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">The document has been processed</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Processed checkbox indicates that a document has been processed.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Processed</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1530" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">1b485772-58cf-407e-b058-c32c3a96427a</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:55.086</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:55.086</Data>
+        <Data AD_Column_ID="58036" Column="Description">The document has been processed</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Processed checkbox indicates that a document has been processed.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Processed</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70139</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1540" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70140" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:55.335</Data>
+        <Data AD_Column_ID="57974" Column="Help">There are two methods of making records unavailable in the system: One is to delete the record, the other is to de-activate the record. A de-activated record is not available for selection, but available for reports.
+There are two reasons for de-activating and not deleting records:
+(1) The system requires the record for audit purposes.
+(2) The record is referenced by other records. E.g., you cannot delete a Business Partner, if there are invoices for this partner record existing. You de-activate the Business Partner and prevent that this record is used for future entries.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Active</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70140</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">21</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">348</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70864</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">20</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">88b2aee1-d72a-44ce-b619-8b35cec20871</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:55.335</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">The record is active in the system</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1550" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">e9ae035e-03f7-418c-a55a-e32b1768e633</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70140</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:56.128</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:56.128</Data>
+        <Data AD_Column_ID="58036" Column="Description">The record is active in the system</Data>
+        <Data AD_Column_ID="58037" Column="Help">There are two methods of making records unavailable in the system: One is to delete the record, the other is to de-activate the record. A de-activated record is not available for selection, but available for reports.
+There are two reasons for de-activating and not deleting records:
+(1) The system requires the record for audit purposes.
+(2) The record is referenced by other records. E.g., you cannot delete a Business Partner, if there are invoices for this partner record existing. You de-activate the Business Partner and prevent that this record is used for future entries.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Active</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1560" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70141" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:56.449</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:56.449</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Posting status</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Posted field indicates the status of the Generation of General Ledger Accounting Lines </Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Posted</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70141</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">22</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">234</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">1308</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70865</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">28</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">9c6e4a0f-4715-4ec5-9f8c-574023874a33</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1570" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="58037" Column="Help">The Posted field indicates the status of the Generation of General Ledger Accounting Lines </Data>
+        <Data AD_Column_ID="84297" Column="UUID">deef05b0-f8b5-4661-9c90-d8a6a4b7ce66</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:57.389</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:57.389</Data>
+        <Data AD_Column_ID="58036" Column="Description">Posting status</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Posted</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70141</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1580" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70142" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:57.612</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">c82383b0-54dc-48f9-9779-9713f7673caa</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:57.612</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Date this record was updated</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Updated field indicates the date that this record was updated.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Updated</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70142</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">23</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">607</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70866</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">16</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">29</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1590" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">b47682c0-eeb0-4a5e-b432-5cd8075a5d1f</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:58.397</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:58.397</Data>
+        <Data AD_Column_ID="58036" Column="Description">Date this record was updated</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Updated field indicates the date that this record was updated.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Updated</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70142</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1600" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70143" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:58.723</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:58.723</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Date this record was created</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Created field indicates the date that this record was created.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Created</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70143</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">24</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">245</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70867</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">16</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">29</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">74f843d4-9377-4515-8c13-b63f39ee248b</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1610" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">bd182579-6344-4f2a-b201-e0c0cea35807</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:04:59.505</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:04:59.505</Data>
+        <Data AD_Column_ID="58036" Column="Description">Date this record was created</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Created field indicates the date that this record was created.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Created</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70143</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1620" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70144" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:04:59.731</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:04:59.731</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Client/Tenant for this installation.</Data>
+        <Data AD_Column_ID="57974" Column="Help">A Client is a company or a legal entity. You cannot share data between Clients. Tenant is a synonym for Client.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Client</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70144</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">25</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">102</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70868</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">26988042-78c5-43ff-9138-2df32f646602</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1630" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">7698c7f1-28b6-4b76-b19a-480df02ecc91</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:00.762</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:00.762</Data>
+        <Data AD_Column_ID="58036" Column="Description">Client/Tenant for this installation.</Data>
+        <Data AD_Column_ID="58037" Column="Help">A Client is a company or a legal entity. You cannot share data between Clients. Tenant is a synonym for Client.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Client</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70144</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1640" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70145" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:00.991</Data>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70145</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">26</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">113</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70869</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">ed79668d-786b-4782-a7aa-4a66fafccabd</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:00.991</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Organizational entity within client</Data>
+        <Data AD_Column_ID="57974" Column="Help">An organization is a unit of your client or legal entity - examples are store, department. You can share data between organizations.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Organization</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="1650" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">334879e9-26a2-4ef2-a676-e6dd55807a4b</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:02.056</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:02.056</Data>
+        <Data AD_Column_ID="58036" Column="Description">Organizational entity within client</Data>
+        <Data AD_Column_ID="58037" Column="Help">An organization is a unit of your client or legal entity - examples are store, department. You can share data between organizations.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Organization</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70145</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1660" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70146" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:02.289</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Document Action</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70146</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">27</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">135</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">287</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70870</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">28</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">2</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">30460dba-151d-4a50-a72d-246d877f7b12</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:02.289</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">The targeted status of the document</Data>
+        <Data AD_Column_ID="57974" Column="Help">You find the current status in the Document Status field. The options are listed in a popup</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1670" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">65026545-ea37-4a29-861d-4da72ef7d172</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:03.309</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:03.309</Data>
+        <Data AD_Column_ID="58036" Column="Description">The targeted status of the document</Data>
+        <Data AD_Column_ID="58037" Column="Help">You find the current status in the Document Status field. The options are listed in a popup</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Document Action</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70146</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1680" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70147" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:03.566</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Document type or rules</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Document Type determines document sequence and processing rules</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Document Type</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70147</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">28</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">196</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70871</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">c22c2cf5-8a32-442e-870f-051baf12add2</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:03.566</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1690" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">6576c0e4-5d51-4e09-95ef-0144eb273b61</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:04.862</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:04.862</Data>
+        <Data AD_Column_ID="58036" Column="Description">Document type or rules</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Document Type determines document sequence and processing rules</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Document Type</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70147</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1700" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70148" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:05.252</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:05.252</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57974" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Payroll Process</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70148</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">29</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">53407</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70872</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">13</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">9428ac1d-878c-46df-bac9-1535fdf24e7a</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1710" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">3656a8e7-cbd4-4a10-97f5-d42676dd4852</Data>
+        <Data AD_Column_ID="58039" Column="Name">Payroll Process</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70148</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:06.51</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:06.51</Data>
+        <Data AD_Column_ID="58036" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58037" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1720" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70149" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:06.742</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:06.742</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Identifies a Business Partner</Data>
+        <Data AD_Column_ID="57974" Column="Help">A Business Partner is anyone with whom you transact.  This can include Vendor, Customer, Employee or Salesperson</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Business Partner </Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70149</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">30</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">187</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70873</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">30</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">73e9744b-d366-4ff8-ba5f-fa04af554a4e</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1730" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">1248b15f-b602-457c-8e8c-ccd4c1757789</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:07.887</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:07.887</Data>
+        <Data AD_Column_ID="58036" Column="Description">Identifies a Business Partner</Data>
+        <Data AD_Column_ID="58037" Column="Help">A Business Partner is anyone with whom you transact.  This can include Vendor, Customer, Employee or Salesperson</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Business Partner </Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70149</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1740" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70150" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:08.13</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:08.13</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57974" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Payroll Department</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70150</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">31</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">53390</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70874</Data>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">58e10c01-f144-42f7-b2f1-8230496688dc</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1750" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">8955a5c0-ad17-47d9-a406-afbe63273605</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:08.859</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:08.859</Data>
+        <Data AD_Column_ID="58036" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58037" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Payroll Department</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70150</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1760" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70151" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:09.069</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:09.069</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">ID of document reversal</Data>
+        <Data AD_Column_ID="57974" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Reversal ID</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70151</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">32</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">53253</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">53457</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70875</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">038c3859-e1a3-414a-8457-1167e60b4c3a</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1770" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">0ccb57e2-df0f-4386-bfd1-c1eb15b8263a</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:09.915</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:09.915</Data>
+        <Data AD_Column_ID="58036" Column="Description">ID of document reversal</Data>
+        <Data AD_Column_ID="58037" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Reversal ID</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70151</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1780" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70152" Table="AD_Browse_Field">
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70152</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">33</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">110</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">246</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70876</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">d7f227c9-f385-4aa1-bbb3-b8b8a249d012</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:10.16</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:10.16</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">User who created this records</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Created By field indicates the user who created this record.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Created By</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="1790" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">d8ab4a85-cd67-49da-b7eb-bc70b3752e23</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:11.388</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:11.388</Data>
+        <Data AD_Column_ID="58036" Column="Description">User who created this records</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Created By field indicates the user who created this record.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Created By</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70152</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1800" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70153" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:11.644</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:11.644</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">User who updated this records</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Updated By field indicates the user who updated this record.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Updated By</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70153</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">34</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">110</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">608</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70877</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">265bb2ae-8036-44e8-866c-b93f1becbce1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1810" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">bfb91c26-6f5a-4a93-9aba-c15b73968f2f</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:12.784</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:12.784</Data>
+        <Data AD_Column_ID="58036" Column="Description">User who updated this records</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Updated By field indicates the user who updated this record.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Updated By</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70153</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1820" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70154" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:13.142</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:13.142</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Workflow or combination of tasks</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Workflow field identifies a unique Workflow in the system.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Workflow</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70154</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">35</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">144</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70878</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">d4a00d59-d67e-49eb-860b-b5a7ace06a54</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1830" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">f5bfc0c8-9928-4fb0-bdaa-e98179012b78</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:14.198</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:14.198</Data>
+        <Data AD_Column_ID="58036" Column="Description">Workflow or combination of tasks</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Workflow field identifies a unique Workflow in the system.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Workflow</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70154</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1840" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70155" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:14.405</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:14.405</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57974" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Payroll Employee</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70155</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">36</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">53391</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70879</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">8caa8716-78f9-4424-b271-414074af07c4</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1850" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70155</Data>
+        <Data AD_Column_ID="84297" Column="UUID">146bd955-792d-4f76-b4ac-7adcc025e614</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:15.555</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:15.555</Data>
+        <Data AD_Column_ID="58036" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58037" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Payroll Employee</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1860" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70156" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:15.776</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:15.776</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">The date+time (expressed in decimal format) when the document has been processed</Data>
+        <Data AD_Column_ID="57974" Column="Help">The ProcessedOn Date+Time save the exact moment (nanoseconds precision if allowed by the DB) when a document has been processed.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Processed On</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70156</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">37</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">54128</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70880</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">22</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">20</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">76198712-56a3-40c9-9490-cc9d205f886e</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1870" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="58037" Column="Help">The ProcessedOn Date+Time save the exact moment (nanoseconds precision if allowed by the DB) when a document has been processed.</Data>
+        <Data AD_Column_ID="84297" Column="UUID">986c2bd7-dac2-4dc4-a98d-8eff3ea30dc0</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:16.913</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:16.913</Data>
+        <Data AD_Column_ID="58036" Column="Description">The date+time (expressed in decimal format) when the document has been processed</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Processed On</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70156</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1880" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70157" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:17.292</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:17.292</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="57974" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70157</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">38</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">59595</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70881</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">10</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">36</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">3478896a-dc27-4f9e-971b-998b6342acbc</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1890" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">cae7687a-521b-4163-af30-d194f306156d</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:18.213</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:18.213</Data>
+        <Data AD_Column_ID="58036" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="58037" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70157</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1900" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70158" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:18.49</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">193</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70882</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">53c9dd64-c578-401d-9217-53265a3843d7</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:18.49</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="57974" Column="Help">Indicates the Currency to be used when processing or reporting on this record</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Currency</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70158</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">39</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="1910" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">663a5326-e332-4040-b084-bd71668b16cd</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:19.683</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:19.683</Data>
+        <Data AD_Column_ID="58036" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="58037" Column="Help">Indicates the Currency to be used when processing or reporting on this record</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Currency</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70158</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1920" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70159" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:20.027</Data>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70159</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">40</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">2278</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70883</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">2c7bf91d-dbc9-4dee-8d16-d7fee6ce3d20</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:20.027</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Currency Conversion Rate Type</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Currency Conversion Rate Type lets you define different type of rates, e.g. Spot, Corporate and/or Sell/Buy rates.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Currency Type</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="1930" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">10cf6d09-3ada-48af-9bef-8faa449e8e76</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:21.302</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:21.302</Data>
+        <Data AD_Column_ID="58036" Column="Description">Currency Conversion Rate Type</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Currency Conversion Rate Type lets you define different type of rates, e.g. Spot, Corporate and/or Sell/Buy rates.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Currency Type</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70159</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1940" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70160" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:21.791</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:21.791</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57974" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Payroll Period</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70160</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">41</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">53408</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70884</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">3c692a72-79c0-4925-95fc-6a0196fc231d</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1950" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">bb7bfb3a-7324-45ee-ace1-ac121d4e8d15</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:23.063</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:23.063</Data>
+        <Data AD_Column_ID="58036" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58037" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Payroll Period</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70160</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1960" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70161" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57974" Column="Help">The Accounting Date indicates the date to be used on the General Ledger account entries generated from this document. It is also used for any currency conversion.</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:23.336</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:23.336</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Accounting Date</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Account Date</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70161</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">42</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">263</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70885</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">15</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">0</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">27cbddb8-59ca-49fe-b261-03966012abe6</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1970" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">3508babe-023a-4837-af04-89954881c4fb</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:24.311</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:24.311</Data>
+        <Data AD_Column_ID="58036" Column="Description">Accounting Date</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Accounting Date indicates the date to be used on the General Ledger account entries generated from this document. It is also used for any currency conversion.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Account Date</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70161</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1980" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70162" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:24.64</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="57974" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Payroll</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70162</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">43</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">53393</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70886</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">33093e06-651c-4aac-8f92-171748f25185</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:24.64</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1990" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">f9841c5b-1c56-4ad1-8955-ea5e14769d63</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70162</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:25.508</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:25.508</Data>
+        <Data AD_Column_ID="58036" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58037" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Payroll</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2000" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70163" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:25.749</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:25.749</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Performing or initiating organization</Data>
+        <Data AD_Column_ID="57974" Column="Help">The organization which performs or initiates this transaction (for another organization).  The owning Organization may not be the transaction organization in a service bureau environment, with centralized services, and inter-organization transactions.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Trx Organization</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70163</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">44</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">130</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">112</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70887</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">4a6f48ca-7a30-4757-80af-0fa91f2eafb3</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2010" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">7607a19a-fd1e-4cac-a123-676a88222fa3</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:26.661</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:26.661</Data>
+        <Data AD_Column_ID="58036" Column="Description">Performing or initiating organization</Data>
+        <Data AD_Column_ID="58037" Column="Help">The organization which performs or initiates this transaction (for another organization).  The owning Organization may not be the transaction organization in a service bureau environment, with centralized services, and inter-organization transactions.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Trx Organization</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70163</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2020" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70164" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:26.881</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:26.881</Data>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">75a93a05-a0ce-450b-bb53-ca07092919da</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Financial Project</Data>
+        <Data AD_Column_ID="57974" Column="Help">A Project allows you to track and control internal or external activities.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Project</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70164</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">45</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">208</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70888</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="2030" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">68dfce8e-642f-4909-9c29-98431b3e265e</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:27.692</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:27.692</Data>
+        <Data AD_Column_ID="58036" Column="Description">Financial Project</Data>
+        <Data AD_Column_ID="58037" Column="Help">A Project allows you to track and control internal or external activities.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Project</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70164</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2040" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70165" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:27.912</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">210</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70889</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">f0efdd4d-fb77-4beb-a176-0f8d15972f2a</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:27.912</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Sales coverage region</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Sales Region indicates a specific area of sales coverage.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Sales Region</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70165</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">46</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2050" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">ed2babe6-acda-45fc-932f-b726b9a63c8b</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:28.953</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:28.953</Data>
+        <Data AD_Column_ID="58036" Column="Description">Sales coverage region</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Sales Region indicates a specific area of sales coverage.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Sales Region</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70165</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2060" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70166" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70166</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">47</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">142</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">1005</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70890</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">3b69ac39-9b09-4308-8935-49afbe07ef76</Data>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:29.426</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:29.426</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Business Activity</Data>
+        <Data AD_Column_ID="57974" Column="Help">Activities indicate tasks that are performed and used to utilize Activity based Costing</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Activity</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2070" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">bb7b6fac-47da-4c9d-91c8-2aedb0adf7f7</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:30.664</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:30.664</Data>
+        <Data AD_Column_ID="58036" Column="Description">Business Activity</Data>
+        <Data AD_Column_ID="58037" Column="Help">Activities indicate tasks that are performed and used to utilize Activity based Costing</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Activity</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70166</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2080" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70167" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 10:05:30.91</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 10:05:30.91</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">false</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">Marketing Campaign</Data>
+        <Data AD_Column_ID="57974" Column="Help">The Campaign defines a unique marketing program.  Projects can be associated with a pre defined Marketing Campaign.  You can then report based on a specific Campaign.</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Campaign</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">D</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70167</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">48</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID">143</Data>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">550</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50052</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70891</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">18</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength">10</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">13efbcf1-1979-416c-b45c-0d6471fb7e97</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2090" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">47188b3c-9549-4315-83be-6a6f6475a8b5</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 10:05:32.239</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 10:05:32.239</Data>
+        <Data AD_Column_ID="58036" Column="Description">Marketing Campaign</Data>
+        <Data AD_Column_ID="58037" Column="Help">The Campaign defines a unique marketing program.  Projects can be associated with a pre defined Marketing Campaign.  You can then report based on a specific Campaign.</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Campaign</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70167</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2100" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55174" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="110">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2110" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55152" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="120">110</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2120" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70158" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria" oldValue="false">true</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="0">120</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2130" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70132" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="13">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2140" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70129" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="10">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2150" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70130" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="11">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2160" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70131" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="12">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2170" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70144" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="25">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2180" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70163" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="44">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2190" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70145" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="26">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2200" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70154" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="35">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2210" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70166" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="47">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2220" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70149" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="30">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2230" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70167" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="48">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2240" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70135" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="16">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2250" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70147" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="28">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2260" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70164" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="45">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2270" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70165" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="46">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2280" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70143" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="24">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2290" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70152" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="33">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2300" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70161" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="42">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2310" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70146" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="27">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2320" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70133" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="14">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2330" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70137" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="18">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2340" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70150" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="31">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2350" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70155" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="36">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2360" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70136" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="17">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2370" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70162" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="43">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2380" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70160" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="41">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2390" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70148" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="29">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2400" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70140" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="21">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2410" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70134" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="15">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2420" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70141" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="22">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2430" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70139" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="20">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2440" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70156" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="37">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2450" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70138" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="19">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2460" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70151" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="32">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2470" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70157" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="38">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2480" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70142" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="23">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2490" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70153" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="34">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2500" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55158" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="80">70</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2510" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55174" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="90">80</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2520" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70158" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57976" Column="IsDisplayed" oldValue="false">true</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="39">90</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2530" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55165" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="110">120</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2540" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55136" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="120">130</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2550" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55155" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="130">140</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2560" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55163" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="140">150</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2570" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70159" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57976" Column="IsDisplayed" oldValue="false">true</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="40">160</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2580" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70158" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64354" Column="DefaultValue" isOldNull="true">-1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2590" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55168" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57977" Column="IsIdentifier" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2600" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70128" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57981" Column="Name" oldValue="Amount">Converted Amount</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="2610" StepType="AD">
+      <PO AD_Table_ID="53227" Action="U" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="58036" Column="Description" oldValue="Amount in a defined currency">Monto Convertido en la moneda</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID" oldValue="70128">70128</Data>
+        <Data AD_Column_ID="58037" Column="Help" isNewNull="true" oldValue="The Amount indicates the amount for this document line."/>
+        <Data AD_Column_ID="58039" Column="Name" oldValue="Amount">Monto Convertido</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language" oldValue="es_MX">es_MX</Data>
       </PO>
     </Step>
   </Migration>

--- a/migration/393lts-394lts/07170_Add_Multi_Currency_support_to_Payment_Selection.xml
+++ b/migration/393lts-394lts/07170_Add_Multi_Currency_support_to_Payment_Selection.xml
@@ -1,0 +1,1841 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add Multi Currency support to Payment Selection" ReleaseNo="3.9.4" SeqNo="7170">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70856" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">d31c6d45-2844-4885-9604-cf8c878868e6</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:36:33.542</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:36:33.542</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50102</Data>
+        <Data AD_Column_ID="58104" Column="Help">Indicates the Currency to be used when processing or reporting on this record</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">@C_Currency_ID@</Data>
+        <Data AD_Column_ID="58105" Column="Name">Currency to Convert</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">PS_C_Currency_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70856</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50046</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70856" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70856</Data>
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:36:36.838</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:36:36.838</Data>
+        <Data AD_Column_ID="58049" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Currency to Convert</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">b05c1433-ee63-40cf-9d88-3d2b0cb6a1f8</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="53228" Action="U" Record_ID="70856" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58049" Column="Description" oldValue="The Currency for this record">Moneda a Convertir el Documento</Data>
+        <Data AD_Column_ID="58052" Column="Name" oldValue="Currency to Convert">Moneda a Convertir</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID" oldValue="70856">70856</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language" oldValue="es_MX">es_MX</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="53232" Action="U" Record_ID="53973" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="currencyConvert(inv.GrandTotal, inv.C_Currency_ID, @INV_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID,inv.AD_Client_ID, inv.AD_Org_ID)">currencyConvert(inv.GrandTotal, inv.C_Currency_ID, @PS_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID,inv.AD_Client_ID, inv.AD_Org_ID)</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="53232" Action="U" Record_ID="53974" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="currencyConvert(paymentTermDiscount(inv.GrandTotal, inv.C_Currency_ID, inv.C_PaymentTerm_ID, inv.DateInvoiced, TO_DATE('@PayDate@','YYYY-MM-DD')), inv.C_Currency_ID, @INV_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID, inv.AD_Client_ID, inv.AD_Org_ID)">currencyConvert(paymentTermDiscount(inv.GrandTotal, inv.C_Currency_ID, inv.C_PaymentTerm_ID, inv.DateInvoiced, TO_DATE('@PayDate@','YYYY-MM-DD')), inv.C_Currency_ID, @PS_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID, inv.AD_Client_ID, inv.AD_Org_ID)</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="53232" Action="U" Record_ID="53975" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="currencyConvert(invoiceOpen(inv.C_Invoice_ID, inv.C_InvoicePaySchedule_ID), inv.C_Currency_ID, @INV_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID, inv.AD_Client_ID, inv.AD_Org_ID)">currencyConvert(invoiceOpen(inv.C_Invoice_ID, inv.C_InvoicePaySchedule_ID), inv.C_Currency_ID, @PS_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID, inv.AD_Client_ID, inv.AD_Org_ID)</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="53232" Action="U" Record_ID="54002" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="CASE WHEN paymentTermDiscount(invoiceOpen(inv.C_Invoice_ID, inv.C_InvoicePaySchedule_ID), @INV_C_Currency_ID@, inv.C_PaymentTerm_ID, inv.DateInvoiced, TO_DATE('@PayDate@','YYYY-MM-DD')) &gt; 0 THEN 'Y' ELSE 'N' END">CASE WHEN paymentTermDiscount(invoiceOpen(inv.C_Invoice_ID, inv.C_InvoicePaySchedule_ID), @PS_C_Currency_ID@, inv.C_PaymentTerm_ID, inv.DateInvoiced, TO_DATE('@PayDate@','YYYY-MM-DD')) &gt; 0 THEN 'Y' ELSE 'N' END</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="53232" Action="U" Record_ID="54229" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="currencyConvert(invoiceOpen(inv.C_Invoice_ID, inv.C_InvoicePaySchedule_ID), inv.C_Currency_ID, @INV_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID, inv.AD_Client_ID, inv.AD_Org_ID)  -  currencyConvert(paymentTermDiscount(inv.GrandTotal, inv.C_Currency_ID, inv.C_PaymentTerm_ID, inv.DateInvoiced, TO_DATE('@PayDate@','YYYY-MM-DD')), inv.C_Currency_ID, @INV_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID, inv.AD_Client_ID, inv.AD_Org_ID) ">currencyConvert(invoiceOpen(inv.C_Invoice_ID, inv.C_InvoicePaySchedule_ID), inv.C_Currency_ID, @PS_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID, inv.AD_Client_ID, inv.AD_Org_ID)  -  currencyConvert(paymentTermDiscount(inv.GrandTotal, inv.C_Currency_ID, inv.C_PaymentTerm_ID, inv.DateInvoiced, TO_DATE('@PayDate@','YYYY-MM-DD')), inv.C_Currency_ID, @PS_C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), inv.C_ConversionType_ID, inv.AD_Client_ID, inv.AD_Org_ID) </Data>
+      </PO>
+    </Step>
+    <Step SeqNo="90" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55285" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64354" Column="DefaultValue" oldValue="@C_Currency_ID@">-1</Data>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true" oldValue="@C_Currency_ID@!0"/>
+      </PO>
+    </Step>
+    <Step SeqNo="100" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70126" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 01:40:42.585</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 01:40:42.585</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">true</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue">@C_Currency_ID@</Data>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="57974" Column="Help">Indicates the Currency to be used when processing or reporting on this record</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Currency</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">true</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic">1=1</Data>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">true</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70126</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">80</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">193</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50054</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">53929</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo" isNewNull="true"/>
+        <Data AD_Column_ID="64357" Column="FieldLength" isNewNull="true"/>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">2bfc3e67-1187-4022-a534-0b574243e2eb</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="110" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="84297" Column="UUID">5fdc1a7e-24ea-46e3-a645-af86ec59a5e9</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 01:40:44.728</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 01:40:44.728</Data>
+        <Data AD_Column_ID="58036" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="58037" Column="Help">Indicates the Currency to be used when processing or reporting on this record</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Currency</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70126</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="120" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70126" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57982" Column="SeqNo" oldValue="80">85</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="130" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70126" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="0">40</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="140" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55280" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="40">50</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="150" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55321" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="50">60</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="160" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55286" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="60">70</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="170" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55292" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="70">80</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="180" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55363" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="80">90</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="190" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55312" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="90">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="200" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55364" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="100">110</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="210" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55365" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="110">120</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="220" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55358" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="120">130</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="230" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55291" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="130">140</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="240" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55289" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="140">150</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="250" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55297" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="150">160</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="260" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55305" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="160">170</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="270" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55361" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="170">180</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="280" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70126" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID" oldValue="53929">70856</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="290" StepType="AD">
+      <PO AD_Table_ID="53223" Action="I" Record_ID="70127" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57964" Column="Created">2020-12-15 01:49:32.591</Data>
+        <Data AD_Column_ID="57963" Column="IsActive">true</Data>
+        <Data AD_Column_ID="57965" Column="Updated">2020-12-15 01:49:32.591</Data>
+        <Data AD_Column_ID="57980" Column="IsRange">false</Data>
+        <Data AD_Column_ID="57979" Column="IsQueryCriteria">true</Data>
+        <Data AD_Column_ID="57985" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="64354" Column="DefaultValue">@SQL=SELECT ba.C_Currency_ID FROM C_BankAccount ba WHERE ba.C_BankAccount_ID = @C_BankAccount_ID@</Data>
+        <Data AD_Column_ID="64853" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="57972" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="57974" Column="Help">Indicates the Currency to be used when processing or reporting on this record</Data>
+        <Data AD_Column_ID="57976" Column="IsDisplayed">false</Data>
+        <Data AD_Column_ID="57977" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="57978" Column="IsKey">false</Data>
+        <Data AD_Column_ID="57981" Column="Name">Currency</Data>
+        <Data AD_Column_ID="63579" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="57975" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="64222" Column="IsOrderBy">false</Data>
+        <Data AD_Column_ID="64355" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="64356" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic">1=1</Data>
+        <Data AD_Column_ID="64359" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="64360" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="64361" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="67114" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="81229" Column="IsInfoOnly">true</Data>
+        <Data AD_Column_ID="57961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="57962" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="57973" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="57968" Column="AD_Browse_Field_ID">70127</Data>
+        <Data AD_Column_ID="57982" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="57984" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57967" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="57966" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="63218" Column="Axis_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57969" Column="AD_Element_ID">193</Data>
+        <Data AD_Column_ID="57983" Column="AD_Browse_ID">50064</Data>
+        <Data AD_Column_ID="57971" Column="AD_View_Column_ID">70856</Data>
+        <Data AD_Column_ID="64353" Column="AD_Val_Rule_ID">52492</Data>
+        <Data AD_Column_ID="57970" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="63219" Column="Axis_Parent_Column_ID" isNewNull="true"/>
+        <Data AD_Column_ID="64221" Column="SortNo">0</Data>
+        <Data AD_Column_ID="64357" Column="FieldLength">0</Data>
+        <Data AD_Column_ID="78559" Column="SeqNoGrid">0</Data>
+        <Data AD_Column_ID="84296" Column="UUID">4bfe9d69-07b7-4744-b006-ed84d0cc7948</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="300" StepType="AD">
+      <PO AD_Table_ID="53227" Action="I" Record_ID="0" Table="AD_Browse_Field_Trl">
+        <Data AD_Column_ID="58030" Column="Created">2020-12-15 01:49:33.821</Data>
+        <Data AD_Column_ID="58031" Column="Updated">2020-12-15 01:49:33.821</Data>
+        <Data AD_Column_ID="84297" Column="UUID">d8b485a6-915f-48a7-89a8-81b634942195</Data>
+        <Data AD_Column_ID="58029" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58036" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="58037" Column="Help">Indicates the Currency to be used when processing or reporting on this record</Data>
+        <Data AD_Column_ID="58038" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58039" Column="Name">Currency</Data>
+        <Data AD_Column_ID="58027" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58028" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58035" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58033" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58034" Column="AD_Browse_Field_ID">70127</Data>
+        <Data AD_Column_ID="58032" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="310" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55995" Table="AD_Browse_Field">
+        <Data AD_Column_ID="64354" Column="DefaultValue" isOldNull="true">-1</Data>
+        <Data AD_Column_ID="64358" Column="ReadOnlyLogic" isNewNull="true" oldValue="1=1"/>
+      </PO>
+    </Step>
+    <Step SeqNo="320" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70127" Table="AD_Browse_Field">
+        <Data AD_Column_ID="57981" Column="Name" oldValue="Currency">Currency To Convert</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="330" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70127" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="0">20</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="340" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55995" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="20">30</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="350" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55987" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="30">40</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="360" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55962" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="40">50</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="370" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55972" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="50">60</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="380" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55985" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="60">70</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="390" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55988" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="70">80</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="400" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55940" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="80">90</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="410" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55986" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="90">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="420" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55945" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="100">110</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="430" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55944" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="110">120</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="440" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55969" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="120">130</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="450" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55941" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="130">140</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="460" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55971" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="140">150</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="470" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55973" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="150">160</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="480" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55974" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="160">170</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="490" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55975" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="170">180</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="500" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55962" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="50">20</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="510" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="70127" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="20">40</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="520" StepType="AD">
+      <PO AD_Table_ID="53223" Action="U" Record_ID="55987" Table="AD_Browse_Field">
+        <Data AD_Column_ID="78559" Column="SeqNoGrid" oldValue="40">50</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="530" StepType="AD">
+      <PO AD_Table_ID="53231" Action="I" Record_ID="50530" Table="AD_View_Definition">
+        <Data AD_Column_ID="58092" Column="Processing">false</Data>
+        <Data AD_Column_ID="58083" Column="Updated">2020-12-15 01:58:34.139</Data>
+        <Data AD_Column_ID="58081" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58082" Column="Created">2020-12-15 01:58:34.139</Data>
+        <Data AD_Column_ID="58090" Column="TableAlias">hrp</Data>
+        <Data AD_Column_ID="58091" Column="JoinClause">INNER JOIN HR_Process hrp ON(hrp.HR_Process_ID = hrm.HR_Process_ID)</Data>
+        <Data AD_Column_ID="58086" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58079" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58080" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58084" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58085" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58089" Column="AD_Table_ID">53092</Data>
+        <Data AD_Column_ID="58087" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58088" Column="SeqNo">20</Data>
+        <Data AD_Column_ID="84464" Column="UUID">44598842-f96b-4507-a5ab-a88c93453462</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="540" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70857" Table="AD_View_Column">
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:40.983</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:40.983</Data>
+        <Data AD_Column_ID="84462" Column="UUID">8dabdf3e-9a39-4beb-b5f8-7b859e17dbb7</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Document Status indicates the status of a document at this time.  If you want to change the document status, use the Document Action field</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.DocStatus</Data>
+        <Data AD_Column_ID="58105" Column="Name">Document Status</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_DocStatus</Data>
+        <Data AD_Column_ID="58102" Column="Description">The current status of the document</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70857</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54869</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="550" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70857" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:42.829</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:42.829</Data>
+        <Data AD_Column_ID="58049" Column="Description">The current status of the document</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Document Status</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70857</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">55caf4fc-aceb-4517-959b-fef1b2846156</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="560" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70858" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">0f371c82-a441-4d74-9cce-7b8d6b371c0f</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:43.176</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:43.176</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The name of an entity (record) is used as an default search option in addition to the search key. The name is up to 60 characters in length.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.Name</Data>
+        <Data AD_Column_ID="58105" Column="Name">Name</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_Name</Data>
+        <Data AD_Column_ID="58102" Column="Description">Alphanumeric identifier of the entity</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70858</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54862</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="570" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70858" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:44.837</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:44.837</Data>
+        <Data AD_Column_ID="58049" Column="Description">Alphanumeric identifier of the entity</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Name</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70858</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">f043da3b-1d8a-413e-82fa-37d449a15683</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="580" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70859" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">286f8315-f0f4-4b6b-a00a-f5c59b360da8</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:45.21</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:45.21</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">You can convert document types (e.g. from Offer to Order or Invoice).  The conversion is then reflected in the current type.  This processing is initiated by selecting the appropriate Document Action.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.C_DocTypeTarget_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Target Document Type</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_DocTypeTarget_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Target document type for conversing documents</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70859</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54863</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="590" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70859" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:46.101</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:46.101</Data>
+        <Data AD_Column_ID="58049" Column="Description">Target document type for conversing documents</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Target Document Type</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70859</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">99ef8588-0043-4df7-b43c-d0e99c9b974c</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="600" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70860" Table="AD_View_Column">
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:46.327</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:46.327</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.HR_Job_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Payroll Job</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_HR_Job_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70860</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54857</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84462" Column="UUID">46dfd72d-480d-4b9a-952e-1bc9fbbf9eb4</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="610" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70860" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:47.322</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:47.322</Data>
+        <Data AD_Column_ID="58049" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Payroll Job</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70860</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">8c78a6b4-577f-4268-82d6-0e5d33dd7a84</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="620" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70861" Table="AD_View_Column">
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54870</Data>
+        <Data AD_Column_ID="84462" Column="UUID">b3d4545a-3b7d-4ec8-9796-69f225bd49c0</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:47.553</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:47.553</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The document number is usually automatically generated by the system and determined by the document type of the document. If the document is not saved, the preliminary number is displayed in "&lt;&gt;".
+
+If the document type of your document has no automatic document sequence defined, the field is empty if you create a new document. This is for documents which usually have an external number (like vendor invoice).  If you leave the field empty, the system will generate a document number for you. The document sequence used for this fallback number is defined in the "Maintain Sequence" window with the name "DocumentNo_&lt;TableName&gt;", where TableName is the actual name of the table (e.g. C_Order).</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.DocumentNo</Data>
+        <Data AD_Column_ID="58105" Column="Name">Document No</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_DocumentNo</Data>
+        <Data AD_Column_ID="58102" Column="Description">Document sequence number of the document</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70861</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="630" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70861" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:48.413</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:48.413</Data>
+        <Data AD_Column_ID="58049" Column="Description">Document sequence number of the document</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Document No</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70861</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">f3b113d3-ef11-4f0e-96d3-618e901094e1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="640" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70862" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">da3fb546-8768-44c0-ba38-a9d6d7858b21</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:48.626</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:48.626</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.Processing</Data>
+        <Data AD_Column_ID="58105" Column="Name">Process Now</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_Processing</Data>
+        <Data AD_Column_ID="58102" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70862</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54877</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="650" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70862" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:49.591</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:49.591</Data>
+        <Data AD_Column_ID="58049" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Process Now</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70862</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">e2d8a7af-c68c-4bc0-a1f4-bb3a310fecee</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="660" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70863" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">e32a2261-aa33-4883-865f-06b197f0ad14</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:50.0</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:50.0</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Processed checkbox indicates that a document has been processed.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.Processed</Data>
+        <Data AD_Column_ID="58105" Column="Name">Processed</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_Processed</Data>
+        <Data AD_Column_ID="58102" Column="Description">The document has been processed</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70863</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54876</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="670" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70863" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:51.143</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:51.143</Data>
+        <Data AD_Column_ID="58049" Column="Description">The document has been processed</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Processed</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70863</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">0affe22c-fd57-435f-b4f1-80102a2077f7</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="680" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70864" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">9c447eb4-12bc-4f1a-bd9e-53be53973843</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54874</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:51.513</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:51.513</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">There are two methods of making records unavailable in the system: One is to delete the record, the other is to de-activate the record. A de-activated record is not available for selection, but available for reports.
+There are two reasons for de-activating and not deleting records:
+(1) The system requires the record for audit purposes.
+(2) The record is referenced by other records. E.g., you cannot delete a Business Partner, if there are invoices for this partner record existing. You de-activate the Business Partner and prevent that this record is used for future entries.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.IsActive</Data>
+        <Data AD_Column_ID="58105" Column="Name">Active</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_IsActive</Data>
+        <Data AD_Column_ID="58102" Column="Description">The record is active in the system</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70864</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="690" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70864" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:52.465</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:52.465</Data>
+        <Data AD_Column_ID="58049" Column="Description">The record is active in the system</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Active</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70864</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">ce240f74-e507-4e98-b156-968ef51ba0e0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="700" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70865" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">ea11bf63-fd1c-4f08-81a8-6940031ecd04</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:52.744</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:52.744</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Posted field indicates the status of the Generation of General Ledger Accounting Lines </Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.Posted</Data>
+        <Data AD_Column_ID="58105" Column="Name">Posted</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_Posted</Data>
+        <Data AD_Column_ID="58102" Column="Description">Posting status</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70865</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54875</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="710" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70865" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="84463" Column="UUID">b9876232-c745-4032-be37-760e4be90a96</Data>
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:53.727</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:53.727</Data>
+        <Data AD_Column_ID="58049" Column="Description">Posting status</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Posted</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70865</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="720" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70866" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">78cd5e63-1a86-450a-a9f7-8fc9ea998a97</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:54.077</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:54.077</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Updated field indicates the date that this record was updated.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.Updated</Data>
+        <Data AD_Column_ID="58105" Column="Name">Updated</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_Updated</Data>
+        <Data AD_Column_ID="58102" Column="Description">Date this record was updated</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70866</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54878</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="730" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70866" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:55.204</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:55.204</Data>
+        <Data AD_Column_ID="58049" Column="Description">Date this record was updated</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Updated</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70866</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">cdbb2003-dcdd-45e9-9209-1af5704db86c</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="740" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70867" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">4dcff1ee-0820-4b3a-a44b-2b44f2579538</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:55.466</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:55.466</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Created field indicates the date that this record was created.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.Created</Data>
+        <Data AD_Column_ID="58105" Column="Name">Created</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_Created</Data>
+        <Data AD_Column_ID="58102" Column="Description">Date this record was created</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70867</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54865</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="750" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70867" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:56.567</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:56.567</Data>
+        <Data AD_Column_ID="58049" Column="Description">Date this record was created</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Created</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70867</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">108c914e-9eb4-447e-a1a0-04eb65dd72ee</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="760" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70868" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">f3a7158e-679c-4cb0-8575-0ab2e9cc8804</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:56.878</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:56.878</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">A Client is a company or a legal entity. You cannot share data between Clients. Tenant is a synonym for Client.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.AD_Client_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Client</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_AD_Client_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Client/Tenant for this installation.</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70868</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54879</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="770" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70868" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:57.82</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:57.82</Data>
+        <Data AD_Column_ID="58049" Column="Description">Client/Tenant for this installation.</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Client</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70868</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">c51c26c3-10a7-4c0a-9097-ece3c463d984</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="780" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70869" Table="AD_View_Column">
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:58.241</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:58.241</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">An organization is a unit of your client or legal entity - examples are store, department. You can share data between organizations.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.AD_Org_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Organization</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_AD_Org_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Organizational entity within client</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70869</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54881</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84462" Column="UUID">fe5bd95c-a70f-4cf8-9304-8d6d750e190b</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="790" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70869" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:58:59.056</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:58:59.056</Data>
+        <Data AD_Column_ID="58049" Column="Description">Organizational entity within client</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Organization</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70869</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">ea2a37c5-ba55-4919-9863-78cf9f2a8596</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="800" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70870" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">d73c17c5-91cd-46d1-8c44-c685a78922ab</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:58:59.386</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:58:59.386</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">You find the current status in the Document Status field. The options are listed in a popup</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.DocAction</Data>
+        <Data AD_Column_ID="58105" Column="Name">Document Action</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_DocAction</Data>
+        <Data AD_Column_ID="58102" Column="Description">The targeted status of the document</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70870</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54868</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="810" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70870" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:00.435</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:00.435</Data>
+        <Data AD_Column_ID="58049" Column="Description">The targeted status of the document</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Document Action</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70870</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">1e2d08cf-7fba-455e-a4f2-e0e661b7c39d</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="820" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70871" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">4d739804-cc52-4ebd-9eda-3ff3073eb79e</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:00.636</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:00.636</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Document Type determines document sequence and processing rules</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.C_DocType_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Document Type</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_DocType_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Document type or rules</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70871</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54858</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="830" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70871" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:01.511</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:01.511</Data>
+        <Data AD_Column_ID="58049" Column="Description">Document type or rules</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Document Type</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70871</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">c92f72de-8643-4d4e-a5c0-4c1fff4a434c</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="840" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70872" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">1c1fb9d0-229a-4fe0-b6fd-a8564a2674fa</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:01.732</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:01.732</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.HR_Process_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Payroll Process</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_HR_Process_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70872</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54860</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="850" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70872" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:02.817</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:02.817</Data>
+        <Data AD_Column_ID="58049" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Payroll Process</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70872</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">3d67bb2b-a46f-456e-8653-7eb8b8a63d77</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="860" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70873" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">3b8840b1-48e9-4c04-ba0b-3de46e70432b</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:03.162</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:03.162</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">A Business Partner is anyone with whom you transact.  This can include Vendor, Customer, Employee or Salesperson</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.C_BPartner_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Business Partner </Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_BPartner_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Identifies a Business Partner</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70873</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54884</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="870" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70873" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:04.047</Data>
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:04.047</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58049" Column="Description">Identifies a Business Partner</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Business Partner </Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70873</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">c58bdecd-5ae9-4280-9bd4-2bd2548d0247</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="880" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70874" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">5daeb2ff-1c83-4988-a490-46f09f4679f0</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:04.248</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:04.248</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.HR_Department_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Payroll Department</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_HR_Department_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70874</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54871</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="890" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70874" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:05.148</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:05.148</Data>
+        <Data AD_Column_ID="58049" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Payroll Department</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70874</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">d73dfdb9-007a-437c-ab36-c381282b7188</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="900" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70875" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">42188f63-dbc3-4a88-9c1d-51ff9d96504b</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.Reversal_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Reversal ID</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_Reversal_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">ID of document reversal</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70875</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">55310</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:05.474</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:05.474</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="910" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70875" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:06.503</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:06.503</Data>
+        <Data AD_Column_ID="58049" Column="Description">ID of document reversal</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Reversal ID</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70875</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">065573a3-c2db-4223-901c-c499f8248418</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="920" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70876" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">c5aeea17-d9c2-4b58-a48e-e538560f867e</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:06.751</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:06.751</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Created By field indicates the user who created this record.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.CreatedBy</Data>
+        <Data AD_Column_ID="58105" Column="Name">Created By</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_CreatedBy</Data>
+        <Data AD_Column_ID="58102" Column="Description">User who created this records</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70876</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54866</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="930" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70876" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:07.615</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Created By</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70876</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">245cdfad-b07f-4be7-81e5-4bcf74b07f76</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:07.615</Data>
+        <Data AD_Column_ID="58049" Column="Description">User who created this records</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="940" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70877" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">33d90625-a751-4c4a-825f-287e9a89a17d</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:07.832</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:07.832</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Updated By field indicates the user who updated this record.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.UpdatedBy</Data>
+        <Data AD_Column_ID="58105" Column="Name">Updated By</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_UpdatedBy</Data>
+        <Data AD_Column_ID="58102" Column="Description">User who updated this records</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70877</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54880</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="950" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70877" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:08.8</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:08.8</Data>
+        <Data AD_Column_ID="58049" Column="Description">User who updated this records</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Updated By</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70877</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">188a4732-9d8e-42f1-b384-c760593e61be</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="960" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70878" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">d041784d-5451-42de-8eba-f1d87ec709e9</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:09.004</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:09.004</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Workflow field identifies a unique Workflow in the system.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.AD_Workflow_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Workflow</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_AD_Workflow_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Workflow or combination of tasks</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70878</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54883</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="970" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70878" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:09.942</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:09.942</Data>
+        <Data AD_Column_ID="58049" Column="Description">Workflow or combination of tasks</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Workflow</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70878</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">6afaded6-72d4-4b4a-8490-87ba220a70fa</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="980" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70879" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">0b5229ae-2223-49f7-b580-2335a9d6e800</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:10.209</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:10.209</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.HR_Employee_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Payroll Employee</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_HR_Employee_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70879</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54861</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="990" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70879" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:11.063</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:11.063</Data>
+        <Data AD_Column_ID="58049" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Payroll Employee</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70879</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">5f68f264-1893-4163-89da-4a1ce2b5309c</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1000" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70880" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">01c4be6e-0e8c-4e89-b29a-fe79e2d278dd</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:11.289</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:11.289</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The ProcessedOn Date+Time save the exact moment (nanoseconds precision if allowed by the DB) when a document has been processed.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.ProcessedOn</Data>
+        <Data AD_Column_ID="58105" Column="Name">Processed On</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_ProcessedOn</Data>
+        <Data AD_Column_ID="58102" Column="Description">The date+time (expressed in decimal format) when the document has been processed</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70880</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">59043</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1010" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70880" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:12.437</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:12.437</Data>
+        <Data AD_Column_ID="58049" Column="Description">The date+time (expressed in decimal format) when the document has been processed</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Processed On</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70880</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">160b8233-0735-446c-bfb1-ff2dc514e49d</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1020" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70881" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.UUID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_UUID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70881</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">84845</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84462" Column="UUID">cf28cd96-1b71-41b5-a687-87e1887f9440</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:12.774</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:12.774</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1030" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70881" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:16.241</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:16.241</Data>
+        <Data AD_Column_ID="58049" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70881</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">5ac91748-67cc-4592-8d85-ee1b40098a53</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1040" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70882" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">6582a99d-6a90-4a11-974f-62ea27d4aff8</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:16.472</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:16.472</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">Indicates the Currency to be used when processing or reporting on this record</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.C_Currency_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Currency</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_Currency_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70882</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">92523</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1050" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70882" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:17.791</Data>
+        <Data AD_Column_ID="58052" Column="Name">Currency</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70882</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">e02e3f7d-5ccc-4a62-98b4-789b68bd2b1c</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:17.791</Data>
+        <Data AD_Column_ID="58049" Column="Description">The Currency for this record</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1060" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70883" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">fd617174-9d31-4028-9bd3-fc80bb1520c4</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:18.016</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:18.016</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Currency Conversion Rate Type lets you define different type of rates, e.g. Spot, Corporate and/or Sell/Buy rates.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.C_ConversionType_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Currency Type</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_ConversionType_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Currency Conversion Rate Type</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70883</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">92524</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1070" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70883" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:18.805</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:18.805</Data>
+        <Data AD_Column_ID="58049" Column="Description">Currency Conversion Rate Type</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Currency Type</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70883</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">7fe98b1f-8876-44c1-bb4d-813975534a3f</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1080" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70884" Table="AD_View_Column">
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_HR_Period_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70884</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54873</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="84462" Column="UUID">0060e0db-22b9-4a6b-8024-ce0202a1e525</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:19.018</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:19.018</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.HR_Period_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Payroll Period</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1090" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70884" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:20.018</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:20.018</Data>
+        <Data AD_Column_ID="58049" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Payroll Period</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70884</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">3cceb5c5-b37e-4008-868e-33d63f2f8ec4</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1100" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70885" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">1c8c0af9-a7bb-4aec-9dbb-237981edc25b</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:20.325</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:20.325</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Accounting Date indicates the date to be used on the General Ledger account entries generated from this document. It is also used for any currency conversion.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.DateAcct</Data>
+        <Data AD_Column_ID="58105" Column="Name">Account Date</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_DateAcct</Data>
+        <Data AD_Column_ID="58102" Column="Description">Accounting Date</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70885</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54867</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1110" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70885" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:21.185</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70885</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">c980ff68-ad51-4c3c-8cf5-9323f5e86c44</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:21.185</Data>
+        <Data AD_Column_ID="58049" Column="Description">Accounting Date</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Account Date</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1120" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70886" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">231aba6f-7e5a-4b66-bff6-3d91a9712ef4</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:21.418</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:21.418</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.HR_Payroll_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Payroll</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_HR_Payroll_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70886</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">54872</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1130" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70886" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:22.44</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:22.44</Data>
+        <Data AD_Column_ID="58049" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Payroll</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70886</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">fe47b10c-69d3-46f4-bbfa-912a88ffb12e</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1140" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70887" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">013e4ba6-2ec4-474d-b101-a67aaa551661</Data>
+        <Data AD_Column_ID="58102" Column="Description">Performing or initiating organization</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70887</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">96195</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:22.739</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:22.739</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The organization which performs or initiates this transaction (for another organization).  The owning Organization may not be the transaction organization in a service bureau environment, with centralized services, and inter-organization transactions.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.AD_OrgTrx_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Trx Organization</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_AD_OrgTrx_ID</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1150" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70887" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:23.711</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:23.711</Data>
+        <Data AD_Column_ID="58049" Column="Description">Performing or initiating organization</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Trx Organization</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70887</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">f0932f9b-147f-48df-af46-5814d0ef81fa</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1160" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70888" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">68de27be-381c-4403-831d-29903c870de6</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:24.113</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:24.113</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">A Project allows you to track and control internal or external activities.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.C_Project_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Project</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_Project_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Financial Project</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70888</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">96196</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1170" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70888" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:25.273</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">92e5e7fd-dec3-4879-a9ac-62ce392ec06b</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:25.273</Data>
+        <Data AD_Column_ID="58049" Column="Description">Financial Project</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Project</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70888</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1180" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70889" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">1784bf77-e51a-4d3f-a9ca-768a42fe3cbe</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:25.647</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:25.647</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Sales Region indicates a specific area of sales coverage.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.C_SalesRegion_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Sales Region</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_SalesRegion_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Sales coverage region</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70889</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">96197</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1190" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70889" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:26.774</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:26.774</Data>
+        <Data AD_Column_ID="58049" Column="Description">Sales coverage region</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Sales Region</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70889</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">339d7be0-d096-4938-b244-1ad5a55741e2</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1200" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70890" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">45815574-c7cb-44b5-9452-a39befd9a97a</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70890</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">96198</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:27.047</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:27.047</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">Activities indicate tasks that are performed and used to utilize Activity based Costing</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.C_Activity_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Activity</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_Activity_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Business Activity</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1210" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70890" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:28.265</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:28.265</Data>
+        <Data AD_Column_ID="58049" Column="Description">Business Activity</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Activity</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70890</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">7f4cbb68-9a11-487c-ae61-b2d8b1586089</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1220" StepType="AD">
+      <PO AD_Table_ID="53232" Action="I" Record_ID="70891" Table="AD_View_Column">
+        <Data AD_Column_ID="84462" Column="UUID">d0a2ba5d-3e92-45df-b896-351d4c94d701</Data>
+        <Data AD_Column_ID="58095" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58096" Column="Created">2020-12-15 01:59:28.603</Data>
+        <Data AD_Column_ID="58097" Column="Updated">2020-12-15 01:59:28.603</Data>
+        <Data AD_Column_ID="58101" Column="AD_View_Definition_ID">50530</Data>
+        <Data AD_Column_ID="58104" Column="Help">The Campaign defines a unique marketing program.  Projects can be associated with a pre defined Marketing Campaign.  You can then report based on a specific Campaign.</Data>
+        <Data AD_Column_ID="58106" Column="ColumnSQL">hrp.C_Campaign_ID</Data>
+        <Data AD_Column_ID="58105" Column="Name">Campaign</Data>
+        <Data AD_Column_ID="58107" Column="ColumnName">HRP_C_Campaign_ID</Data>
+        <Data AD_Column_ID="58102" Column="Description">Marketing Campaign</Data>
+        <Data AD_Column_ID="58100" Column="AD_View_Column_ID">70891</Data>
+        <Data AD_Column_ID="58093" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58094" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58103" Column="EntityType">D</Data>
+        <Data AD_Column_ID="58099" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="58108" Column="AD_View_ID">50044</Data>
+        <Data AD_Column_ID="58109" Column="AD_Column_ID">96199</Data>
+        <Data AD_Column_ID="58098" Column="CreatedBy">100</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1230" StepType="AD">
+      <PO AD_Table_ID="53228" Action="I" Record_ID="70891" Table="AD_View_Column_Trl">
+        <Data AD_Column_ID="58041" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="58044" Column="Updated">2020-12-15 01:59:29.724</Data>
+        <Data AD_Column_ID="58042" Column="IsActive">true</Data>
+        <Data AD_Column_ID="58043" Column="Created">2020-12-15 01:59:29.724</Data>
+        <Data AD_Column_ID="58049" Column="Description">Marketing Campaign</Data>
+        <Data AD_Column_ID="58050" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="58051" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="58052" Column="Name">Campaign</Data>
+        <Data AD_Column_ID="58047" Column="AD_View_Column_ID">70891</Data>
+        <Data AD_Column_ID="58040" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="58045" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="58048" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="58046" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84463" Column="UUID">0b9e95bd-841d-4600-ae26-3d535e2074b2</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="1240" StepType="AD">
+      <PO AD_Table_ID="53232" Action="U" Record_ID="53812" Table="AD_View_Column">
+        <Data AD_Column_ID="58106" Column="ColumnSQL" oldValue="hrm.Amount">currencyConvert(hrm.Amount, hrp.C_Currency_ID, @C_Currency_ID@, TO_DATE('@PayDate@','YYYY-MM-DD'), hrp.C_ConversionType_ID,hrp.AD_Client_ID, hrp.AD_Org_ID)</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
This pull request allows convert to payment selection currency all documents that will be paid. Currently exists a parameter for Smart Browser called Currency but it is used as query criteria and for convert amount of document, the problem is that always is filtered from selected currency and when it is converted is based on the same currency.

Just is change the follows Smart Browsers:
- Payment Selection Create From Invoice
- Generate Payment Selection (From Invoice) 
- Payment Selection Create From Payroll Movement