### PR TITLE
Fixed error with Reversed document when it is copied from window

### DIFF
--- a/base/src/org/compiere/model/M_Element.java
+++ b/base/src/org/compiere/model/M_Element.java
@@ -346,22 +346,37 @@ public class M_Element extends X_AD_Element
 		//	its must be change for dynamic dictionary query
 		return columnName.equals("AD_Client_ID")
 			//
-			|| columnName.startsWith("Created") || columnName.startsWith("Updated")
-			|| columnName.equals("EntityType") || columnName.equals("DocumentNo")
-			|| columnName.equals("Processed") || columnName.equals("IsSelfService")
-			|| columnName.equals("DocAction") || columnName.equals("DocStatus")
-			|| columnName.equals("Posted") || columnName.equals("IsReconciled")
+			|| columnName.startsWith("Created") 
+			|| columnName.startsWith("Updated")
+			|| columnName.equals("EntityType") 
+			|| columnName.equals("DocumentNo")
+			|| columnName.equals("Processed") 
+			|| columnName.equals("IsSelfService")
+			|| columnName.equals("DocAction") 
+			|| columnName.equals("DocStatus")
+			|| columnName.equals("Posted") 
+			|| columnName.equals("IsReconciled")
 			|| columnName.equals("IsApproved") // BF [ 1943682 ]
 			|| columnName.equals("IsGenerated") // BF [ 1943682 ]
 			|| columnName.startsWith("Ref_")
 			//	Order/Invoice
-			|| columnName.equals("GrandTotal") || columnName.equals("TotalLines")
-			|| columnName.equals("C_CashLine_ID") || columnName.equals("C_Payment_ID")
-			|| columnName.equals("IsPaid") || columnName.equals("IsAllocated")
+			|| columnName.equals("GrandTotal") 
+			|| columnName.equals("TotalLines")
+			|| columnName.equals("C_CashLine_ID") 
+			|| columnName.equals("C_Payment_ID")
+			|| columnName.equals("IsPaid") 
+			|| columnName.equals("IsAllocated")
 			// Bug [ 1807947 ] 
 			|| columnName.equals("C_DocType_ID")
 			|| columnName.equals("Line")
