### PR TITLE
Cleaning Landed Cost Allocation when don't have landed cost definition

### DIFF
--- a/base/src/org/compiere/model/MInvoiceLine.java
+++ b/base/src/org/compiere/model/MInvoiceLine.java
@@ -991,9 +991,6 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 			getParent().setPosted(false);
 			getParent().saveEx();
 		}
-		MLandedCost[] lcs = MLandedCost.getLandedCosts(this);
-		if (lcs.length == 0)
-			return "";
 
 		String sql = "DELETE M_CostDetail WHERE C_landedcostallocation_ID in " +
 				"(select c_landedCostAllocation_ID from c_landedcostAllocation where c_invoiceline_ID=" + getC_InvoiceLine_ID() + ")";
@@ -1005,6 +1002,10 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 		if (no != 0)
 			log.info("Deleted #" + no);
 
+		MLandedCost[] lcs = MLandedCost.getLandedCosts(this);
+		if (lcs.length == 0)
+			return "";
+		
 		int inserted = 0;
 		//	*** Single Criteria ***
 		if (lcs.length == 1)


### PR DESCRIPTION
Currently, when you have an invoice and generate landed cost but you want revert the landed costs generated, is not possible because if deleted the landed cost definition don't deleted the landed costs allocation records. It causes landed costs to be generated in a document even without you want generated landed costs for the document. 

Currently, the method validate that landed cost definition and after clean the landed costs allocation
![Screenshot_20210105_190325](https://user-images.githubusercontent.com/1847863/103709421-e1f4de80-4f88-11eb-96f5-ae6c4a7414b0.png)

My purpose is that clean the landed costs definition and after validate landed costs definition
![Screenshot_20210105_190049](https://user-images.githubusercontent.com/1847863/103709632-5e87bd00-4f89-11eb-944f-fac419695556.png)

Current functionality:
![CurrentLandedCostsAllocation](https://user-images.githubusercontent.com/1847863/103710750-351c6080-4f8c-11eb-80d9-9036129bf543.gif)

Purposed functionality:
![PurpusedLandedCostsAllocation](https://user-images.githubusercontent.com/1847863/103710827-5c732d80-4f8c-11eb-9c02-c4db42d4d628.gif)
