### PR TITLE
Fixed error with ZK panel when a window have too many record

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/panel/AbstractADWindowPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/panel/AbstractADWindowPanel.java
@@ -1502,8 +1502,7 @@ public abstract class AbstractADWindowPanel extends AbstractUIPart implements To
         if (!autoSave()) {
         	return;
         }
-
-		currentTab.setQuery(null);	//	reset previous queries
+        
 		MRole role = MRole.getDefault();
 		int maxRows = role.getMaxQueryRecords();
 		currentTab.query(m_onlyCurrentRows, 0, maxRows);


### PR DESCRIPTION
## The problem
When a client have too many record (over 500k) the zk is slowly loading
records

## Step by Step
- Go to window (any window) and save a record: note tha tthe window
should have some 20 records
- Go to main menu and reload recent items
- Select the recent item with last record
- After open window note that exist **1/1** records
- Press new button: here the problem, note that now have **1/20**
records (20 records because the table have 20 records but if it have
500k or more then is **1/500000** instead)

Load 500k or more in one window is very hard for database and server
memory