### PR TITLE
Enable customizable test properties which don't affect the test.properties file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ zkwebui/WEB-INF/test/test_results/
 utils_dev/packages/testSqlStatement2Pack.tar.gz
 utils_dev/packages/testSqlStatement2Pack.zip
 utils_dev/packages/testSqlStatement2Pack/
+utils_dev/mytest.properties

--- a/utils_dev/properties.xml
+++ b/utils_dev/properties.xml
@@ -11,6 +11,7 @@
     <property file="${user.home}/.adempiere.properties"/>
     <property file="${adempiere.base}/utils_dev/mybuild.properties"/>
     <property file="${adempiere.base}/utils_dev/build.properties"/>
+    <property file="${adempiere.base}/utils_dev/mytest.properties"/>
     <property file="${adempiere.base}/utils_dev/test.properties"/>
 
     <!-- Here we could add most common buildpaths -->

--- a/utils_dev/test.properties
+++ b/utils_dev/test.properties
@@ -1,5 +1,10 @@
 #  Controls for the tests performed during builds.
 
+#  Copy to mytest.properties to set properties different
+#  then these.  These properties will be used during
+#  continuation testing which does not support integration
+#  testing. 
+
 #  A flag/switch to turn all testing on or off -->
 test.performTests=true
 


### PR DESCRIPTION
Changes the build properties to read test properties from a file mytest.properties which the developer can add to their IDE.  mytest.properties will be ignored by git and will allow the user to enable integration testing locally.  The test.properties will control the tests performed during the Github actions run on pull requests.

This is similar to the way mybuild.properties can be used to override the build.properties. It also means the developer has less chance of changing and accidentally committing the test.properties file.