### PR TITLE
Change the order of steps to avoid an error when the views are added before the fields they require.

### DIFF
--- a/migration/393lts-394lts/06550_Add_Collecting_Agent_Reference_to_Payment.xml
+++ b/migration/393lts-394lts/06550_Add_Collecting_Agent_Reference_to_Payment.xml
@@ -1,582 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
   <Migration EntityType="ECA02" Name="Add Collecting Agent Reference to Payment" ReleaseNo="3.9.4" SeqNo="6550">
-    <Step DBType="Postgres" Parse="N" SeqNo="0" StepType="SQL">
-      <Comments>RV_PAYMENT</Comments>
-      <SQLStatement>CREATE OR REPLACE VIEW RV_PAYMENT
-(C_PAYMENT_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
- CREATEDBY, UPDATED, UPDATEDBY, DOCUMENTNO, DATETRX, 
- ISRECEIPT, C_DOCTYPE_ID, TRXTYPE, C_BANKACCOUNT_ID, C_BPARTNER_ID, 
- C_INVOICE_ID, C_BP_BANKACCOUNT_ID, C_PAYMENTBATCH_ID, TENDERTYPE, CREDITCARDTYPE, 
- CREDITCARDNUMBER, CREDITCARDVV, CREDITCARDEXPMM, CREDITCARDEXPYY, MICR, 
- ROUTINGNO, ACCOUNTNO, CHECKNO, A_NAME, A_STREET, 
- A_CITY, A_STATE, A_ZIP, A_IDENT_DL, A_IDENT_SSN, 
- A_EMAIL, VOICEAUTHCODE, ORIG_TRXID, PONUM, C_CURRENCY_ID, 
- C_CONVERSIONTYPE_ID, PAYAMT, DISCOUNTAMT, WRITEOFFAMT, TAXAMT, 
- OVERUNDERAMT, MULTIPLIERAP, ALLOCATEDAMT, AVAILABLEAMT, ISOVERUNDERPAYMENT, 
- ISAPPROVED, R_PNREF, R_RESULT, R_RESPMSG, R_AUTHCODE, 
- R_AVSADDR, R_AVSZIP, R_INFO, PROCESSING, OPROCESSING, 
- DOCSTATUS, DOCACTION, ISPREPAYMENT, C_CHARGE_ID, ISRECONCILED, 
- ISALLOCATED, ISONLINE, PROCESSED, POSTED, C_CAMPAIGN_ID, 
- C_PROJECT_ID, C_ACTIVITY_ID, IsUnidentifiedPayment, Ref_Payment_ID, RelatedPayment_ID, Description, 
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, CollectingAgent_ID)
-AS 
-SELECT p.C_Payment_ID, p.AD_Client_ID, p.AD_Org_ID, p.IsActive, p.Created, p.CreatedBy, p.Updated, p.UpdatedBy,
-    p.DocumentNo, p.DateTrx, p.IsReceipt, p.C_DocType_ID, p.TrxType,
-    p.C_BankAccount_ID, p.C_BPartner_ID, p.C_Invoice_ID, p.C_BP_BankAccount_ID, p.C_PaymentBatch_ID,
-    p.TenderType, p.CreditCardType, p.CreditCardNumber, p.CreditCardVV, p.CreditCardExpMM, p.CreditCardExpYY,
-    p.Micr, p.RoutingNo, p.AccountNo, p.CheckNo,
-    p.A_Name, p.A_Street, p.A_City, p.A_State, p.A_Zip, p.A_Ident_DL, p.A_Ident_SSN, p.A_EMail,
-    p.VoiceAuthCode, p.Orig_TrxID, p.PONum,
-    p.C_Currency_ID, p.C_ConversionType_ID,
-    CASE p.IsReceipt WHEN 'Y' THEN p.PayAmt ELSE p.PayAmt*-1 END AS PayAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN p.DiscountAmt ELSE p.DiscountAmt*-1 END AS DiscountAmt, 
-    CASE p.IsReceipt WHEN 'Y' THEN p.WriteOffAmt ELSE p.WriteOffAmt*-1 END AS WriteOffAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN p.TaxAmt ELSE p.TaxAmt*-1 END AS TaxAmt, 
-    CASE p.IsReceipt WHEN 'Y' THEN p.OverUnderAmt ELSE p.OverUnderAmt*-1 END AS OverUnderAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN 1 ELSE -1 END AS MultiplierAP,
-    paymentAllocated(p.C_Payment_ID, p.C_Currency_ID) AS AllocatedAmt,
-    paymentAvailable(p.C_Payment_ID) AS AvailableAmt,
-    p.IsOverUnderPayment, p.IsApproved,
-    p.R_PnRef, p.R_Result, p.R_RespMsg, p.R_AuthCode, p.R_AvsAddr, p.R_AvsZip, p.R_Info,
-    p.Processing, p.OProcessing, p.DocStatus, p.DocAction,
-    p.IsPrepayment, p.C_Charge_ID,
-    p.IsReconciled, p.IsAllocated, p.IsOnline, p.Processed, p.Posted,
-    p.C_Campaign_ID, p.C_Project_ID, p.C_Activity_ID, p.IsUnidentifiedPayment, p.Ref_Payment_ID, p.RelatedPayment_ID,
-    p.Description, 
-    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID, p.CollectingAgent_ID
-FROM C_Payment p
-LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</SQLStatement>
-      <RollbackStatement>CREATE OR REPLACE VIEW RV_PAYMENT
-(C_PAYMENT_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
- CREATEDBY, UPDATED, UPDATEDBY, DOCUMENTNO, DATETRX, 
- ISRECEIPT, C_DOCTYPE_ID, TRXTYPE, C_BANKACCOUNT_ID, C_BPARTNER_ID, 
- C_INVOICE_ID, C_BP_BANKACCOUNT_ID, C_PAYMENTBATCH_ID, TENDERTYPE, CREDITCARDTYPE, 
- CREDITCARDNUMBER, CREDITCARDVV, CREDITCARDEXPMM, CREDITCARDEXPYY, MICR, 
- ROUTINGNO, ACCOUNTNO, CHECKNO, A_NAME, A_STREET, 
- A_CITY, A_STATE, A_ZIP, A_IDENT_DL, A_IDENT_SSN, 
- A_EMAIL, VOICEAUTHCODE, ORIG_TRXID, PONUM, C_CURRENCY_ID, 
- C_CONVERSIONTYPE_ID, PAYAMT, DISCOUNTAMT, WRITEOFFAMT, TAXAMT, 
- OVERUNDERAMT, MULTIPLIERAP, ALLOCATEDAMT, AVAILABLEAMT, ISOVERUNDERPAYMENT, 
- ISAPPROVED, R_PNREF, R_RESULT, R_RESPMSG, R_AUTHCODE, 
- R_AVSADDR, R_AVSZIP, R_INFO, PROCESSING, OPROCESSING, 
- DOCSTATUS, DOCACTION, ISPREPAYMENT, C_CHARGE_ID, ISRECONCILED, 
- ISALLOCATED, ISONLINE, PROCESSED, POSTED, C_CAMPAIGN_ID, 
- C_PROJECT_ID, C_ACTIVITY_ID, IsUnidentifiedPayment, Ref_Payment_ID, RelatedPayment_ID, Description, 
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID)
-AS 
-SELECT p.C_Payment_ID, p.AD_Client_ID, p.AD_Org_ID, p.IsActive, p.Created, p.CreatedBy, p.Updated, p.UpdatedBy,
-    p.DocumentNo, p.DateTrx, p.IsReceipt, p.C_DocType_ID, p.TrxType,
-    p.C_BankAccount_ID, p.C_BPartner_ID, p.C_Invoice_ID, p.C_BP_BankAccount_ID, p.C_PaymentBatch_ID,
-    p.TenderType, p.CreditCardType, p.CreditCardNumber, p.CreditCardVV, p.CreditCardExpMM, p.CreditCardExpYY,
-    p.Micr, p.RoutingNo, p.AccountNo, p.CheckNo,
-    p.A_Name, p.A_Street, p.A_City, p.A_State, p.A_Zip, p.A_Ident_DL, p.A_Ident_SSN, p.A_EMail,
-    p.VoiceAuthCode, p.Orig_TrxID, p.PONum,
-    p.C_Currency_ID, p.C_ConversionType_ID,
-    CASE p.IsReceipt WHEN 'Y' THEN p.PayAmt ELSE p.PayAmt*-1 END AS PayAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN p.DiscountAmt ELSE p.DiscountAmt*-1 END AS DiscountAmt, 
-    CASE p.IsReceipt WHEN 'Y' THEN p.WriteOffAmt ELSE p.WriteOffAmt*-1 END AS WriteOffAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN p.TaxAmt ELSE p.TaxAmt*-1 END AS TaxAmt, 
-    CASE p.IsReceipt WHEN 'Y' THEN p.OverUnderAmt ELSE p.OverUnderAmt*-1 END AS OverUnderAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN 1 ELSE -1 END AS MultiplierAP,
-    paymentAllocated(p.C_Payment_ID, p.C_Currency_ID) AS AllocatedAmt,
-    paymentAvailable(p.C_Payment_ID) AS AvailableAmt,
-    p.IsOverUnderPayment, p.IsApproved,
-    p.R_PnRef, p.R_Result, p.R_RespMsg, p.R_AuthCode, p.R_AvsAddr, p.R_AvsZip, p.R_Info,
-    p.Processing, p.OProcessing, p.DocStatus, p.DocAction,
-    p.IsPrepayment, p.C_Charge_ID,
-    p.IsReconciled, p.IsAllocated, p.IsOnline, p.Processed, p.Posted,
-    p.C_Campaign_ID, p.C_Project_ID, p.C_Activity_ID, p.IsUnidentifiedPayment, p.Ref_Payment_ID, p.RelatedPayment_ID,
-    p.Description, 
-    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID
-FROM C_Payment p
-LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStatement>
-    </Step>
-    <Step DBType="Oracle" Parse="N" SeqNo="0" StepType="SQL">
-      <Comments>C_Payment_V</Comments>
-      <SQLStatement>CREATE OR REPLACE VIEW C_Payment_v AS
- SELECT p.C_Payment_ID,
-    p.AD_Client_ID,
-    p.AD_Org_ID,
-    p.IsActive,
-    p.Created,
-    p.CreatedBy,
-    p.Updated,
-    p.UpdatedBy,
-    p.DocumentNo,
-    p.DateTrx,
-    p.DateAcct,
-    p.IsReceipt,
-    p.C_Doctype_ID,
-    p.TrxType,
-    p.C_BankAccount_ID,
-    p.C_BPartner_ID,
-    p.C_Invoice_ID,
-    p.C_BP_BankAccount_ID,
-    p.C_PaymentBatch_ID,
-    p.TenderType,
-    p.CreditCardType,
-    p.CreditCardNumber,
-    p.CreditCardVV,
-    p.CreditCardExpMM,
-    p.CreditCardExpYY,
-    p.Micr,
-    p.RoutingNo,
-    p.AccountNo,
-    p.CheckNo,
-    p.A_Name,
-    p.A_Street,
-    p.A_City,
-    p.A_State,
-    p.A_Zip,
-    p.A_Ident_DL,
-    p.A_Ident_SSN,
-    p.A_Email,
-    p.VoiceAuthCode,
-    p.Orig_TrxID,
-    p.PONum,
-    p.C_Currency_ID,
-    p.C_ConversionType_ID,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.PayAmt
-            ELSE p.PayAmt * (-1)
-        END AS PayAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.DiscountAmt
-            ELSE p.DiscountAmt * (-1)
-        END AS DiscountAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.WriteOffAmt
-            ELSE p.WriteOffAmt * (-1)
-        END AS WriteOffAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.TaxAmt
-            ELSE p.TaxAmt * (-1)
-        END AS TaxAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.OverUnderAmt
-            ELSE p.OverUnderAmt * (-1)
-        END AS OverUnderAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN 1
-            ELSE (-1)
-        END AS MultiplierAP,
-    p.IsOverUnderPayment,
-    p.IsApproved,
-    p.R_PNRef,
-    p.R_Result,
-    p.R_RespMsg,
-    p.R_AuthCode,
-    p.R_AvsAddr,
-    p.r_AvsZip,
-    p.r_Info,
-    p.Processing,
-    p.Oprocessing,
-    p.DocStatus,
-    p.DocAction,
-    p.IsPrepayment,
-    p.C_Charge_ID,
-    p.IsReconciled,
-    p.IsAllocated,
-    p.IsOnline,
-    p.Processed,
-    p.Posted,
-    p.C_Campaign_ID,
-    p.C_Project_ID,
-    p.C_Activity_ID,
-    p.C_Order_ID,
-    p.User1_ID,
-    p.User2_ID, 
-    p.Description,
-    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID, CollectingAgent_ID
-   FROM C_Payment p
-   LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</SQLStatement>
-      <RollbackStatement>CREATE OR REPLACE VIEW C_Payment_v AS
- SELECT p.C_Payment_ID,
-    p.AD_Client_ID,
-    p.AD_Org_ID,
-    p.IsActive,
-    p.Created,
-    p.CreatedBy,
-    p.Updated,
-    p.UpdatedBy,
-    p.DocumentNo,
-    p.DateTrx,
-    p.DateAcct,
-    p.IsReceipt,
-    p.C_Doctype_ID,
-    p.TrxType,
-    p.C_BankAccount_ID,
-    p.C_BPartner_ID,
-    p.C_Invoice_ID,
-    p.C_BP_BankAccount_ID,
-    p.C_PaymentBatch_ID,
-    p.TenderType,
-    p.CreditCardType,
-    p.CreditCardNumber,
-    p.CreditCardVV,
-    p.CreditCardExpMM,
-    p.CreditCardExpYY,
-    p.Micr,
-    p.RoutingNo,
-    p.AccountNo,
-    p.CheckNo,
-    p.A_Name,
-    p.A_Street,
-    p.A_City,
-    p.A_State,
-    p.A_Zip,
-    p.A_Ident_DL,
-    p.A_Ident_SSN,
-    p.A_Email,
-    p.VoiceAuthCode,
-    p.Orig_TrxID,
-    p.PONum,
-    p.C_Currency_ID,
-    p.C_ConversionType_ID,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.PayAmt
-            ELSE p.PayAmt * (-1)
-        END AS PayAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.DiscountAmt
-            ELSE p.DiscountAmt * (-1)
-        END AS DiscountAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.WriteOffAmt
-            ELSE p.WriteOffAmt * (-1)
-        END AS WriteOffAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.TaxAmt
-            ELSE p.TaxAmt * (-1)
-        END AS TaxAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.OverUnderAmt
-            ELSE p.OverUnderAmt * (-1)
-        END AS OverUnderAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN 1
-            ELSE (-1)
-        END AS MultiplierAP,
-    p.IsOverUnderPayment,
-    p.IsApproved,
-    p.R_PNRef,
-    p.R_Result,
-    p.R_RespMsg,
-    p.R_AuthCode,
-    p.R_AvsAddr,
-    p.r_AvsZip,
-    p.r_Info,
-    p.Processing,
-    p.Oprocessing,
-    p.DocStatus,
-    p.DocAction,
-    p.IsPrepayment,
-    p.C_Charge_ID,
-    p.IsReconciled,
-    p.IsAllocated,
-    p.IsOnline,
-    p.Processed,
-    p.Posted,
-    p.C_Campaign_ID,
-    p.C_Project_ID,
-    p.C_Activity_ID,
-    p.C_Order_ID,
-    p.User1_ID,
-    p.User2_ID, 
-    p.Description,
-    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID
-   FROM C_Payment p
-   LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStatement>
-    </Step>
-    <Step DBType="Postgres" Parse="N" SeqNo="0" StepType="SQL">
-      <Comments>C_Payment_V</Comments>
-      <SQLStatement>CREATE OR REPLACE VIEW C_Payment_v AS
- SELECT p.C_Payment_ID,
-    p.AD_Client_ID,
-    p.AD_Org_ID,
-    p.IsActive,
-    p.Created,
-    p.CreatedBy,
-    p.Updated,
-    p.UpdatedBy,
-    p.DocumentNo,
-    p.DateTrx,
-    p.DateAcct,
-    p.IsReceipt,
-    p.C_Doctype_ID,
-    p.TrxType,
-    p.C_BankAccount_ID,
-    p.C_BPartner_ID,
-    p.C_Invoice_ID,
-    p.C_BP_BankAccount_ID,
-    p.C_PaymentBatch_ID,
-    p.TenderType,
-    p.CreditCardType,
-    p.CreditCardNumber,
-    p.CreditCardVV,
-    p.CreditCardExpMM,
-    p.CreditCardExpYY,
-    p.Micr,
-    p.RoutingNo,
-    p.AccountNo,
-    p.CheckNo,
-    p.A_Name,
-    p.A_Street,
-    p.A_City,
-    p.A_State,
-    p.A_Zip,
-    p.A_Ident_DL,
-    p.A_Ident_SSN,
-    p.A_Email,
-    p.VoiceAuthCode,
-    p.Orig_TrxID,
-    p.PONum,
-    p.C_Currency_ID,
-    p.C_ConversionType_ID,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.PayAmt
-            ELSE p.PayAmt * (-1)
-        END AS PayAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.DiscountAmt
-            ELSE p.DiscountAmt * (-1)
-        END AS DiscountAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.WriteOffAmt
-            ELSE p.WriteOffAmt * (-1)
-        END AS WriteOffAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.TaxAmt
-            ELSE p.TaxAmt * (-1)
-        END AS TaxAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.OverUnderAmt
-            ELSE p.OverUnderAmt * (-1)
-        END AS OverUnderAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN 1
-            ELSE (-1)
-        END AS MultiplierAP,
-    p.IsOverUnderPayment,
-    p.IsApproved,
-    p.R_PNRef,
-    p.R_Result,
-    p.R_RespMsg,
-    p.R_AuthCode,
-    p.R_AvsAddr,
-    p.r_AvsZip,
-    p.r_Info,
-    p.Processing,
-    p.Oprocessing,
-    p.DocStatus,
-    p.DocAction,
-    p.IsPrepayment,
-    p.C_Charge_ID,
-    p.IsReconciled,
-    p.IsAllocated,
-    p.IsOnline,
-    p.Processed,
-    p.Posted,
-    p.C_Campaign_ID,
-    p.C_Project_ID,
-    p.C_Activity_ID,
-    p.C_Order_ID,
-    p.User1_ID,
-    p.User2_ID, 
-    p.Description,
-    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID, CollectingAgent_ID
-   FROM C_Payment p
-   LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</SQLStatement>
-      <RollbackStatement>CREATE OR REPLACE VIEW C_Payment_v AS
- SELECT p.C_Payment_ID,
-    p.AD_Client_ID,
-    p.AD_Org_ID,
-    p.IsActive,
-    p.Created,
-    p.CreatedBy,
-    p.Updated,
-    p.UpdatedBy,
-    p.DocumentNo,
-    p.DateTrx,
-    p.DateAcct,
-    p.IsReceipt,
-    p.C_Doctype_ID,
-    p.TrxType,
-    p.C_BankAccount_ID,
-    p.C_BPartner_ID,
-    p.C_Invoice_ID,
-    p.C_BP_BankAccount_ID,
-    p.C_PaymentBatch_ID,
-    p.TenderType,
-    p.CreditCardType,
-    p.CreditCardNumber,
-    p.CreditCardVV,
-    p.CreditCardExpMM,
-    p.CreditCardExpYY,
-    p.Micr,
-    p.RoutingNo,
-    p.AccountNo,
-    p.CheckNo,
-    p.A_Name,
-    p.A_Street,
-    p.A_City,
-    p.A_State,
-    p.A_Zip,
-    p.A_Ident_DL,
-    p.A_Ident_SSN,
-    p.A_Email,
-    p.VoiceAuthCode,
-    p.Orig_TrxID,
-    p.PONum,
-    p.C_Currency_ID,
-    p.C_ConversionType_ID,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.PayAmt
-            ELSE p.PayAmt * (-1)
-        END AS PayAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.DiscountAmt
-            ELSE p.DiscountAmt * (-1)
-        END AS DiscountAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.WriteOffAmt
-            ELSE p.WriteOffAmt * (-1)
-        END AS WriteOffAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.TaxAmt
-            ELSE p.TaxAmt * (-1)
-        END AS TaxAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN p.OverUnderAmt
-            ELSE p.OverUnderAmt * (-1)
-        END AS OverUnderAmt,
-        CASE p.IsReceipt
-            WHEN 'Y' THEN 1
-            ELSE (-1)
-        END AS MultiplierAP,
-    p.IsOverUnderPayment,
-    p.IsApproved,
-    p.R_PNRef,
-    p.R_Result,
-    p.R_RespMsg,
-    p.R_AuthCode,
-    p.R_AvsAddr,
-    p.r_AvsZip,
-    p.r_Info,
-    p.Processing,
-    p.Oprocessing,
-    p.DocStatus,
-    p.DocAction,
-    p.IsPrepayment,
-    p.C_Charge_ID,
-    p.IsReconciled,
-    p.IsAllocated,
-    p.IsOnline,
-    p.Processed,
-    p.Posted,
-    p.C_Campaign_ID,
-    p.C_Project_ID,
-    p.C_Activity_ID,
-    p.C_Order_ID,
-    p.User1_ID,
-    p.User2_ID, 
-    p.Description,
-    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID
-   FROM C_Payment p
-   LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStatement>
-    </Step>
-    <Step DBType="Oracle" Parse="N" SeqNo="0" StepType="SQL">
-      <Comments>RV_PAYMENT</Comments>
-      <SQLStatement>CREATE OR REPLACE VIEW RV_PAYMENT
-(C_PAYMENT_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
- CREATEDBY, UPDATED, UPDATEDBY, DOCUMENTNO, DATETRX, 
- ISRECEIPT, C_DOCTYPE_ID, TRXTYPE, C_BANKACCOUNT_ID, C_BPARTNER_ID, 
- C_INVOICE_ID, C_BP_BANKACCOUNT_ID, C_PAYMENTBATCH_ID, TENDERTYPE, CREDITCARDTYPE, 
- CREDITCARDNUMBER, CREDITCARDVV, CREDITCARDEXPMM, CREDITCARDEXPYY, MICR, 
- ROUTINGNO, ACCOUNTNO, CHECKNO, A_NAME, A_STREET, 
- A_CITY, A_STATE, A_ZIP, A_IDENT_DL, A_IDENT_SSN, 
- A_EMAIL, VOICEAUTHCODE, ORIG_TRXID, PONUM, C_CURRENCY_ID, 
- C_CONVERSIONTYPE_ID, PAYAMT, DISCOUNTAMT, WRITEOFFAMT, TAXAMT, 
- OVERUNDERAMT, MULTIPLIERAP, ALLOCATEDAMT, AVAILABLEAMT, ISOVERUNDERPAYMENT, 
- ISAPPROVED, R_PNREF, R_RESULT, R_RESPMSG, R_AUTHCODE, 
- R_AVSADDR, R_AVSZIP, R_INFO, PROCESSING, OPROCESSING, 
- DOCSTATUS, DOCACTION, ISPREPAYMENT, C_CHARGE_ID, ISRECONCILED, 
- ISALLOCATED, ISONLINE, PROCESSED, POSTED, C_CAMPAIGN_ID, 
- C_PROJECT_ID, C_ACTIVITY_ID, IsUnidentifiedPayment, Ref_Payment_ID, RelatedPayment_ID, Description, 
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, CollectingAgent_ID)
-AS 
-SELECT p.C_Payment_ID, p.AD_Client_ID, p.AD_Org_ID, p.IsActive, p.Created, p.CreatedBy, p.Updated, p.UpdatedBy,
-    p.DocumentNo, p.DateTrx, p.IsReceipt, p.C_DocType_ID, p.TrxType,
-    p.C_BankAccount_ID, p.C_BPartner_ID, p.C_Invoice_ID, p.C_BP_BankAccount_ID, p.C_PaymentBatch_ID,
-    p.TenderType, p.CreditCardType, p.CreditCardNumber, p.CreditCardVV, p.CreditCardExpMM, p.CreditCardExpYY,
-    p.Micr, p.RoutingNo, p.AccountNo, p.CheckNo,
-    p.A_Name, p.A_Street, p.A_City, p.A_State, p.A_Zip, p.A_Ident_DL, p.A_Ident_SSN, p.A_EMail,
-    p.VoiceAuthCode, p.Orig_TrxID, p.PONum,
-    p.C_Currency_ID, p.C_ConversionType_ID,
-    CASE p.IsReceipt WHEN 'Y' THEN p.PayAmt ELSE p.PayAmt*-1 END AS PayAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN p.DiscountAmt ELSE p.DiscountAmt*-1 END AS DiscountAmt, 
-    CASE p.IsReceipt WHEN 'Y' THEN p.WriteOffAmt ELSE p.WriteOffAmt*-1 END AS WriteOffAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN p.TaxAmt ELSE p.TaxAmt*-1 END AS TaxAmt, 
-    CASE p.IsReceipt WHEN 'Y' THEN p.OverUnderAmt ELSE p.OverUnderAmt*-1 END AS OverUnderAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN 1 ELSE -1 END AS MultiplierAP,
-    paymentAllocated(p.C_Payment_ID, p.C_Currency_ID) AS AllocatedAmt,
-    paymentAvailable(p.C_Payment_ID) AS AvailableAmt,
-    p.IsOverUnderPayment, p.IsApproved,
-    p.R_PnRef, p.R_Result, p.R_RespMsg, p.R_AuthCode, p.R_AvsAddr, p.R_AvsZip, p.R_Info,
-    p.Processing, p.OProcessing, p.DocStatus, p.DocAction,
-    p.IsPrepayment, p.C_Charge_ID,
-    p.IsReconciled, p.IsAllocated, p.IsOnline, p.Processed, p.Posted,
-    p.C_Campaign_ID, p.C_Project_ID, p.C_Activity_ID, p.IsUnidentifiedPayment, p.Ref_Payment_ID, p.RelatedPayment_ID,
-    p.Description, 
-    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID, p.CollectingAgent_ID
-FROM C_Payment p
-LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</SQLStatement>
-      <RollbackStatement>CREATE OR REPLACE VIEW RV_PAYMENT
-(C_PAYMENT_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
- CREATEDBY, UPDATED, UPDATEDBY, DOCUMENTNO, DATETRX, 
- ISRECEIPT, C_DOCTYPE_ID, TRXTYPE, C_BANKACCOUNT_ID, C_BPARTNER_ID, 
- C_INVOICE_ID, C_BP_BANKACCOUNT_ID, C_PAYMENTBATCH_ID, TENDERTYPE, CREDITCARDTYPE, 
- CREDITCARDNUMBER, CREDITCARDVV, CREDITCARDEXPMM, CREDITCARDEXPYY, MICR, 
- ROUTINGNO, ACCOUNTNO, CHECKNO, A_NAME, A_STREET, 
- A_CITY, A_STATE, A_ZIP, A_IDENT_DL, A_IDENT_SSN, 
- A_EMAIL, VOICEAUTHCODE, ORIG_TRXID, PONUM, C_CURRENCY_ID, 
- C_CONVERSIONTYPE_ID, PAYAMT, DISCOUNTAMT, WRITEOFFAMT, TAXAMT, 
- OVERUNDERAMT, MULTIPLIERAP, ALLOCATEDAMT, AVAILABLEAMT, ISOVERUNDERPAYMENT, 
- ISAPPROVED, R_PNREF, R_RESULT, R_RESPMSG, R_AUTHCODE, 
- R_AVSADDR, R_AVSZIP, R_INFO, PROCESSING, OPROCESSING, 
- DOCSTATUS, DOCACTION, ISPREPAYMENT, C_CHARGE_ID, ISRECONCILED, 
- ISALLOCATED, ISONLINE, PROCESSED, POSTED, C_CAMPAIGN_ID, 
- C_PROJECT_ID, C_ACTIVITY_ID, IsUnidentifiedPayment, Ref_Payment_ID, RelatedPayment_ID, Description, 
- C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID)
-AS 
-SELECT p.C_Payment_ID, p.AD_Client_ID, p.AD_Org_ID, p.IsActive, p.Created, p.CreatedBy, p.Updated, p.UpdatedBy,
-    p.DocumentNo, p.DateTrx, p.IsReceipt, p.C_DocType_ID, p.TrxType,
-    p.C_BankAccount_ID, p.C_BPartner_ID, p.C_Invoice_ID, p.C_BP_BankAccount_ID, p.C_PaymentBatch_ID,
-    p.TenderType, p.CreditCardType, p.CreditCardNumber, p.CreditCardVV, p.CreditCardExpMM, p.CreditCardExpYY,
-    p.Micr, p.RoutingNo, p.AccountNo, p.CheckNo,
-    p.A_Name, p.A_Street, p.A_City, p.A_State, p.A_Zip, p.A_Ident_DL, p.A_Ident_SSN, p.A_EMail,
-    p.VoiceAuthCode, p.Orig_TrxID, p.PONum,
-    p.C_Currency_ID, p.C_ConversionType_ID,
-    CASE p.IsReceipt WHEN 'Y' THEN p.PayAmt ELSE p.PayAmt*-1 END AS PayAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN p.DiscountAmt ELSE p.DiscountAmt*-1 END AS DiscountAmt, 
-    CASE p.IsReceipt WHEN 'Y' THEN p.WriteOffAmt ELSE p.WriteOffAmt*-1 END AS WriteOffAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN p.TaxAmt ELSE p.TaxAmt*-1 END AS TaxAmt, 
-    CASE p.IsReceipt WHEN 'Y' THEN p.OverUnderAmt ELSE p.OverUnderAmt*-1 END AS OverUnderAmt,
-    CASE p.IsReceipt WHEN 'Y' THEN 1 ELSE -1 END AS MultiplierAP,
-    paymentAllocated(p.C_Payment_ID, p.C_Currency_ID) AS AllocatedAmt,
-    paymentAvailable(p.C_Payment_ID) AS AvailableAmt,
-    p.IsOverUnderPayment, p.IsApproved,
-    p.R_PnRef, p.R_Result, p.R_RespMsg, p.R_AuthCode, p.R_AvsAddr, p.R_AvsZip, p.R_Info,
-    p.Processing, p.OProcessing, p.DocStatus, p.DocAction,
-    p.IsPrepayment, p.C_Charge_ID,
-    p.IsReconciled, p.IsAllocated, p.IsOnline, p.Processed, p.Posted,
-    p.C_Campaign_ID, p.C_Project_ID, p.C_Activity_ID, p.IsUnidentifiedPayment, p.Ref_Payment_ID, p.RelatedPayment_ID,
-    p.Description, 
-    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID
-FROM C_Payment p
-LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStatement>
-    </Step>
+    <Comments>RV_PAYMENT</Comments>
     <Step SeqNo="7" StepType="AD">
       <PO AD_Table_ID="276" Action="I" Record_ID="61514" Table="AD_Element">
         <Data AD_Column_ID="6285" Column="PO_Name" isNewNull="true"/>
