### PR TITLE
Fixed error with payment selection for Over Under Payment

### DIFF
--- a/migration/393lts-394lts/07230_Fixed_error_with_Over_Under_Amount_for_Payment_Selection.xml
+++ b/migration/393lts-394lts/07230_Fixed_error_with_Over_Under_Amount_for_Payment_Selection.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Fixed error with Over Under Amount for Payment Selection" ReleaseNo="3.9.4" SeqNo="7230">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="53224" Action="U" Record_ID="50054" Table="AD_Browse">
+        <Data AD_Column_ID="58000" Column="WhereClause" oldValue="inv.DocStatus IN('CO', 'CL') AND inv.IsPaid = 'N' AND inv.IsSOTrx = 'N'&#10;AND NOT EXISTS(SELECT 1 FROM C_PaySelectionLine psl WHERE psl.C_PaySelection_ID = @C_PaySelection_ID@ AND psl.C_Invoice_ID = inv.C_Invoice_ID)&#10;AND NOT EXISTS(SELECT 1 FROM C_PaySelection ps INNER JOIN C_PaySelectionLine psl ON(psl.C_PaySelection_ID = ps.C_PaySelection_ID) &#10;&#9;&#9;WHERE ps.DocStatus IN('CO', 'CL') AND psl.C_Invoice_ID = inv.C_Invoice_ID)">inv.DocStatus IN('CO', 'CL') AND inv.IsPaid = 'N' AND inv.IsSOTrx = 'N'
+AND NOT EXISTS(SELECT 1 FROM C_PaySelectionLine psl WHERE psl.C_PaySelection_ID = @C_PaySelection_ID@ AND psl.C_Invoice_ID = inv.C_Invoice_ID)
+AND NOT EXISTS(SELECT 1 FROM C_PaySelection ps INNER JOIN C_PaySelectionLine psl ON(psl.C_PaySelection_ID = ps.C_PaySelection_ID) 
+        INNER JOIN C_PaySelectionCheck psc ON(psc.C_PaySelectionCheck_ID = psl.C_PaySelectionCheck_ID)
+        INNER JOIN C_Payment p ON(p.C_Payment_ID = psc.C_Payment_ID)
+		WHERE COALESCE(p.DocStatus, 'DR') NOT IN('CO', 'CL') AND ps.DocStatus IN('CO', 'CL') AND psl.C_Invoice_ID = inv.C_Invoice_ID)</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="53224" Action="U" Record_ID="50064" Table="AD_Browse">
+        <Data AD_Column_ID="58000" Column="WhereClause" oldValue="inv.DocStatus IN('CO', 'CL') AND inv.IsPaid = 'N' AND inv.IsSOTrx = 'N'&#10;AND NOT EXISTS(SELECT 1 FROM C_PaySelection ps INNER JOIN C_PaySelectionLine psl ON(psl.C_PaySelection_ID = ps.C_PaySelection_ID) &#10;&#9;&#9;WHERE ps.DocStatus IN('CO', 'CL') AND psl.C_Invoice_ID = inv.C_Invoice_ID)">inv.DocStatus IN('CO', 'CL') AND inv.IsPaid = 'N' AND inv.IsSOTrx = 'N'
+AND NOT EXISTS(SELECT 1 FROM C_PaySelection ps INNER JOIN C_PaySelectionLine psl ON(psl.C_PaySelection_ID = ps.C_PaySelection_ID) 
+        INNER JOIN C_PaySelectionCheck psc ON(psc.C_PaySelectionCheck_ID = psl.C_PaySelectionCheck_ID)
+        INNER JOIN C_Payment p ON(p.C_Payment_ID = psc.C_Payment_ID)
+		WHERE COALESCE(p.DocStatus, 'DR') NOT IN('CO', 'CL') AND ps.DocStatus IN('CO', 'CL') AND psl.C_Invoice_ID = inv.C_Invoice_ID)</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
## Step by Step
- Create a AP Invoice with USD 2000
- Create a Payment for created invoice with 1500, set flag over un der
amount to true
- Print payment created
- Create a new payment selection
- Search previous invoice created from SB "Create from Invoice"

## Expected behavior
The Invoice shoul be showed with:
  - Grand Total: USD 2000
  - Open Amount: USD 500
  - Payment Amount: 500

## Bug
The invoice is missing

## What is the problem?
The Create From Invoice (SB) not show a invoice after add to payment
selection and don't allows create a new payment selection for a invoice
with a previous under payment

This Pull Request resolve it