### PR TITLE
Adempiere B#3421 Fin Report, Parameter Userelement2_ID not  assigned

### DIFF
--- a/base/src/org/compiere/report/FinReport.java
+++ b/base/src/org/compiere/report/FinReport.java
@@ -122,7 +122,7 @@ public class FinReport extends FinReportAbstract {
 			parameterWhere.append(" AND UserElement1_ID=").append(getUserElement1Id());
 		//  Optional UserElement2_ID
 		if (getUserElement2Id() != 0)
-			parameterWhere.append(" AND UserElement2_ID=").append(getUserElement1Id());
+			parameterWhere.append(" AND UserElement2_ID=").append(getUserElement2Id());
 
 		//	Load Report Definition
 		finReport = new MReport (getCtx(), getRecord_ID(), get_TrxName());


### PR DESCRIPTION
https://github.com/adempiere/adempiere/issues/3421

How to reproduce:
Define Userelement2_ID as accounting dimension
Create a financial report and filter for userelement2
The result is null

Correction:
Class finReport, line 125
Erroneous Code
```
if (getUserElement2Id() != 0)
			parameterWhere.append(" AND UserElement2_ID=").append(getUserElement1Id());
```
Correct code
```
if (getUserElement2Id() != 0)
			parameterWhere.append(" AND UserElement2_ID=").append(getUserElement2Id());
```
Result before correction:
![imagen](https://user-images.githubusercontent.com/15349639/113532626-1593d480-9589-11eb-8518-79cb200c71f9.png)

Result after correction:
![imagen](https://user-images.githubusercontent.com/15349639/113532721-4c69ea80-9589-11eb-823e-39ea72b17a2a.png)