@@ -628,11 +53,11 @@ LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStateme
     </Step>
     <Step SeqNo="9" StepType="AD">
       <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="4300" Column="PrintName" oldValue="Collecting Agent">Agente Cobrador</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="61514">61514</Data>
         <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>
         <Data AD_Column_ID="2646" Column="Name" oldValue="Collecting Agent">Agente Cobrador</Data>
         <Data AD_Column_ID="2647" Column="Description" oldValue="In market terms such an economic operator would often be referred to as a &quot;collecting agent&quot;"> En términos de mercado dicho operador económico es denominado a menudo "agente cobrador"</Data>
-        <Data AD_Column_ID="4300" Column="PrintName" oldValue="Collecting Agent">Agente Cobrador</Data>
-        <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="61514">61514</Data>
       </PO>
     </Step>
     <Step SeqNo="10" StepType="AD">
@@ -840,8 +265,8 @@ LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStateme
     </Step>
     <Step SeqNo="70" StepType="AD">
       <PO AD_Table_ID="101" Action="U" Record_ID="97185" Table="AD_Column">
-        <Data AD_Column_ID="117" Column="DefaultValue" isOldNull="true">@#AD_User_ID@</Data>
         <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isOldNull="true">@#AD_User_ID@</Data>
         <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">CollectingAgent_ID</Data>
       </PO>
     </Step>
