### PR TITLE
Fixed error with tax calculation for Sales Order

### DIFF
--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -1610,7 +1610,7 @@ public class MOrder extends X_C_Order implements DocAction
 		//	Lines
 		AtomicReference<BigDecimal> totalLines = new AtomicReference<>(Env.ZERO);
 		ArrayList<Integer> taxList = new ArrayList<>();
-		MOrderLine[] orderLines = getLines();
+		MOrderLine[] orderLines = getLines(true, null);
 		for (MOrderLine orderLine : orderLines) {
 			if (!taxList.contains(orderLine.getC_Tax_ID())) {
 				Optional<MOrderTax> maybeOrderTax = Optional.ofNullable(MOrderTax.get(orderLine, getPrecision(), false, get_TrxName()));//	current Tax


### PR DESCRIPTION
## The Problem
When is called tax calculation method for Order it use cache for get
lines and is loaded a old data for lines

## Step for reproduce
- Create two products: one without tax and other with tax
- Go to POS and create a new Order
- Add as first the product without tax
- Add as second the product with tax

## Result
When is added the second product already exist some line and the tax
make a calculation based on old line without include the new