### PR TITLE
Remove unnecessary exception before save order line

### DIFF
--- a/base/src/org/compiere/model/MOrderLine.java
+++ b/base/src/org/compiere/model/MOrderLine.java
@@ -909,7 +909,15 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 			//	Check if on Price list
 			if (m_productPrice == null)
 				getProductPricing(m_M_PriceList_ID);
-			if (!m_productPrice.isCalculated()) {
+			if (!m_productPrice.isCalculated()
+					&& !isProcessed()
+					&& (newRecord
+							|| is_ValueChanged(COLUMNNAME_M_Product_ID)
+							|| is_ValueChanged(COLUMNNAME_C_UOM_ID)
+							|| is_ValueChanged(COLUMNNAME_QtyEntered)
+							|| is_ValueChanged(COLUMNNAME_PriceEntered)
+							|| is_ValueChanged(COLUMNNAME_Discount)
+							|| is_ValueChanged(COLUMNNAME_PriceEntered))) {
 				MDocType documentType = MDocType.get(getCtx(), getParent().getC_DocTypeTarget_ID());
 				if(Util.isEmpty(documentType.getDocSubTypeSO())
 						|| !documentType.getDocSubTypeSO().equals(MDocType.DOCSUBTYPESO_ReturnMaterial)) {


### PR DESCRIPTION
Currently exist a validation for price list on any order when a line is
added or modify. The problem is that if you want just add a text for
description or change a account dimension the error is throwed:

```Java
-----------> MOrderLine.save: beforeSave - MOrderLine[1098206, Line=10,
Ordered=8.0000, Delivered=8.0000, Invoiced=8.0000, Reserved=0.0000,
LineNet=22143310.32] [18]
org.adempiere.exceptions.ProductNotOnPriceListException: Product is not
on PriceList - Line No:10, Product:CEMENTO GRIS GENERICO ( SACOS ) ,
Price List:Ventas (VES), Date:02/15/2021
	at org.compiere.model.MOrderLine.beforeSave(MOrderLine.java:923)
	at org.compiere.model.PO.save(PO.java:2170)
	at org.compiere.model.GridTable.dataSavePO(GridTable.java:2192)
	at org.compiere.model.GridTable.dataSave(GridTable.java:1516)
	at org.compiere.model.GridTab.dataSave(GridTab.java:997)
	at org.compiere.apps.APanel.cmd_save(APanel.java:2045)
	at org.compiere.apps.APanel.actionPerformed(APanel.java:1752)
	at org.compiere.apps.AppsAction.actionPerformed(AppsAction.java:286)
	at javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:2022)
	at javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2348)
	at javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:402)
	at javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:259)
	at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:252)
	at java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:289)
	at java.awt.Component.processMouseEvent(Component.java:6535)
	at javax.swing.JComponent.processMouseEvent(JComponent.java:3324)
	at java.awt.Component.processEvent(Component.java:6300)
	at java.awt.Container.processEvent(Container.java:2236)
	at java.awt.Component.dispatchEventImpl(Component.java:4891)
	at java.awt.Container.dispatchEventImpl(Container.java:2294)
	at java.awt.Component.dispatchEvent(Component.java:4713)

-----------> GridTable.saveWarning: Error - Product is not on PriceList
- Line No:10, Product:CEMENTO GRIS GENERICO ( SACOS ) , Price
List:Ventas (VES), Date:02/15/2021 [18]
```