### PR TITLE
Add support to functionality Allow Negative Posting from Accounting

### DIFF
--- a/base/src/org/compiere/acct/Doc.java
+++ b/base/src/org/compiere/acct/Doc.java
@@ -2509,16 +2509,15 @@ public abstract class Doc
 		getReversalFactAcct().stream().forEach(factAcct -> {
 			MFactAcct reverseFactAcct = new MFactAcct(getPO().getCtx() , 0 , getPO().get_TrxName());
 			PO.copyValues(factAcct, reverseFactAcct);
+			MAcctSchema as = MAcctSchema.get(getCtx(), factAcct.getC_AcctSchema_ID());
 			reverseFactAcct.setAD_Org_ID(factAcct.getAD_Org_ID());
 			reverseFactAcct.setAD_Table_ID(getPO().get_Table_ID());
 			reverseFactAcct.setDateAcct(getDateAcct());
 			reverseFactAcct.setC_Period_ID(getC_Period_ID());
 			reverseFactAcct.setRecord_ID(getPO().get_ID());
 			reverseFactAcct.setQty(factAcct.getQty().negate());
-			reverseFactAcct.setAmtSourceDr(factAcct.getAmtSourceDr().negate());
-			reverseFactAcct.setAmtSourceCr(factAcct.getAmtSourceCr().negate());
-			reverseFactAcct.setAmtAcctDr(factAcct.getAmtAcctDr().negate());
-			reverseFactAcct.setAmtAcctCr(factAcct.getAmtAcctCr().negate());
+			FactLine.setSourceAmount(as, reverseFactAcct, factAcct.getAmtSourceDr().negate(), factAcct.getAmtSourceCr().negate());
+			FactLine.setAccountingAmount(as, reverseFactAcct, factAcct.getAmtAcctDr().negate(), factAcct.getAmtAcctCr().negate());
 			reverseFactAcct.saveEx();
 		});
 		return STATUS_Posted;


### PR DESCRIPTION
Hi to all, this pull request allow to control that reversed documents with document type checked with Reversal with Original Accounting.

Currently all reversed documents with the document type with this check has been posted with negative amounts, without consider the setting for allow posting negative in Accounting Schema.

see this example:
![ControlNegativePosting](https://user-images.githubusercontent.com/1847863/103683444-93cbe500-4f60-11eb-94dc-aa3b5aa52004.gif)