-			|| columnName.equals("UUID");
+			|| columnName.equals("UUID")
+			|| columnName.equals("Reversal_ID")
+			|| columnName.equals("ReversalLine_ID")
+			|| columnName.equals("ProcessedOn")
+			|| columnName.equals("Processing")
+			|| columnName.equals("Related_ID")
+			|| columnName.equals("SeqNo")
+			|| columnName.equals("IsActive");
 	}
 	
 	/**

--- a/base/src/org/compiere/model/M_Element.java
+++ b/base/src/org/compiere/model/M_Element.java
@@ -393,6 +393,7 @@ public class M_Element extends X_AD_Element
 			|| columnName.equals("IsReversal")
 			|| columnName.equals("DatePrinted")
 			|| columnName.equals("IsPrinted")
+			|| columnName.equals("IsOverUnderPayment")
 			|| (columnName.startsWith("Ref_") && columnName.endsWith("_ID"));
 	}
 	

--- a/base/src/org/compiere/model/M_Element.java
+++ b/base/src/org/compiere/model/M_Element.java
@@ -376,7 +376,24 @@ public class M_Element extends X_AD_Element
 			|| columnName.equals("Processing")
 			|| columnName.equals("Related_ID")
 			|| columnName.equals("SeqNo")
-			|| columnName.equals("IsActive");
+			|| columnName.equals("IsActive")
+			|| columnName.equals("RelatedPayment_ID")
+			|| columnName.equals("RelatedProduct_ID")
+			|| columnName.equals("Ref_BPartner_ID")
+			|| columnName.equals("Ref_DefinitionPeriod_ID")
+			|| columnName.equals("Ref_InOut_ID")
+			|| columnName.equals("Ref_InOutLine_ID")
+			|| columnName.equals("Ref_Invoice_ID")
+			|| columnName.equals("Ref_InvoiceLine_ID")
+			|| columnName.equals("Ref_Order_ID")
+			|| columnName.equals("Ref_OrderLine_ID")
+			|| columnName.equals("Ref_Payment_ID")
+			|| columnName.equals("Ref_RMA_ID")
+			|| columnName.equals("Ref_RMALine_ID")
+			|| columnName.equals("IsReversal")
+			|| columnName.equals("DatePrinted")
+			|| columnName.equals("IsPrinted")
+			|| (columnName.startsWith("Ref_") && columnName.endsWith("_ID"));
 	}
 	
 	/**

--- a/migration/393lts-394lts/07230_Fixed_error_with_Reversal_ID_and_ReversalLine_ID.xml
+++ b/migration/393lts-394lts/07230_Fixed_error_with_Reversal_ID_and_ReversalLine_ID.xml
@@ -2,8 +2,8 @@
 <Migrations>
   <Migration EntityType="ECA02" Name="Fixed error with Reversal ID and ReversalLine ID" ReleaseNo="3.9.4" SeqNo="7230">
     <Step DBType="ALL" Parse="Y" SeqNo="10" StepType="SQL">
-      <SQLStatement>UPDATE AD_Column SET IsAllowCopy = 'N' WHERE ColumnName IN('Reversal_ID', 'ReversalLine_ID');
-UPDATE AD_Field SET IsAllowCopy = 'N' WHERE EXISTS(SELECT 1 FROM AD_Column WHERE AD_Column_ID = AD_Field.AD_Column_ID AND ColumnName IN('Reversal_ID', 'ReversalLine_ID'));</SQLStatement>
+      <SQLStatement>UPDATE AD_Column SET IsAllowCopy = 'N' WHERE ColumnName IN('Reversal_ID', 'ReversalLine_ID', 'Processed', 'ProcessedOn', 'Processing', 'Posted', 'DocStatus', 'DocAction');
+UPDATE AD_Field SET IsAllowCopy = 'N' WHERE EXISTS(SELECT 1 FROM AD_Column WHERE AD_Column_ID = AD_Field.AD_Column_ID AND ColumnName IN('Reversal_ID', 'ReversalLine_ID', 'Processed', 'ProcessedOn', 'Processing', 'Posted', 'DocStatus', 'DocAction'));</SQLStatement>
     </Step>
   </Migration>
 </Migrations>

--- a/migration/393lts-394lts/07230_Fixed_error_with_Reversal_ID_and_ReversalLine_ID.xml
+++ b/migration/393lts-394lts/07230_Fixed_error_with_Reversal_ID_and_ReversalLine_ID.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="ECA02" Name="Fixed error with Reversal ID and ReversalLine ID" ReleaseNo="3.9.4" SeqNo="7230">
+    <Step DBType="ALL" Parse="Y" SeqNo="10" StepType="SQL">
+      <SQLStatement>UPDATE AD_Column SET IsAllowCopy = 'N' WHERE ColumnName IN('Reversal_ID', 'ReversalLine_ID');
+UPDATE AD_Field SET IsAllowCopy = 'N' WHERE EXISTS(SELECT 1 FROM AD_Column WHERE AD_Column_ID = AD_Field.AD_Column_ID AND ColumnName IN('Reversal_ID', 'ReversalLine_ID'));</SQLStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
# Step by Step
- Create a Payment
- Reverse created payment
- Copy the reversed payment and complete it

# What is the bug? 
Sometimes the **Reversal_ID** is flagged as **IsAllowsCopy** on true for window, then is copied for new payment, it is a error because some validator have **Reversal_ID** as value for determinate if is a voided document or not

# What is the consequenses
Is a document type is flagged as **IsReversedWithOriginalAcct** as true then the account fact engine sear a reversal document for create fact and is wrong

# A sample
![Screenshot_20201216_221825](https://user-images.githubusercontent.com/2333092/102435223-a0f25580-3fec-11eb-8370-da922af423ee.png)

![Peek 2020-12-16 22-17](https://user-images.githubusercontent.com/2333092/102435182-8cae5880-3fec-11eb-900a-42a1121704c2.gif)