### PR TITLE
Update Currency for Venezuela Country

### DIFF
--- a/migration/393lts-394lts/07640_Update_Currency_for_Venezuela.xml
+++ b/migration/393lts-394lts/07640_Update_Currency_for_Venezuela.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Update Currency for Venezuela" ReleaseNo="3.9.4" SeqNo="7640">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="170" Action="U" Record_ID="339" Table="C_Country">
+        <Data AD_Column_ID="7049" Column="C_Currency_ID" oldValue="205">50001</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
From the last year Venezuela was change the currency from VEB to VEF and
after it now is VES.

This pull request just update the current currency for Venezuela