### PR TITLE
Fixed error for IsDiscountPrinted attribute from business partner

### DIFF
--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -484,8 +484,9 @@ public class MOrder extends X_C_Order implements DocAction
 		ii = bp.getSalesRep_ID();
 		if (ii != 0)
 			setSalesRep_ID(ii);
-
-
+		
+		//	Discount
+		setIsDiscountPrinted(bp.isDiscountPrinted());
 		//	Set Locations
 		MBPartnerLocation[] locs = bp.getLocations(false);
 		if (locs != null)


### PR DESCRIPTION
Currently the attribute IsDiscountPrinted only is setted on Sales Order
from a callout and it is ok. The problem is when you create a sales
order without using Sales Order window.

A example is when a sales order is created from POS.

This pull request resolve it