@@ -1662,6 +1087,582 @@ LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStateme
         <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
         <Data AD_Column_ID="2837" Column="CreatedBy">100</Data>
       </PO>
+    </Step>
+    <Step DBType="Oracle" Parse="N" SeqNo="1120" StepType="SQL">
+      <Comments>C_Payment_V</Comments>
+      <SQLStatement>CREATE OR REPLACE VIEW C_Payment_v AS
+ SELECT p.C_Payment_ID,
+    p.AD_Client_ID,
+    p.AD_Org_ID,
+    p.IsActive,
+    p.Created,
+    p.CreatedBy,
+    p.Updated,
+    p.UpdatedBy,
+    p.DocumentNo,
+    p.DateTrx,
+    p.DateAcct,
+    p.IsReceipt,
+    p.C_Doctype_ID,
+    p.TrxType,
+    p.C_BankAccount_ID,
+    p.C_BPartner_ID,
+    p.C_Invoice_ID,
+    p.C_BP_BankAccount_ID,
+    p.C_PaymentBatch_ID,
+    p.TenderType,
+    p.CreditCardType,
+    p.CreditCardNumber,
+    p.CreditCardVV,
+    p.CreditCardExpMM,
+    p.CreditCardExpYY,
+    p.Micr,
+    p.RoutingNo,
+    p.AccountNo,
+    p.CheckNo,
+    p.A_Name,
+    p.A_Street,
+    p.A_City,
+    p.A_State,
+    p.A_Zip,
+    p.A_Ident_DL,
+    p.A_Ident_SSN,
+    p.A_Email,
+    p.VoiceAuthCode,
+    p.Orig_TrxID,
+    p.PONum,
+    p.C_Currency_ID,
+    p.C_ConversionType_ID,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.PayAmt
+            ELSE p.PayAmt * (-1)
+        END AS PayAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.DiscountAmt
+            ELSE p.DiscountAmt * (-1)
+        END AS DiscountAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.WriteOffAmt
+            ELSE p.WriteOffAmt * (-1)
+        END AS WriteOffAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.TaxAmt
+            ELSE p.TaxAmt * (-1)
+        END AS TaxAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.OverUnderAmt
+            ELSE p.OverUnderAmt * (-1)
+        END AS OverUnderAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN 1
+            ELSE (-1)
+        END AS MultiplierAP,
+    p.IsOverUnderPayment,
+    p.IsApproved,
+    p.R_PNRef,
+    p.R_Result,
+    p.R_RespMsg,
+    p.R_AuthCode,
+    p.R_AvsAddr,
+    p.r_AvsZip,
+    p.r_Info,
+    p.Processing,
+    p.Oprocessing,
+    p.DocStatus,
+    p.DocAction,
+    p.IsPrepayment,
+    p.C_Charge_ID,
+    p.IsReconciled,
+    p.IsAllocated,
+    p.IsOnline,
+    p.Processed,
+    p.Posted,
+    p.C_Campaign_ID,
+    p.C_Project_ID,
+    p.C_Activity_ID,
+    p.C_Order_ID,
+    p.User1_ID,
+    p.User2_ID, 
+    p.Description,
+    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID, CollectingAgent_ID
+   FROM C_Payment p
+   LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</SQLStatement>
+      <RollbackStatement>CREATE OR REPLACE VIEW C_Payment_v AS
+ SELECT p.C_Payment_ID,
+    p.AD_Client_ID,
+    p.AD_Org_ID,
+    p.IsActive,
+    p.Created,
+    p.CreatedBy,
+    p.Updated,
+    p.UpdatedBy,
+    p.DocumentNo,
+    p.DateTrx,
+    p.DateAcct,
+    p.IsReceipt,
+    p.C_Doctype_ID,
+    p.TrxType,
+    p.C_BankAccount_ID,
+    p.C_BPartner_ID,
+    p.C_Invoice_ID,
+    p.C_BP_BankAccount_ID,
+    p.C_PaymentBatch_ID,
+    p.TenderType,
+    p.CreditCardType,
+    p.CreditCardNumber,
+    p.CreditCardVV,
+    p.CreditCardExpMM,
+    p.CreditCardExpYY,
+    p.Micr,
+    p.RoutingNo,
+    p.AccountNo,
+    p.CheckNo,
+    p.A_Name,
+    p.A_Street,
+    p.A_City,
+    p.A_State,
+    p.A_Zip,
+    p.A_Ident_DL,
+    p.A_Ident_SSN,
+    p.A_Email,
+    p.VoiceAuthCode,
+    p.Orig_TrxID,
+    p.PONum,
+    p.C_Currency_ID,
+    p.C_ConversionType_ID,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.PayAmt
+            ELSE p.PayAmt * (-1)
+        END AS PayAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.DiscountAmt
+            ELSE p.DiscountAmt * (-1)
+        END AS DiscountAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.WriteOffAmt
+            ELSE p.WriteOffAmt * (-1)
+        END AS WriteOffAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.TaxAmt
+            ELSE p.TaxAmt * (-1)
+        END AS TaxAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.OverUnderAmt
+            ELSE p.OverUnderAmt * (-1)
+        END AS OverUnderAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN 1
+            ELSE (-1)
+        END AS MultiplierAP,
+    p.IsOverUnderPayment,
+    p.IsApproved,
+    p.R_PNRef,
+    p.R_Result,
+    p.R_RespMsg,
+    p.R_AuthCode,
+    p.R_AvsAddr,
+    p.r_AvsZip,
+    p.r_Info,
+    p.Processing,
+    p.Oprocessing,
+    p.DocStatus,
+    p.DocAction,
+    p.IsPrepayment,
+    p.C_Charge_ID,
+    p.IsReconciled,
+    p.IsAllocated,
+    p.IsOnline,
+    p.Processed,
+    p.Posted,
+    p.C_Campaign_ID,
+    p.C_Project_ID,
+    p.C_Activity_ID,
+    p.C_Order_ID,
+    p.User1_ID,
+    p.User2_ID, 
+    p.Description,
+    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID
+   FROM C_Payment p
+   LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="N" SeqNo="1130" StepType="SQL">
+      <Comments>RV_PAYMENT</Comments>
+      <SQLStatement>CREATE OR REPLACE VIEW RV_PAYMENT
+(C_PAYMENT_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
+ CREATEDBY, UPDATED, UPDATEDBY, DOCUMENTNO, DATETRX, 
+ ISRECEIPT, C_DOCTYPE_ID, TRXTYPE, C_BANKACCOUNT_ID, C_BPARTNER_ID, 
+ C_INVOICE_ID, C_BP_BANKACCOUNT_ID, C_PAYMENTBATCH_ID, TENDERTYPE, CREDITCARDTYPE, 
+ CREDITCARDNUMBER, CREDITCARDVV, CREDITCARDEXPMM, CREDITCARDEXPYY, MICR, 
+ ROUTINGNO, ACCOUNTNO, CHECKNO, A_NAME, A_STREET, 
+ A_CITY, A_STATE, A_ZIP, A_IDENT_DL, A_IDENT_SSN, 
+ A_EMAIL, VOICEAUTHCODE, ORIG_TRXID, PONUM, C_CURRENCY_ID, 
+ C_CONVERSIONTYPE_ID, PAYAMT, DISCOUNTAMT, WRITEOFFAMT, TAXAMT, 
+ OVERUNDERAMT, MULTIPLIERAP, ALLOCATEDAMT, AVAILABLEAMT, ISOVERUNDERPAYMENT, 
+ ISAPPROVED, R_PNREF, R_RESULT, R_RESPMSG, R_AUTHCODE, 
+ R_AVSADDR, R_AVSZIP, R_INFO, PROCESSING, OPROCESSING, 
+ DOCSTATUS, DOCACTION, ISPREPAYMENT, C_CHARGE_ID, ISRECONCILED, 
+ ISALLOCATED, ISONLINE, PROCESSED, POSTED, C_CAMPAIGN_ID, 
+ C_PROJECT_ID, C_ACTIVITY_ID, IsUnidentifiedPayment, Ref_Payment_ID, RelatedPayment_ID, Description, 
+ C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, CollectingAgent_ID)
+AS 
+SELECT p.C_Payment_ID, p.AD_Client_ID, p.AD_Org_ID, p.IsActive, p.Created, p.CreatedBy, p.Updated, p.UpdatedBy,
+    p.DocumentNo, p.DateTrx, p.IsReceipt, p.C_DocType_ID, p.TrxType,
+    p.C_BankAccount_ID, p.C_BPartner_ID, p.C_Invoice_ID, p.C_BP_BankAccount_ID, p.C_PaymentBatch_ID,
+    p.TenderType, p.CreditCardType, p.CreditCardNumber, p.CreditCardVV, p.CreditCardExpMM, p.CreditCardExpYY,
+    p.Micr, p.RoutingNo, p.AccountNo, p.CheckNo,
+    p.A_Name, p.A_Street, p.A_City, p.A_State, p.A_Zip, p.A_Ident_DL, p.A_Ident_SSN, p.A_EMail,
+    p.VoiceAuthCode, p.Orig_TrxID, p.PONum,
+    p.C_Currency_ID, p.C_ConversionType_ID,
+    CASE p.IsReceipt WHEN 'Y' THEN p.PayAmt ELSE p.PayAmt*-1 END AS PayAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN p.DiscountAmt ELSE p.DiscountAmt*-1 END AS DiscountAmt, 
+    CASE p.IsReceipt WHEN 'Y' THEN p.WriteOffAmt ELSE p.WriteOffAmt*-1 END AS WriteOffAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN p.TaxAmt ELSE p.TaxAmt*-1 END AS TaxAmt, 
+    CASE p.IsReceipt WHEN 'Y' THEN p.OverUnderAmt ELSE p.OverUnderAmt*-1 END AS OverUnderAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN 1 ELSE -1 END AS MultiplierAP,
+    paymentAllocated(p.C_Payment_ID, p.C_Currency_ID) AS AllocatedAmt,
+    paymentAvailable(p.C_Payment_ID) AS AvailableAmt,
+    p.IsOverUnderPayment, p.IsApproved,
+    p.R_PnRef, p.R_Result, p.R_RespMsg, p.R_AuthCode, p.R_AvsAddr, p.R_AvsZip, p.R_Info,
+    p.Processing, p.OProcessing, p.DocStatus, p.DocAction,
+    p.IsPrepayment, p.C_Charge_ID,
+    p.IsReconciled, p.IsAllocated, p.IsOnline, p.Processed, p.Posted,
+    p.C_Campaign_ID, p.C_Project_ID, p.C_Activity_ID, p.IsUnidentifiedPayment, p.Ref_Payment_ID, p.RelatedPayment_ID,
+    p.Description, 
+    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID, p.CollectingAgent_ID
+FROM C_Payment p
+LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</SQLStatement>
+      <RollbackStatement>CREATE OR REPLACE VIEW RV_PAYMENT
+(C_PAYMENT_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
+ CREATEDBY, UPDATED, UPDATEDBY, DOCUMENTNO, DATETRX, 
+ ISRECEIPT, C_DOCTYPE_ID, TRXTYPE, C_BANKACCOUNT_ID, C_BPARTNER_ID, 
+ C_INVOICE_ID, C_BP_BANKACCOUNT_ID, C_PAYMENTBATCH_ID, TENDERTYPE, CREDITCARDTYPE, 
+ CREDITCARDNUMBER, CREDITCARDVV, CREDITCARDEXPMM, CREDITCARDEXPYY, MICR, 
+ ROUTINGNO, ACCOUNTNO, CHECKNO, A_NAME, A_STREET, 
+ A_CITY, A_STATE, A_ZIP, A_IDENT_DL, A_IDENT_SSN, 
+ A_EMAIL, VOICEAUTHCODE, ORIG_TRXID, PONUM, C_CURRENCY_ID, 
+ C_CONVERSIONTYPE_ID, PAYAMT, DISCOUNTAMT, WRITEOFFAMT, TAXAMT, 
+ OVERUNDERAMT, MULTIPLIERAP, ALLOCATEDAMT, AVAILABLEAMT, ISOVERUNDERPAYMENT, 
+ ISAPPROVED, R_PNREF, R_RESULT, R_RESPMSG, R_AUTHCODE, 
+ R_AVSADDR, R_AVSZIP, R_INFO, PROCESSING, OPROCESSING, 
+ DOCSTATUS, DOCACTION, ISPREPAYMENT, C_CHARGE_ID, ISRECONCILED, 
+ ISALLOCATED, ISONLINE, PROCESSED, POSTED, C_CAMPAIGN_ID, 
+ C_PROJECT_ID, C_ACTIVITY_ID, IsUnidentifiedPayment, Ref_Payment_ID, RelatedPayment_ID, Description, 
+ C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID)
+AS 
+SELECT p.C_Payment_ID, p.AD_Client_ID, p.AD_Org_ID, p.IsActive, p.Created, p.CreatedBy, p.Updated, p.UpdatedBy,
+    p.DocumentNo, p.DateTrx, p.IsReceipt, p.C_DocType_ID, p.TrxType,
+    p.C_BankAccount_ID, p.C_BPartner_ID, p.C_Invoice_ID, p.C_BP_BankAccount_ID, p.C_PaymentBatch_ID,
+    p.TenderType, p.CreditCardType, p.CreditCardNumber, p.CreditCardVV, p.CreditCardExpMM, p.CreditCardExpYY,
+    p.Micr, p.RoutingNo, p.AccountNo, p.CheckNo,
+    p.A_Name, p.A_Street, p.A_City, p.A_State, p.A_Zip, p.A_Ident_DL, p.A_Ident_SSN, p.A_EMail,
+    p.VoiceAuthCode, p.Orig_TrxID, p.PONum,
+    p.C_Currency_ID, p.C_ConversionType_ID,
+    CASE p.IsReceipt WHEN 'Y' THEN p.PayAmt ELSE p.PayAmt*-1 END AS PayAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN p.DiscountAmt ELSE p.DiscountAmt*-1 END AS DiscountAmt, 
+    CASE p.IsReceipt WHEN 'Y' THEN p.WriteOffAmt ELSE p.WriteOffAmt*-1 END AS WriteOffAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN p.TaxAmt ELSE p.TaxAmt*-1 END AS TaxAmt, 
+    CASE p.IsReceipt WHEN 'Y' THEN p.OverUnderAmt ELSE p.OverUnderAmt*-1 END AS OverUnderAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN 1 ELSE -1 END AS MultiplierAP,
+    paymentAllocated(p.C_Payment_ID, p.C_Currency_ID) AS AllocatedAmt,
+    paymentAvailable(p.C_Payment_ID) AS AvailableAmt,
+    p.IsOverUnderPayment, p.IsApproved,
+    p.R_PnRef, p.R_Result, p.R_RespMsg, p.R_AuthCode, p.R_AvsAddr, p.R_AvsZip, p.R_Info,
+    p.Processing, p.OProcessing, p.DocStatus, p.DocAction,
+    p.IsPrepayment, p.C_Charge_ID,
+    p.IsReconciled, p.IsAllocated, p.IsOnline, p.Processed, p.Posted,
+    p.C_Campaign_ID, p.C_Project_ID, p.C_Activity_ID, p.IsUnidentifiedPayment, p.Ref_Payment_ID, p.RelatedPayment_ID,
+    p.Description, 
+    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID
+FROM C_Payment p
+LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStatement>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="1140" StepType="SQL">
+      <Comments>C_Payment_V</Comments>
+      <SQLStatement>CREATE OR REPLACE VIEW C_Payment_v AS
+ SELECT p.C_Payment_ID,
+    p.AD_Client_ID,
+    p.AD_Org_ID,
+    p.IsActive,
+    p.Created,
+    p.CreatedBy,
+    p.Updated,
+    p.UpdatedBy,
+    p.DocumentNo,
+    p.DateTrx,
+    p.DateAcct,
+    p.IsReceipt,
+    p.C_Doctype_ID,
+    p.TrxType,
+    p.C_BankAccount_ID,
+    p.C_BPartner_ID,
+    p.C_Invoice_ID,
+    p.C_BP_BankAccount_ID,
+    p.C_PaymentBatch_ID,
+    p.TenderType,
+    p.CreditCardType,
+    p.CreditCardNumber,
+    p.CreditCardVV,
+    p.CreditCardExpMM,
+    p.CreditCardExpYY,
+    p.Micr,
+    p.RoutingNo,
+    p.AccountNo,
+    p.CheckNo,
+    p.A_Name,
+    p.A_Street,
+    p.A_City,
+    p.A_State,
+    p.A_Zip,
+    p.A_Ident_DL,
+    p.A_Ident_SSN,
+    p.A_Email,
+    p.VoiceAuthCode,
+    p.Orig_TrxID,
+    p.PONum,
+    p.C_Currency_ID,
+    p.C_ConversionType_ID,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.PayAmt
+            ELSE p.PayAmt * (-1)
+        END AS PayAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.DiscountAmt
+            ELSE p.DiscountAmt * (-1)
+        END AS DiscountAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.WriteOffAmt
+            ELSE p.WriteOffAmt * (-1)
+        END AS WriteOffAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.TaxAmt
+            ELSE p.TaxAmt * (-1)
+        END AS TaxAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.OverUnderAmt
+            ELSE p.OverUnderAmt * (-1)
+        END AS OverUnderAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN 1
+            ELSE (-1)
+        END AS MultiplierAP,
+    p.IsOverUnderPayment,
+    p.IsApproved,
+    p.R_PNRef,
+    p.R_Result,
+    p.R_RespMsg,
+    p.R_AuthCode,
+    p.R_AvsAddr,
+    p.r_AvsZip,
+    p.r_Info,
+    p.Processing,
+    p.Oprocessing,
+    p.DocStatus,
+    p.DocAction,
+    p.IsPrepayment,
+    p.C_Charge_ID,
+    p.IsReconciled,
+    p.IsAllocated,
+    p.IsOnline,
+    p.Processed,
+    p.Posted,
+    p.C_Campaign_ID,
+    p.C_Project_ID,
+    p.C_Activity_ID,
+    p.C_Order_ID,
+    p.User1_ID,
+    p.User2_ID, 
+    p.Description,
+    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID, CollectingAgent_ID
+   FROM C_Payment p
+   LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</SQLStatement>
+      <RollbackStatement>CREATE OR REPLACE VIEW C_Payment_v AS
+ SELECT p.C_Payment_ID,
+    p.AD_Client_ID,
+    p.AD_Org_ID,
+    p.IsActive,
+    p.Created,
+    p.CreatedBy,
+    p.Updated,
+    p.UpdatedBy,
+    p.DocumentNo,
+    p.DateTrx,
+    p.DateAcct,
+    p.IsReceipt,
+    p.C_Doctype_ID,
+    p.TrxType,
+    p.C_BankAccount_ID,
+    p.C_BPartner_ID,
+    p.C_Invoice_ID,
+    p.C_BP_BankAccount_ID,
+    p.C_PaymentBatch_ID,
+    p.TenderType,
+    p.CreditCardType,
+    p.CreditCardNumber,
+    p.CreditCardVV,
+    p.CreditCardExpMM,
+    p.CreditCardExpYY,
+    p.Micr,
+    p.RoutingNo,
+    p.AccountNo,
+    p.CheckNo,
+    p.A_Name,
+    p.A_Street,
+    p.A_City,
+    p.A_State,
+    p.A_Zip,
+    p.A_Ident_DL,
+    p.A_Ident_SSN,
+    p.A_Email,
+    p.VoiceAuthCode,
+    p.Orig_TrxID,
+    p.PONum,
+    p.C_Currency_ID,
+    p.C_ConversionType_ID,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.PayAmt
+            ELSE p.PayAmt * (-1)
+        END AS PayAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.DiscountAmt
+            ELSE p.DiscountAmt * (-1)
+        END AS DiscountAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.WriteOffAmt
+            ELSE p.WriteOffAmt * (-1)
+        END AS WriteOffAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.TaxAmt
+            ELSE p.TaxAmt * (-1)
+        END AS TaxAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN p.OverUnderAmt
+            ELSE p.OverUnderAmt * (-1)
+        END AS OverUnderAmt,
+        CASE p.IsReceipt
+            WHEN 'Y' THEN 1
+            ELSE (-1)
+        END AS MultiplierAP,
+    p.IsOverUnderPayment,
+    p.IsApproved,
+    p.R_PNRef,
+    p.R_Result,
+    p.R_RespMsg,
+    p.R_AuthCode,
+    p.R_AvsAddr,
+    p.r_AvsZip,
+    p.r_Info,
+    p.Processing,
+    p.Oprocessing,
+    p.DocStatus,
+    p.DocAction,
+    p.IsPrepayment,
+    p.C_Charge_ID,
+    p.IsReconciled,
+    p.IsAllocated,
+    p.IsOnline,
+    p.Processed,
+    p.Posted,
+    p.C_Campaign_ID,
+    p.C_Project_ID,
+    p.C_Activity_ID,
+    p.C_Order_ID,
+    p.User1_ID,
+    p.User2_ID, 
+    p.Description,
+    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID
+   FROM C_Payment p
+   LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStatement>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="1150" StepType="SQL">
+      <Comments>RV_PAYMENT</Comments>
+      <SQLStatement>CREATE OR REPLACE VIEW RV_PAYMENT
+(C_PAYMENT_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
+ CREATEDBY, UPDATED, UPDATEDBY, DOCUMENTNO, DATETRX, 
+ ISRECEIPT, C_DOCTYPE_ID, TRXTYPE, C_BANKACCOUNT_ID, C_BPARTNER_ID, 
+ C_INVOICE_ID, C_BP_BANKACCOUNT_ID, C_PAYMENTBATCH_ID, TENDERTYPE, CREDITCARDTYPE, 
+ CREDITCARDNUMBER, CREDITCARDVV, CREDITCARDEXPMM, CREDITCARDEXPYY, MICR, 
+ ROUTINGNO, ACCOUNTNO, CHECKNO, A_NAME, A_STREET, 
+ A_CITY, A_STATE, A_ZIP, A_IDENT_DL, A_IDENT_SSN, 
+ A_EMAIL, VOICEAUTHCODE, ORIG_TRXID, PONUM, C_CURRENCY_ID, 
+ C_CONVERSIONTYPE_ID, PAYAMT, DISCOUNTAMT, WRITEOFFAMT, TAXAMT, 
+ OVERUNDERAMT, MULTIPLIERAP, ALLOCATEDAMT, AVAILABLEAMT, ISOVERUNDERPAYMENT, 
+ ISAPPROVED, R_PNREF, R_RESULT, R_RESPMSG, R_AUTHCODE, 
+ R_AVSADDR, R_AVSZIP, R_INFO, PROCESSING, OPROCESSING, 
+ DOCSTATUS, DOCACTION, ISPREPAYMENT, C_CHARGE_ID, ISRECONCILED, 
+ ISALLOCATED, ISONLINE, PROCESSED, POSTED, C_CAMPAIGN_ID, 
+ C_PROJECT_ID, C_ACTIVITY_ID, IsUnidentifiedPayment, Ref_Payment_ID, RelatedPayment_ID, Description, 
+ C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID, CollectingAgent_ID)
+AS 
+SELECT p.C_Payment_ID, p.AD_Client_ID, p.AD_Org_ID, p.IsActive, p.Created, p.CreatedBy, p.Updated, p.UpdatedBy,
+    p.DocumentNo, p.DateTrx, p.IsReceipt, p.C_DocType_ID, p.TrxType,
+    p.C_BankAccount_ID, p.C_BPartner_ID, p.C_Invoice_ID, p.C_BP_BankAccount_ID, p.C_PaymentBatch_ID,
+    p.TenderType, p.CreditCardType, p.CreditCardNumber, p.CreditCardVV, p.CreditCardExpMM, p.CreditCardExpYY,
+    p.Micr, p.RoutingNo, p.AccountNo, p.CheckNo,
+    p.A_Name, p.A_Street, p.A_City, p.A_State, p.A_Zip, p.A_Ident_DL, p.A_Ident_SSN, p.A_EMail,
+    p.VoiceAuthCode, p.Orig_TrxID, p.PONum,
+    p.C_Currency_ID, p.C_ConversionType_ID,
+    CASE p.IsReceipt WHEN 'Y' THEN p.PayAmt ELSE p.PayAmt*-1 END AS PayAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN p.DiscountAmt ELSE p.DiscountAmt*-1 END AS DiscountAmt, 
+    CASE p.IsReceipt WHEN 'Y' THEN p.WriteOffAmt ELSE p.WriteOffAmt*-1 END AS WriteOffAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN p.TaxAmt ELSE p.TaxAmt*-1 END AS TaxAmt, 
+    CASE p.IsReceipt WHEN 'Y' THEN p.OverUnderAmt ELSE p.OverUnderAmt*-1 END AS OverUnderAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN 1 ELSE -1 END AS MultiplierAP,
+    paymentAllocated(p.C_Payment_ID, p.C_Currency_ID) AS AllocatedAmt,
+    paymentAvailable(p.C_Payment_ID) AS AvailableAmt,
+    p.IsOverUnderPayment, p.IsApproved,
+    p.R_PnRef, p.R_Result, p.R_RespMsg, p.R_AuthCode, p.R_AvsAddr, p.R_AvsZip, p.R_Info,
+    p.Processing, p.OProcessing, p.DocStatus, p.DocAction,
+    p.IsPrepayment, p.C_Charge_ID,
+    p.IsReconciled, p.IsAllocated, p.IsOnline, p.Processed, p.Posted,
+    p.C_Campaign_ID, p.C_Project_ID, p.C_Activity_ID, p.IsUnidentifiedPayment, p.Ref_Payment_ID, p.RelatedPayment_ID,
+    p.Description, 
+    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID, p.CollectingAgent_ID
+FROM C_Payment p
+LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</SQLStatement>
+      <RollbackStatement>CREATE OR REPLACE VIEW RV_PAYMENT
+(C_PAYMENT_ID, AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, 
+ CREATEDBY, UPDATED, UPDATEDBY, DOCUMENTNO, DATETRX, 
+ ISRECEIPT, C_DOCTYPE_ID, TRXTYPE, C_BANKACCOUNT_ID, C_BPARTNER_ID, 
+ C_INVOICE_ID, C_BP_BANKACCOUNT_ID, C_PAYMENTBATCH_ID, TENDERTYPE, CREDITCARDTYPE, 
+ CREDITCARDNUMBER, CREDITCARDVV, CREDITCARDEXPMM, CREDITCARDEXPYY, MICR, 
+ ROUTINGNO, ACCOUNTNO, CHECKNO, A_NAME, A_STREET, 
+ A_CITY, A_STATE, A_ZIP, A_IDENT_DL, A_IDENT_SSN, 
+ A_EMAIL, VOICEAUTHCODE, ORIG_TRXID, PONUM, C_CURRENCY_ID, 
+ C_CONVERSIONTYPE_ID, PAYAMT, DISCOUNTAMT, WRITEOFFAMT, TAXAMT, 
+ OVERUNDERAMT, MULTIPLIERAP, ALLOCATEDAMT, AVAILABLEAMT, ISOVERUNDERPAYMENT, 
+ ISAPPROVED, R_PNREF, R_RESULT, R_RESPMSG, R_AUTHCODE, 
+ R_AVSADDR, R_AVSZIP, R_INFO, PROCESSING, OPROCESSING, 
+ DOCSTATUS, DOCACTION, ISPREPAYMENT, C_CHARGE_ID, ISRECONCILED, 
+ ISALLOCATED, ISONLINE, PROCESSED, POSTED, C_CAMPAIGN_ID, 
+ C_PROJECT_ID, C_ACTIVITY_ID, IsUnidentifiedPayment, Ref_Payment_ID, RelatedPayment_ID, Description, 
+ C_BP_AccountType_ID, C_BP_SalesGroup_ID, C_BP_Segment_ID, C_BP_IndustryType_ID)
+AS 
+SELECT p.C_Payment_ID, p.AD_Client_ID, p.AD_Org_ID, p.IsActive, p.Created, p.CreatedBy, p.Updated, p.UpdatedBy,
+    p.DocumentNo, p.DateTrx, p.IsReceipt, p.C_DocType_ID, p.TrxType,
+    p.C_BankAccount_ID, p.C_BPartner_ID, p.C_Invoice_ID, p.C_BP_BankAccount_ID, p.C_PaymentBatch_ID,
+    p.TenderType, p.CreditCardType, p.CreditCardNumber, p.CreditCardVV, p.CreditCardExpMM, p.CreditCardExpYY,
+    p.Micr, p.RoutingNo, p.AccountNo, p.CheckNo,
+    p.A_Name, p.A_Street, p.A_City, p.A_State, p.A_Zip, p.A_Ident_DL, p.A_Ident_SSN, p.A_EMail,
+    p.VoiceAuthCode, p.Orig_TrxID, p.PONum,
+    p.C_Currency_ID, p.C_ConversionType_ID,
+    CASE p.IsReceipt WHEN 'Y' THEN p.PayAmt ELSE p.PayAmt*-1 END AS PayAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN p.DiscountAmt ELSE p.DiscountAmt*-1 END AS DiscountAmt, 
+    CASE p.IsReceipt WHEN 'Y' THEN p.WriteOffAmt ELSE p.WriteOffAmt*-1 END AS WriteOffAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN p.TaxAmt ELSE p.TaxAmt*-1 END AS TaxAmt, 
+    CASE p.IsReceipt WHEN 'Y' THEN p.OverUnderAmt ELSE p.OverUnderAmt*-1 END AS OverUnderAmt,
+    CASE p.IsReceipt WHEN 'Y' THEN 1 ELSE -1 END AS MultiplierAP,
+    paymentAllocated(p.C_Payment_ID, p.C_Currency_ID) AS AllocatedAmt,
+    paymentAvailable(p.C_Payment_ID) AS AvailableAmt,
+    p.IsOverUnderPayment, p.IsApproved,
+    p.R_PnRef, p.R_Result, p.R_RespMsg, p.R_AuthCode, p.R_AvsAddr, p.R_AvsZip, p.R_Info,
+    p.Processing, p.OProcessing, p.DocStatus, p.DocAction,
+    p.IsPrepayment, p.C_Charge_ID,
+    p.IsReconciled, p.IsAllocated, p.IsOnline, p.Processed, p.Posted,
+    p.C_Campaign_ID, p.C_Project_ID, p.C_Activity_ID, p.IsUnidentifiedPayment, p.Ref_Payment_ID, p.RelatedPayment_ID,
+    p.Description, 
+    bp.C_BP_AccountType_ID, bp.C_BP_SalesGroup_ID, bp.C_BP_Segment_ID, bp.C_BP_IndustryType_ID
+FROM C_Payment p
+LEFT JOIN C_BPartner bp ON(bp.C_BPartner_ID = p.C_BPartner_ID);</RollbackStatement>
     </Step>
   </Migration>
 </Migrations>


### PR DESCRIPTION
Fixes #3296.

There were four steps with sequence number zero that added views which depended on the fields added in later steps.  I moved these four to the end and the migration worked fine.
