### PR TITLE
Fix distribution by organization dimension

### DIFF
--- a/base/src/org/compiere/model/MDistribution.java
+++ b/base/src/org/compiere/model/MDistribution.java
@@ -112,7 +112,7 @@ public class MDistribution extends X_GL_Distribution
 			if (distribution.getC_DocType_ID() != 0 && distribution.getC_DocType_ID() != docTypeId)
 				continue;
 			//	Optional Elements - "non-Any"
-			if (!distribution.isAnyOrg() && distribution.getAD_Org_ID() != orgId)
+			if (!distribution.isAnyOrg() && distribution.getOrg_ID() != orgId)
 				continue;
 			if (!distribution.isAnyAcct() && distribution.getAccount_ID() != accountId)
 				continue;
@@ -363,7 +363,7 @@ public class MDistribution extends X_GL_Distribution
 				continue;
 			
 			if (!distribution.isAnyOrg()
-					&& distribution.getAD_Org_ID() != orgId)
+					&& distribution.getOrg_ID() != orgId)
 				continue;
 			if (!distribution.isAnyAcct()
 					&& distribution.getAccount_ID() != accountId)


### PR DESCRIPTION
## Problem
When have an Accounting Distribution by Organization Dimension, this don't work.

## Step by Step

- Create a Accounting Distribution with this definition:
![Screenshot_20210322_111056](https://user-images.githubusercontent.com/1847863/112022944-22d0ae00-8b09-11eb-80d1-37196bb62919.png)
![Screenshot_20210322_111141](https://user-images.githubusercontent.com/1847863/112022951-25330800-8b09-11eb-8cc1-e4d3a2b3c030.png)

- find the Vendor Invoice 10000003
![Screenshot_20210322_111213](https://user-images.githubusercontent.com/1847863/112023518-b7d3a700-8b09-11eb-9382-ef9c13451f41.png)

- Post it document and see that the distribution don't work
![Screenshot_20210322_111234](https://user-images.githubusercontent.com/1847863/112023625-ccb03a80-8b09-11eb-9812-45cd53c9ab57.png)

## Purpose
Change get Distribution method for comparing with Org_ID

![image](https://user-images.githubusercontent.com/1847863/112024415-8c04f100-8b0a-11eb-9091-68b017c38a2f.png)

## Result After Changes
![Screenshot_20210322_111616](https://user-images.githubusercontent.com/1847863/112024458-99ba7680-8b0a-11eb-8a66-55fa55b97b5c.png)
