### PR TITLE
Add github actions to use a single version of java in the build tests.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,14 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      
+      # Ensure a compatible version of java is used
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+            java-version: '1.8'
+            java-package: jdk
+
       # Build ADempiere with ant
       - name: Build Adempiere ...
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,14 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      
+      # Ensure a compatible version of java is used
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+            java-version: '1.8'
+            java-package: jdk
+            
       # Build ADempiere with ant
       - name: Build Adempiere ...
         run: |


### PR DESCRIPTION
Fixes #3383

An upgrade to Java 11 was breaking the build processes on Github.  This PR sets the java version to use at 1.8.

Both main.yml and release.yml have been updated.
