### PR TITLE
Fixed error with ASP for Overwrite definition

### DIFF
--- a/base/src/org/spin/util/ASPUtil.java
+++ b/base/src/org/spin/util/ASPUtil.java
@@ -577,6 +577,7 @@ public class ASPUtil {
 			for(MBrowseField field : browseFields) {
 				MBrowseField fieldToAdd = field.getDuplicated();
 				fieldToAdd.setIsActive(false);
+				fieldToAdd.setIsDisplayed(false);
 				mergedFields.add(fieldToAdd);
 			}
 		} else {
@@ -1499,6 +1500,8 @@ public class ASPUtil {
 				if(!column.isKey()
 						&& !column.isParent()) {
 					fieldToAdd.setIsActive(false);
+					fieldToAdd.setIsDisplayed(false);
+					fieldToAdd.setIsDisplayedGrid(false);
 				}
 				mergedFields.add(fieldToAdd);
 			}


### PR DESCRIPTION
When a Custom Window is created with level **Overwrite** this should
show the window and fields that are added on Custom window instead merge
all.

## Current Behavior
All fields are disabled but are displayed

## Correct Behavior
All fields are disabled and are not displayed
