### PR TITLE
Improve error message for concept beforeSave error

### DIFF
--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRConcept.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRConcept.java
@@ -292,9 +292,12 @@ public class MHRConcept extends X_HR_Concept {
      */
     protected boolean beforeSave(boolean newRecord) {
         if (is_Changed() && is_ValueChanged(MHRConcept.COLUMNNAME_Value)) {
-            final String errorMessage = validateRules((String) get_ValueOld(MHRConcept.COLUMNNAME_Value));
-            if (errorMessage.length() > 0)
-                throw new AdempiereException("@HR_Concept_ID@ @RecordFound@ " + errorMessage);
+        	String oldValue = (String) get_ValueOld(MHRConcept.COLUMNNAME_Value);
+        	String newValue = getValue();
+            final String errorMessage = validateRules(oldValue);
+            if (errorMessage.length() > 0) {
+            	throw new AdempiereException("@RecordFound@ @HR_Concept_ID@: " + getName() + " [@OldValue@: " + oldValue + " @NewValue@: " + newValue + " ]" + errorMessage);
+            }
         }
         return true;
     }


### PR DESCRIPTION
Currently when a concept value is changed and it have some rule using
the old value is throwed a error like it:

```Java
Record found Global Payroll Concept: Asignación Reposo Remunerado 33%
Rule: groovy:CR_SNP -> CR_SNP Salario Normal Parcial
```

The problem is that is now showed what is the concept that is changed.
This pull request just add a better message including the concept value
and name, see:

```Java
Record found Global Payroll Concept: Asignación Reposo Remunerado 33%
[Old Value: AS_RRC New Value: AS_R33% ] Rule: groovy:CR_SNP -> CR_SNP
Salario Normal Parcial
```