### PR TITLE
3292 - fixes to migration script 5910 - remove duplicate steps and set the correct sequence.

### DIFF
--- a/migration/393lts-394lts/05910_Add_Document_Base_Type_Invoice_View.xml
+++ b/migration/393lts-394lts/05910_Add_Document_Base_Type_Invoice_View.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add Document Base Type for Invoices View" ReleaseNo="3.9.3" SeqNo="5910">
+  <Migration EntityType="D" Name="Add Document Base Type for Invoices View" ReleaseNo="3.9.4" SeqNo="5910">
     <Comments>RV_C_INVOICE</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="I" Record_ID="95637" Table="AD_Column">
@@ -321,6 +321,86 @@
       </PO>
     </Step>
     <Step DBType="Postgres" Parse="N" SeqNo="140" StepType="SQL">
+      <Comments>RV_C_INVOICE</Comments>
+      <SQLStatement>CREATE OR REPLACE VIEW RV_C_INVOICE
+(C_INVOICE_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
+ CREATEDBY, UPDATED, UPDATEDBY, ISSOTRX, DOCUMENTNO, 
+ DOCSTATUS, DOCACTION, ISPRINTED, ISDISCOUNTPRINTED, PROCESSING, 
+ PROCESSED, ISTRANSFERRED, ISPAID, C_DOCTYPE_ID, C_DOCTYPETARGET_ID, 
+ C_ORDER_ID, DESCRIPTION, ISAPPROVED, SALESREP_ID, DATEINVOICED, 
+ DATEPRINTED, DATEACCT, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, 
+ C_BP_GROUP_ID, POREFERENCE, DATEORDERED, C_CURRENCY_ID, C_CONVERSIONTYPE_ID, 
+ PAYMENTRULE, C_PAYMENTTERM_ID, M_PRICELIST_ID, C_CAMPAIGN_ID, C_PROJECT_ID, 
+ C_ACTIVITY_ID, ISPAYSCHEDULEVALID, INVOICECOLLECTIONTYPE, C_COUNTRY_ID, C_REGION_ID, 
+ POSTAL, CITY, C_CHARGE_ID, CHARGEAMT, TOTALLINES, 
+ GRANDTOTAL, MULTIPLIER,
+ C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, C_SalesRegion_ID, DocBaseType)
+AS 
+SELECT i.C_Invoice_ID,
+	i.AD_Client_ID,i.AD_Org_ID,i.IsActive,i.Created,i.CreatedBy,i.Updated,i.UpdatedBy,
+	i.IsSOTrx, i.DocumentNo, i.DocStatus, i.DocAction,
+	i.IsPrinted, i.IsDiscountPrinted, i.Processing, i.Processed, i.IsTransferred, i.IsPaid,
+	i.C_DocType_ID, i.C_DocTypeTarget_ID, i.C_Order_ID, i.Description, i.IsApproved,
+	i.SalesRep_ID, i.DateInvoiced, i.DatePrinted, i.DateAcct,
+	i.C_BPartner_ID, i.C_BPartner_Location_ID, i.AD_User_ID, b.C_BP_Group_ID,
+	i.POReference, i.DateOrdered, i.C_Currency_ID, C_ConversionType_ID, i.PaymentRule, i.C_PaymentTerm_ID,
+	i.M_PriceList_ID, i.C_Campaign_ID, i.C_Project_ID, i.C_Activity_ID,
+    i.IsPayScheduleValid, i.InvoiceCollectionType,
+    loc.C_Country_ID, loc.C_Region_ID, loc.Postal, loc.City,
+	--	Amounts
+	i.C_Charge_ID,
+	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.ChargeAmt*-1 ELSE i.ChargeAmt END AS ChargeAmt,
+	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.TotalLines*-1 ELSE i.TotalLines END AS TotalLines,
+	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.GrandTotal*-1 ELSE i.GrandTotal END AS GrandTotal,
+	CASE WHEN charAt(d.DocBaseType,3)='C' THEN -1 ELSE 1 END AS Multiplier,
+	b.C_BP_AccountType_ID, b.C_BP_SalesGroup_ID, b.C_BP_Segment_ID, b.C_BP_IndustryType_ID,
+	i.C_SalesRegion_ID,
+	d.DocBaseType
+FROM  C_Invoice i
+ INNER JOIN C_DocType d ON (i.C_DocType_ID=d.C_DocType_ID)
+ INNER JOIN C_BPartner b ON (i.C_BPartner_ID=b.C_BPartner_ID)
+ INNER JOIN C_BPartner_Location bpl ON (i.C_BPartner_Location_ID=bpl.C_BPartner_Location_ID)
+ INNER JOIN C_Location loc ON (bpl.C_Location_ID=loc.C_Location_ID);</SQLStatement>
+      <RollbackStatement>CREATE OR REPLACE VIEW RV_C_INVOICE
+(C_INVOICE_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
+ CREATEDBY, UPDATED, UPDATEDBY, ISSOTRX, DOCUMENTNO, 
+ DOCSTATUS, DOCACTION, ISPRINTED, ISDISCOUNTPRINTED, PROCESSING, 
+ PROCESSED, ISTRANSFERRED, ISPAID, C_DOCTYPE_ID, C_DOCTYPETARGET_ID, 
+ C_ORDER_ID, DESCRIPTION, ISAPPROVED, SALESREP_ID, DATEINVOICED, 
+ DATEPRINTED, DATEACCT, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, 
+ C_BP_GROUP_ID, POREFERENCE, DATEORDERED, C_CURRENCY_ID, C_CONVERSIONTYPE_ID, 
+ PAYMENTRULE, C_PAYMENTTERM_ID, M_PRICELIST_ID, C_CAMPAIGN_ID, C_PROJECT_ID, 
+ C_ACTIVITY_ID, ISPAYSCHEDULEVALID, INVOICECOLLECTIONTYPE, C_COUNTRY_ID, C_REGION_ID, 
+ POSTAL, CITY, C_CHARGE_ID, CHARGEAMT, TOTALLINES, 
+ GRANDTOTAL, MULTIPLIER,
+ C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, C_SalesRegion_ID)
+AS 
+SELECT i.C_Invoice_ID,
+	i.AD_Client_ID,i.AD_Org_ID,i.IsActive,i.Created,i.CreatedBy,i.Updated,i.UpdatedBy,
+	i.IsSOTrx, i.DocumentNo, i.DocStatus, i.DocAction,
+	i.IsPrinted, i.IsDiscountPrinted, i.Processing, i.Processed, i.IsTransferred, i.IsPaid,
+	i.C_DocType_ID, i.C_DocTypeTarget_ID, i.C_Order_ID, i.Description, i.IsApproved,
+	i.SalesRep_ID, i.DateInvoiced, i.DatePrinted, i.DateAcct,
+	i.C_BPartner_ID, i.C_BPartner_Location_ID, i.AD_User_ID, b.C_BP_Group_ID,
+	i.POReference, i.DateOrdered, i.C_Currency_ID, C_ConversionType_ID, i.PaymentRule, i.C_PaymentTerm_ID,
+	i.M_PriceList_ID, i.C_Campaign_ID, i.C_Project_ID, i.C_Activity_ID,
+    i.IsPayScheduleValid, i.InvoiceCollectionType,
+    loc.C_Country_ID, loc.C_Region_ID, loc.Postal, loc.City,
+	--	Amounts
+	i.C_Charge_ID,
+	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.ChargeAmt*-1 ELSE i.ChargeAmt END AS ChargeAmt,
+	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.TotalLines*-1 ELSE i.TotalLines END AS TotalLines,
+	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.GrandTotal*-1 ELSE i.GrandTotal END AS GrandTotal,
+	CASE WHEN charAt(d.DocBaseType,3)='C' THEN -1 ELSE 1 END AS Multiplier,
+	b.C_BP_AccountType_ID, b.C_BP_SalesGroup_ID, b.C_BP_Segment_ID, b.C_BP_IndustryType_ID,
+	i.C_SalesRegion_ID
+FROM  C_Invoice i
+ INNER JOIN C_DocType d ON (i.C_DocType_ID=d.C_DocType_ID)
+ INNER JOIN C_BPartner b ON (i.C_BPartner_ID=b.C_BPartner_ID)
+ INNER JOIN C_BPartner_Location bpl ON (i.C_BPartner_Location_ID=bpl.C_BPartner_Location_ID)
+ INNER JOIN C_Location loc ON (bpl.C_Location_ID=loc.C_Location_ID);</RollbackStatement>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="145" StepType="SQL">
       <Comments>RV_C_INVOICELINE</Comments>
       <SQLStatement>CREATE OR REPLACE VIEW RV_C_INVOICELINE
 (AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, CREATEDBY, 
@@ -427,274 +507,6 @@ FROM  RV_C_Invoice i
   INNER JOIN C_InvoiceLine il ON (i.C_Invoice_ID=il.C_Invoice_ID)
   LEFT OUTER JOIN M_Product p ON (il.M_Product_ID=p.M_Product_ID)
   LEFT OUTER JOIN M_AttributeSetInstance pasi ON (il.M_AttributeSetInstance_ID=pasi.M_AttributeSetInstance_ID);</RollbackStatement>
-    </Step>
-    <Step DBType="Postgres" Parse="N" SeqNo="140" StepType="SQL">
-      <Comments>RV_C_INVOICE</Comments>
-      <SQLStatement>CREATE OR REPLACE VIEW RV_C_INVOICE
-(C_INVOICE_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
- CREATEDBY, UPDATED, UPDATEDBY, ISSOTRX, DOCUMENTNO, 
- DOCSTATUS, DOCACTION, ISPRINTED, ISDISCOUNTPRINTED, PROCESSING, 
- PROCESSED, ISTRANSFERRED, ISPAID, C_DOCTYPE_ID, C_DOCTYPETARGET_ID, 
- C_ORDER_ID, DESCRIPTION, ISAPPROVED, SALESREP_ID, DATEINVOICED, 
- DATEPRINTED, DATEACCT, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, 
- C_BP_GROUP_ID, POREFERENCE, DATEORDERED, C_CURRENCY_ID, C_CONVERSIONTYPE_ID, 
- PAYMENTRULE, C_PAYMENTTERM_ID, M_PRICELIST_ID, C_CAMPAIGN_ID, C_PROJECT_ID, 
- C_ACTIVITY_ID, ISPAYSCHEDULEVALID, INVOICECOLLECTIONTYPE, C_COUNTRY_ID, C_REGION_ID, 
- POSTAL, CITY, C_CHARGE_ID, CHARGEAMT, TOTALLINES, 
- GRANDTOTAL, MULTIPLIER,
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, C_SalesRegion_ID, DocBaseType)
-AS 
-SELECT i.C_Invoice_ID,
-	i.AD_Client_ID,i.AD_Org_ID,i.IsActive,i.Created,i.CreatedBy,i.Updated,i.UpdatedBy,
-	i.IsSOTrx, i.DocumentNo, i.DocStatus, i.DocAction,
-	i.IsPrinted, i.IsDiscountPrinted, i.Processing, i.Processed, i.IsTransferred, i.IsPaid,
-	i.C_DocType_ID, i.C_DocTypeTarget_ID, i.C_Order_ID, i.Description, i.IsApproved,
-	i.SalesRep_ID, i.DateInvoiced, i.DatePrinted, i.DateAcct,
-	i.C_BPartner_ID, i.C_BPartner_Location_ID, i.AD_User_ID, b.C_BP_Group_ID,
-	i.POReference, i.DateOrdered, i.C_Currency_ID, C_ConversionType_ID, i.PaymentRule, i.C_PaymentTerm_ID,
-	i.M_PriceList_ID, i.C_Campaign_ID, i.C_Project_ID, i.C_Activity_ID,
-    i.IsPayScheduleValid, i.InvoiceCollectionType,
-    loc.C_Country_ID, loc.C_Region_ID, loc.Postal, loc.City,
-	--	Amounts
-	i.C_Charge_ID,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.ChargeAmt*-1 ELSE i.ChargeAmt END AS ChargeAmt,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.TotalLines*-1 ELSE i.TotalLines END AS TotalLines,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.GrandTotal*-1 ELSE i.GrandTotal END AS GrandTotal,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN -1 ELSE 1 END AS Multiplier,
-	b.C_BP_AccountType_ID, b.C_BP_SalesGroup_ID, b.C_BP_Segment_ID, b.C_BP_IndustryType_ID,
-	i.C_SalesRegion_ID,
-	d.DocBaseType
-FROM  C_Invoice i
- INNER JOIN C_DocType d ON (i.C_DocType_ID=d.C_DocType_ID)
- INNER JOIN C_BPartner b ON (i.C_BPartner_ID=b.C_BPartner_ID)
- INNER JOIN C_BPartner_Location bpl ON (i.C_BPartner_Location_ID=bpl.C_BPartner_Location_ID)
- INNER JOIN C_Location loc ON (bpl.C_Location_ID=loc.C_Location_ID);</SQLStatement>
-      <RollbackStatement>CREATE OR REPLACE VIEW RV_C_INVOICE
-(C_INVOICE_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
- CREATEDBY, UPDATED, UPDATEDBY, ISSOTRX, DOCUMENTNO, 
- DOCSTATUS, DOCACTION, ISPRINTED, ISDISCOUNTPRINTED, PROCESSING, 
- PROCESSED, ISTRANSFERRED, ISPAID, C_DOCTYPE_ID, C_DOCTYPETARGET_ID, 
- C_ORDER_ID, DESCRIPTION, ISAPPROVED, SALESREP_ID, DATEINVOICED, 
- DATEPRINTED, DATEACCT, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, 
- C_BP_GROUP_ID, POREFERENCE, DATEORDERED, C_CURRENCY_ID, C_CONVERSIONTYPE_ID, 
- PAYMENTRULE, C_PAYMENTTERM_ID, M_PRICELIST_ID, C_CAMPAIGN_ID, C_PROJECT_ID, 
- C_ACTIVITY_ID, ISPAYSCHEDULEVALID, INVOICECOLLECTIONTYPE, C_COUNTRY_ID, C_REGION_ID, 
- POSTAL, CITY, C_CHARGE_ID, CHARGEAMT, TOTALLINES, 
- GRANDTOTAL, MULTIPLIER,
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, C_SalesRegion_ID)
-AS 
-SELECT i.C_Invoice_ID,
-	i.AD_Client_ID,i.AD_Org_ID,i.IsActive,i.Created,i.CreatedBy,i.Updated,i.UpdatedBy,
-	i.IsSOTrx, i.DocumentNo, i.DocStatus, i.DocAction,
-	i.IsPrinted, i.IsDiscountPrinted, i.Processing, i.Processed, i.IsTransferred, i.IsPaid,
-	i.C_DocType_ID, i.C_DocTypeTarget_ID, i.C_Order_ID, i.Description, i.IsApproved,
-	i.SalesRep_ID, i.DateInvoiced, i.DatePrinted, i.DateAcct,
-	i.C_BPartner_ID, i.C_BPartner_Location_ID, i.AD_User_ID, b.C_BP_Group_ID,
-	i.POReference, i.DateOrdered, i.C_Currency_ID, C_ConversionType_ID, i.PaymentRule, i.C_PaymentTerm_ID,
-	i.M_PriceList_ID, i.C_Campaign_ID, i.C_Project_ID, i.C_Activity_ID,
-    i.IsPayScheduleValid, i.InvoiceCollectionType,
-    loc.C_Country_ID, loc.C_Region_ID, loc.Postal, loc.City,
-	--	Amounts
-	i.C_Charge_ID,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.ChargeAmt*-1 ELSE i.ChargeAmt END AS ChargeAmt,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.TotalLines*-1 ELSE i.TotalLines END AS TotalLines,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.GrandTotal*-1 ELSE i.GrandTotal END AS GrandTotal,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN -1 ELSE 1 END AS Multiplier,
-	b.C_BP_AccountType_ID, b.C_BP_SalesGroup_ID, b.C_BP_Segment_ID, b.C_BP_IndustryType_ID,
-	i.C_SalesRegion_ID
-FROM  C_Invoice i
- INNER JOIN C_DocType d ON (i.C_DocType_ID=d.C_DocType_ID)
- INNER JOIN C_BPartner b ON (i.C_BPartner_ID=b.C_BPartner_ID)
- INNER JOIN C_BPartner_Location bpl ON (i.C_BPartner_Location_ID=bpl.C_BPartner_Location_ID)
- INNER JOIN C_Location loc ON (bpl.C_Location_ID=loc.C_Location_ID);</RollbackStatement>
-    </Step>
-    <Step DBType="Postgres" Parse="N" SeqNo="140" StepType="SQL">
-      <Comments>RV_C_INVOICELINE</Comments>
-      <SQLStatement>CREATE OR REPLACE VIEW RV_C_INVOICELINE
-(AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, CREATEDBY, 
- UPDATED, UPDATEDBY, C_INVOICELINE_ID, C_INVOICE_ID, SALESREP_ID, 
- C_BPARTNER_ID, C_BP_GROUP_ID, M_PRODUCT_ID, M_PRODUCT_CATEGORY_ID, DATEINVOICED, 
- DATEACCT, ISSOTRX, C_DOCTYPE_ID, DOCSTATUS, ISPAID, 
- C_CAMPAIGN_ID, C_PROJECT_ID, C_ACTIVITY_ID, C_PROJECTPHASE_ID, C_PROJECTTASK_ID, 
- QTYINVOICED, QTYENTERED, M_ATTRIBUTESETINSTANCE_ID, PRODUCTATTRIBUTE, M_ATTRIBUTESET_ID, 
- M_LOT_ID, GUARANTEEDATE, LOT, SERNO, PRICELIST, 
- PRICEACTUAL, PRICELIMIT, PRICEENTERED, DISCOUNT, MARGIN, 
- MARGINAMT, LINENETAMT, LINELISTAMT, LINELIMITAMT, LINEDISCOUNTAMT, 
- LINEOVERLIMITAMT, M_Product_Class_ID, M_Product_Group_ID, M_Product_Classification_ID, Description, LineDescription, C_DocTypeTarget_ID,
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, C_SalesRegion_ID, Weight, Volume, DocBaseType, C_Currency_ID)
-AS 
-SELECT 
-	il.AD_Client_ID, il.AD_Org_ID, il.IsActive, il.Created, il.CreatedBy, il.Updated, il.UpdatedBy,
-	il.C_InvoiceLine_ID, i.C_Invoice_ID, i.SalesRep_ID,
-	i.C_BPartner_ID, i.C_BP_Group_ID,
-	il.M_Product_ID, p.M_Product_Category_ID,
-	i.DateInvoiced, i.DateAcct, i.IsSOTrx, i.C_DocType_ID, i.DocStatus, i.IsPaid,
-    il.C_Campaign_ID, il.C_Project_ID, il.C_Activity_ID, il.C_ProjectPhase_ID, il.C_ProjectTask_ID,
-	--	Qty
-	il.QtyInvoiced*i.Multiplier AS QtyInvoiced,
-	il.QtyEntered*i.Multiplier AS QtyEntered,
-    -- Attributes
-    il.M_AttributeSetInstance_ID, productAttribute(il.M_AttributeSetInstance_ID) AS ProductAttribute,
-    pasi.M_AttributeSet_ID, pasi.M_Lot_ID, pasi.GuaranteeDate, pasi.Lot, pasi.SerNo,
-	--	Item Amounts
-	il.PriceList, il.PriceActual, il.PriceLimit, il.PriceEntered,
-	CASE WHEN PriceList=0 THEN 0 ELSE
-	  ROUND((PriceList-PriceActual)/PriceList*100,2) END AS Discount,
-	CASE WHEN PriceLimit=0 THEN 0 ELSE
-	  ROUND((PriceActual-PriceLimit)/PriceLimit*100,2) END AS Margin,
-	CASE WHEN PriceLimit=0 THEN 0 ELSE
-	  (PriceActual-PriceLimit)*QtyInvoiced END AS MarginAmt,
-	--	Line Amounts
-	ROUND(i.Multiplier*LineNetAmt, 2) AS LineNetAmt,
-	ROUND(i.Multiplier*PriceList*QtyInvoiced, 2) AS LineListAmt,
-	CASE WHEN COALESCE(il.PriceLimit, 0)=0 THEN ROUND(i.Multiplier*LineNetAmt,2) ELSE
-		ROUND(i.Multiplier*PriceLimit*QtyInvoiced,2) END AS LineLimitAmt,
-	ROUND(i.Multiplier*PriceList*QtyInvoiced-LineNetAmt,2) AS LineDiscountAmt,
-	CASE WHEN COALESCE(il.PriceLimit,0)=0 THEN 0 ELSE
-		ROUND(i.Multiplier*LineNetAmt-PriceLimit*QtyInvoiced,2) END AS LineOverLimitAmt,
-    p.M_Product_Class_ID, p.M_PRoduct_Group_ID, p.M_Product_Classification_ID, i.Description, 
-    il.Description AS LineDescription, i.C_DocTypeTarget_ID,
-    i.C_BP_AccountType_ID, i.C_BP_SalesGroup_ID, i.C_BP_Segment_ID, i.C_BP_IndustryType_ID,
-    i.C_SalesRegion_ID, 
-    (p.Weight * il.QtyInvoiced) AS Weight,
-    (p.Volume * il.QtyInvoiced) AS Volume,
-    i.DocBaseType, i.C_Currency_ID
-FROM  RV_C_Invoice i
-  INNER JOIN C_InvoiceLine il ON (i.C_Invoice_ID=il.C_Invoice_ID)
-  LEFT OUTER JOIN M_Product p ON (il.M_Product_ID=p.M_Product_ID)
-  LEFT OUTER JOIN M_AttributeSetInstance pasi ON (il.M_AttributeSetInstance_ID=pasi.M_AttributeSetInstance_ID);</SQLStatement>
-      <RollbackStatement>CREATE OR REPLACE VIEW RV_C_INVOICELINE
-(AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, CREATEDBY, 
- UPDATED, UPDATEDBY, C_INVOICELINE_ID, C_INVOICE_ID, SALESREP_ID, 
- C_BPARTNER_ID, C_BP_GROUP_ID, M_PRODUCT_ID, M_PRODUCT_CATEGORY_ID, DATEINVOICED, 
- DATEACCT, ISSOTRX, C_DOCTYPE_ID, DOCSTATUS, ISPAID, 
- C_CAMPAIGN_ID, C_PROJECT_ID, C_ACTIVITY_ID, C_PROJECTPHASE_ID, C_PROJECTTASK_ID, 
- QTYINVOICED, QTYENTERED, M_ATTRIBUTESETINSTANCE_ID, PRODUCTATTRIBUTE, M_ATTRIBUTESET_ID, 
- M_LOT_ID, GUARANTEEDATE, LOT, SERNO, PRICELIST, 
- PRICEACTUAL, PRICELIMIT, PRICEENTERED, DISCOUNT, MARGIN, 
- MARGINAMT, LINENETAMT, LINELISTAMT, LINELIMITAMT, LINEDISCOUNTAMT, 
- LINEOVERLIMITAMT, M_Product_Class_ID, M_Product_Group_ID, M_Product_Classification_ID, Description, LineDescription, C_DocTypeTarget_ID,
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, C_SalesRegion_ID, Weight, Volume)
-AS 
-SELECT 
-	il.AD_Client_ID, il.AD_Org_ID, il.IsActive, il.Created, il.CreatedBy, il.Updated, il.UpdatedBy,
-	il.C_InvoiceLine_ID, i.C_Invoice_ID, i.SalesRep_ID,
-	i.C_BPartner_ID, i.C_BP_Group_ID,
-	il.M_Product_ID, p.M_Product_Category_ID,
-	i.DateInvoiced, i.DateAcct, i.IsSOTrx, i.C_DocType_ID, i.DocStatus, i.IsPaid,
-    il.C_Campaign_ID, il.C_Project_ID, il.C_Activity_ID, il.C_ProjectPhase_ID, il.C_ProjectTask_ID,
-	--	Qty
-	il.QtyInvoiced*i.Multiplier AS QtyInvoiced,
-	il.QtyEntered*i.Multiplier AS QtyEntered,
-    -- Attributes
-    il.M_AttributeSetInstance_ID, productAttribute(il.M_AttributeSetInstance_ID) AS ProductAttribute,
-    pasi.M_AttributeSet_ID, pasi.M_Lot_ID, pasi.GuaranteeDate, pasi.Lot, pasi.SerNo,
-	--	Item Amounts
-	il.PriceList, il.PriceActual, il.PriceLimit, il.PriceEntered,
-	CASE WHEN PriceList=0 THEN 0 ELSE
-	  ROUND((PriceList-PriceActual)/PriceList*100,2) END AS Discount,
-	CASE WHEN PriceLimit=0 THEN 0 ELSE
-	  ROUND((PriceActual-PriceLimit)/PriceLimit*100,2) END AS Margin,
-	CASE WHEN PriceLimit=0 THEN 0 ELSE
-	  (PriceActual-PriceLimit)*QtyInvoiced END AS MarginAmt,
-	--	Line Amounts
-	ROUND(i.Multiplier*LineNetAmt, 2) AS LineNetAmt,
-	ROUND(i.Multiplier*PriceList*QtyInvoiced, 2) AS LineListAmt,
-	CASE WHEN COALESCE(il.PriceLimit, 0)=0 THEN ROUND(i.Multiplier*LineNetAmt,2) ELSE
-		ROUND(i.Multiplier*PriceLimit*QtyInvoiced,2) END AS LineLimitAmt,
-	ROUND(i.Multiplier*PriceList*QtyInvoiced-LineNetAmt,2) AS LineDiscountAmt,
-	CASE WHEN COALESCE(il.PriceLimit,0)=0 THEN 0 ELSE
-		ROUND(i.Multiplier*LineNetAmt-PriceLimit*QtyInvoiced,2) END AS LineOverLimitAmt,
-    p.M_Product_Class_ID, p.M_PRoduct_Group_ID, p.M_Product_Classification_ID, i.Description, 
-    il.Description AS LineDescription, i.C_DocTypeTarget_ID,
-    i.C_BP_AccountType_ID, i.C_BP_SalesGroup_ID, i.C_BP_Segment_ID, i.C_BP_IndustryType_ID,
-    i.C_SalesRegion_ID, 
-    (p.Weight * il.QtyInvoiced) AS Weight,
-    (p.Volume * il.QtyInvoiced) AS Volume
-FROM  RV_C_Invoice i
-  INNER JOIN C_InvoiceLine il ON (i.C_Invoice_ID=il.C_Invoice_ID)
-  LEFT OUTER JOIN M_Product p ON (il.M_Product_ID=p.M_Product_ID)
-  LEFT OUTER JOIN M_AttributeSetInstance pasi ON (il.M_AttributeSetInstance_ID=pasi.M_AttributeSetInstance_ID);</RollbackStatement>
-    </Step>
-    <Step DBType="Postgres" Parse="N" SeqNo="140" StepType="SQL">
-      <Comments>RV_C_INVOICE</Comments>
-      <SQLStatement>CREATE OR REPLACE VIEW RV_C_INVOICE
-(C_INVOICE_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
- CREATEDBY, UPDATED, UPDATEDBY, ISSOTRX, DOCUMENTNO, 
- DOCSTATUS, DOCACTION, ISPRINTED, ISDISCOUNTPRINTED, PROCESSING, 
- PROCESSED, ISTRANSFERRED, ISPAID, C_DOCTYPE_ID, C_DOCTYPETARGET_ID, 
- C_ORDER_ID, DESCRIPTION, ISAPPROVED, SALESREP_ID, DATEINVOICED, 
- DATEPRINTED, DATEACCT, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, 
- C_BP_GROUP_ID, POREFERENCE, DATEORDERED, C_CURRENCY_ID, C_CONVERSIONTYPE_ID, 
- PAYMENTRULE, C_PAYMENTTERM_ID, M_PRICELIST_ID, C_CAMPAIGN_ID, C_PROJECT_ID, 
- C_ACTIVITY_ID, ISPAYSCHEDULEVALID, INVOICECOLLECTIONTYPE, C_COUNTRY_ID, C_REGION_ID, 
- POSTAL, CITY, C_CHARGE_ID, CHARGEAMT, TOTALLINES, 
- GRANDTOTAL, MULTIPLIER,
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, C_SalesRegion_ID, DocBaseType)
-AS 
-SELECT i.C_Invoice_ID,
-	i.AD_Client_ID,i.AD_Org_ID,i.IsActive,i.Created,i.CreatedBy,i.Updated,i.UpdatedBy,
-	i.IsSOTrx, i.DocumentNo, i.DocStatus, i.DocAction,
-	i.IsPrinted, i.IsDiscountPrinted, i.Processing, i.Processed, i.IsTransferred, i.IsPaid,
-	i.C_DocType_ID, i.C_DocTypeTarget_ID, i.C_Order_ID, i.Description, i.IsApproved,
-	i.SalesRep_ID, i.DateInvoiced, i.DatePrinted, i.DateAcct,
-	i.C_BPartner_ID, i.C_BPartner_Location_ID, i.AD_User_ID, b.C_BP_Group_ID,
-	i.POReference, i.DateOrdered, i.C_Currency_ID, C_ConversionType_ID, i.PaymentRule, i.C_PaymentTerm_ID,
-	i.M_PriceList_ID, i.C_Campaign_ID, i.C_Project_ID, i.C_Activity_ID,
-    i.IsPayScheduleValid, i.InvoiceCollectionType,
-    loc.C_Country_ID, loc.C_Region_ID, loc.Postal, loc.City,
-	--	Amounts
-	i.C_Charge_ID,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.ChargeAmt*-1 ELSE i.ChargeAmt END AS ChargeAmt,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.TotalLines*-1 ELSE i.TotalLines END AS TotalLines,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.GrandTotal*-1 ELSE i.GrandTotal END AS GrandTotal,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN -1 ELSE 1 END AS Multiplier,
-	b.C_BP_AccountType_ID, b.C_BP_SalesGroup_ID, b.C_BP_Segment_ID, b.C_BP_IndustryType_ID,
-	i.C_SalesRegion_ID,
-	d.DocBaseType
-FROM  C_Invoice i
- INNER JOIN C_DocType d ON (i.C_DocType_ID=d.C_DocType_ID)
- INNER JOIN C_BPartner b ON (i.C_BPartner_ID=b.C_BPartner_ID)
- INNER JOIN C_BPartner_Location bpl ON (i.C_BPartner_Location_ID=bpl.C_BPartner_Location_ID)
- INNER JOIN C_Location loc ON (bpl.C_Location_ID=loc.C_Location_ID);</SQLStatement>
-      <RollbackStatement>CREATE OR REPLACE VIEW RV_C_INVOICE
-(C_INVOICE_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
- CREATEDBY, UPDATED, UPDATEDBY, ISSOTRX, DOCUMENTNO, 
- DOCSTATUS, DOCACTION, ISPRINTED, ISDISCOUNTPRINTED, PROCESSING, 
- PROCESSED, ISTRANSFERRED, ISPAID, C_DOCTYPE_ID, C_DOCTYPETARGET_ID, 
- C_ORDER_ID, DESCRIPTION, ISAPPROVED, SALESREP_ID, DATEINVOICED, 
- DATEPRINTED, DATEACCT, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, 
- C_BP_GROUP_ID, POREFERENCE, DATEORDERED, C_CURRENCY_ID, C_CONVERSIONTYPE_ID, 
- PAYMENTRULE, C_PAYMENTTERM_ID, M_PRICELIST_ID, C_CAMPAIGN_ID, C_PROJECT_ID, 
- C_ACTIVITY_ID, ISPAYSCHEDULEVALID, INVOICECOLLECTIONTYPE, C_COUNTRY_ID, C_REGION_ID, 
- POSTAL, CITY, C_CHARGE_ID, CHARGEAMT, TOTALLINES, 
- GRANDTOTAL, MULTIPLIER,
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, C_SalesRegion_ID)
-AS 
-SELECT i.C_Invoice_ID,
-	i.AD_Client_ID,i.AD_Org_ID,i.IsActive,i.Created,i.CreatedBy,i.Updated,i.UpdatedBy,
-	i.IsSOTrx, i.DocumentNo, i.DocStatus, i.DocAction,
-	i.IsPrinted, i.IsDiscountPrinted, i.Processing, i.Processed, i.IsTransferred, i.IsPaid,
-	i.C_DocType_ID, i.C_DocTypeTarget_ID, i.C_Order_ID, i.Description, i.IsApproved,
-	i.SalesRep_ID, i.DateInvoiced, i.DatePrinted, i.DateAcct,
-	i.C_BPartner_ID, i.C_BPartner_Location_ID, i.AD_User_ID, b.C_BP_Group_ID,
-	i.POReference, i.DateOrdered, i.C_Currency_ID, C_ConversionType_ID, i.PaymentRule, i.C_PaymentTerm_ID,
-	i.M_PriceList_ID, i.C_Campaign_ID, i.C_Project_ID, i.C_Activity_ID,
-    i.IsPayScheduleValid, i.InvoiceCollectionType,
-    loc.C_Country_ID, loc.C_Region_ID, loc.Postal, loc.City,
-	--	Amounts
-	i.C_Charge_ID,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.ChargeAmt*-1 ELSE i.ChargeAmt END AS ChargeAmt,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.TotalLines*-1 ELSE i.TotalLines END AS TotalLines,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN i.GrandTotal*-1 ELSE i.GrandTotal END AS GrandTotal,
-	CASE WHEN charAt(d.DocBaseType,3)='C' THEN -1 ELSE 1 END AS Multiplier,
-	b.C_BP_AccountType_ID, b.C_BP_SalesGroup_ID, b.C_BP_Segment_ID, b.C_BP_IndustryType_ID,
-	i.C_SalesRegion_ID
-FROM  C_Invoice i
- INNER JOIN C_DocType d ON (i.C_DocType_ID=d.C_DocType_ID)
- INNER JOIN C_BPartner b ON (i.C_BPartner_ID=b.C_BPartner_ID)
- INNER JOIN C_BPartner_Location bpl ON (i.C_BPartner_Location_ID=bpl.C_BPartner_Location_ID)
- INNER JOIN C_Location loc ON (bpl.C_Location_ID=loc.C_Location_ID);</RollbackStatement>
     </Step>
     <Step SeqNo="150" StepType="AD">
       <PO AD_Table_ID="101" Action="I" Record_ID="96362" Table="AD_Column">


### PR DESCRIPTION
The original script had four steps with the same sequence number.  Two were duplicates.  The two originals needed to be applied in order but with the same sequence number, the order of application was unspecified - resulting in errors.

In this PR, I've deleted the duplicate entries and set the correct order.

I've also adjusted the Release No to 3.9.4

The correct entries are:

(New Lines 323-324)
    <Step DBType="Postgres" Parse="N" SeqNo="140" StepType="SQL">
      <Comments>RV_C_INVOICE</Comments>
      ...

and
(New Lines 403-404)
    <Step DBType="Postgres" Parse="N" SeqNo="145" StepType="SQL">
      <Comments>RV_C_INVOICELINE</Comments>
      ....
