### PR TITLE
Fixed error with Generate Token for System Administrator role

### DIFF
--- a/base/src/org/spin/util/ThirdPartyAccess.java
+++ b/base/src/org/spin/util/ThirdPartyAccess.java
@@ -71,11 +71,11 @@ public class ThirdPartyAccess implements IThirdPartyAccessGenerator {
 	@Override
 	public String generateToken(int userId, int roleId) {
 		//	Validate user
-		if(userId <= 0) {
+		if(userId < 0) {
 			throw new AdempiereException("@AD_User_ID@ @NotFound@");
 		}
 		//	Validate Role
-		if(roleId <= 0) {
+		if(roleId < 0) {
 			throw new AdempiereException("@AD_Role_ID@ @NotFound@");
 		}
 		MADToken token = new MADToken(Env.getCtx(), 0, null);


### PR DESCRIPTION
Currently if a user have access to System Administrator and he need
generate a Third Party Access Token is not possible because a role with
0 on ID is invalid for this.