### PR TITLE
Fix RoleAccessUpdate to enable update for all clients and all roles.

### DIFF
--- a/base/src/org/compiere/process/RoleAccessUpdate.java
+++ b/base/src/org/compiere/process/RoleAccessUpdate.java
@@ -21,96 +21,102 @@ import java.util.List;
 import java.util.logging.Level;
 
 import org.compiere.Adempiere;
+import org.compiere.model.I_AD_Role;
 import org.compiere.model.MRole;
 import org.compiere.model.Query;
 import org.compiere.util.CLogMgt;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
+import org.eevolution.service.dsl.ProcessBuilder;
 
 /**
- *	Update Role Access
- *	
- *  @author Jorg Janke
- *  @version $Id: RoleAccessUpdate.java,v 1.3 2006/07/30 00:51:02 jjanke Exp $
+ * Update Role Access
+ * 
+ * @author Jorg Janke
+ * @version $Id: RoleAccessUpdate.java,v 1.3 2006/07/30 00:51:02 jjanke Exp $
  * 
  * @author Teo Sarca, teo.sarca@gmail.com
- * 		<li>BF [ 3018005 ] Role Access Update: updates all roles if I log in as System
- * 			https://sourceforge.net/tracker/?func=detail&aid=3018005&group_id=176962&atid=879332
+ *         <li>BF [ 3018005 ] Role Access Update: updates all roles if I log in
+ *         as System
+ *         https://sourceforge.net/tracker/?func=detail&aid=3018005&group_id=176962&atid=879332
  * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
- * <li> FR [ 1891 ] Add support for update role process on Dashboard
+ *         <li>FR [ 1891 ] Add support for update role process on Dashboard
  * @see https://github.com/adempiere/adempiere/issues/1891
  */
 public class RoleAccessUpdate extends RoleAccessUpdateAbstract {
-	/**	Static Logger	*/
-	private static CLogger	s_log	= CLogger.getCLogger (RoleAccessUpdate.class);
-	
-	/**
-	 * 	Prepare
-	 */
-	protected void prepare () {
-		super.prepare();
-	}	//	prepare
 
-	/**
-	 * 	Process
-	 *	@return info
-	 *	@throws Exception
-	 */
-	protected String doIt () throws Exception
-	{
-		log.info("AD_Client_ID=" + getClientId() + ", AD_Role_ID=" + getRoleId());
-		//
-		if (getRoleId() > 0)
-			updateRole (new MRole (getCtx(), getRoleId(), get_TrxName()));
-		else
-		{
-			List<Object> params = new ArrayList<Object>();
-			String whereClause = "1=1";
-			if (getClientId() > 0) {
-				whereClause += " AND AD_Client_ID=? ";
-				params.add(getClientId());
-			}
-			if (getRoleId() == 0) {	//	System Role
-				whereClause += " AND AD_Role_ID=?";
-				params.add(getRoleId());
-			}
-			//sql += "ORDER BY AD_Client_ID, Name";
-			
-			new Query(getCtx(), MRole.Table_Name, whereClause, get_TrxName())
-				.setOnlyActiveRecords(true)
-				.setParameters(params)
-				.setOrderBy("AD_Client_ID, Name")
-				.<MRole>list().stream().forEach(role -> {
-					updateRole(role);
-				});
-		}
-		
-		return "";
-	}	//	doIt
+    private static CLogger logger = CLogger.getCLogger(RoleAccessUpdate.class);
 
-	/**
-	 * 	Update Role
-	 *	@param role role
-	 */
-	private void updateRole (MRole role) {
-		addLog(0, null, null, role.getName() + ": " 
-			+ role.updateAccessRecords());
-	}	//	updateRole
-	
-	//add main method, preparing for nightly build
-	public static void main(String[] args)  {
-		Adempiere.startupEnvironment(false);
-		CLogMgt.setLevel(Level.FINE);
-		s_log.info("Role Access Update");
-		s_log.info("------------------");
-		ProcessInfo pi = new ProcessInfo("Role Access Update", 295);
-		pi.setAD_Client_ID(0);
-		pi.setAD_User_ID(100);
-		
-		RoleAccessUpdate rau = new RoleAccessUpdate();
-		rau.startProcess(Env.getCtx(), pi, null);
-		
-		System.out.println("Process=" + pi.getTitle() + " Error="+pi.isError() + " Summary=" + pi.getSummary());
-	}
-	
-}	//	RoleAccessUpdate
+    protected String doIt() throws Exception {
+
+        getProcessLog().info("AD_Client_ID=" + getClientId() + ", AD_Role_ID="
+                + getRoleId());
+
+        if (getRoleId() >= 0) {
+            updateRole(getRole(getRoleId()));
+        } else {
+            List<Object> params = new ArrayList<>();
+            String whereClause = "";
+
+            if (getClientId() > 0) {
+                whereClause = "AD_Client_ID=?";
+                params.add(getClientId());
+            }
+
+            getRoleQuery(whereClause)
+                    .setOnlyActiveRecords(true)
+                    .setParameters(params)
+                    .setOrderBy("AD_Client_ID, Name")
+                    .<MRole>list().stream().forEach(this::updateRole);
+        }
+
+        return "";
+
+    }
+
+    MRole getRole(int roleId) {
+
+        return new MRole(getCtx(), roleId, get_TrxName());
+
+    }
+
+    CLogger getProcessLog() {
+
+        return log;
+
+    }
+
+    Query getRoleQuery(String whereClause) {
+
+        return new Query(getCtx(), I_AD_Role.Table_Name, whereClause,
+                get_TrxName());
+
+    }
+
+    protected void updateRole(MRole role) {
+
+        addLog(0, null, null, role.getName() + ": "
+                + role.updateAccessRecords());
+
+    }
+
+    public static void main(String[] args) {
+
+        Adempiere.startupEnvironment(false);
+        CLogMgt.setLevel(Level.FINE);
+        logger.info("Role Access Update");
+        logger.info("------------------");
+
+        ProcessInfo pi = ProcessBuilder
+                .create(Env.getCtx())
+                .process(RoleAccessUpdate.class)
+                .withParameter(AD_CLIENT_ID, 0)
+                .withParameter(AD_ROLE_ID, null)
+                .execute();
+        
+        logger.info("Process=" + pi.getTitle() + " Error=" + pi.isError()
+                + " Summary=" + pi.getSummary());
+
+    }
+
+}

--- a/base/src/org/compiere/process/RoleAccessUpdateAbstract.java
+++ b/base/src/org/compiere/process/RoleAccessUpdateAbstract.java
@@ -17,7 +17,7 @@
 
 package org.compiere.process;
 
-
+import java.math.BigDecimal;
 
 /** Generated Process for (Role Access Update)
  *  @author ADempiere (generated) 
@@ -37,12 +37,12 @@ public abstract class RoleAccessUpdateAbstract extends SvrProcess {
 	/**	Parameter Value for Client	*/
 	private int clientId;
 	/**	Parameter Value for Role	*/
-	private int roleId;
+	private BigDecimal roleId;
 
 	@Override
 	protected void prepare() {
 		clientId = getParameterAsInt(AD_CLIENT_ID);
-		roleId = getParameterAsInt(AD_ROLE_ID);
+		roleId = (BigDecimal) getParameter(AD_ROLE_ID);
 	}
 
 	/**	 Getter Parameter Value for Client	*/
@@ -57,12 +57,14 @@ public abstract class RoleAccessUpdateAbstract extends SvrProcess {
 
 	/**	 Getter Parameter Value for Role	*/
 	protected int getRoleId() {
-		return roleId;
+	    if (roleId == null)
+	        return -1;
+		return roleId.intValue();
 	}
 
 	/**	 Setter Parameter Value for Role	*/
 	protected void setRoleId(int roleId) {
-		this.roleId = roleId;
+		this.roleId = BigDecimal.valueOf(roleId);
 	}
 
 	/**	 Getter Parameter Value for Process ID	*/

--- a/base/test/src/org/compiere/process/RoleAccessUpdate_IT.java
+++ b/base/test/src/org/compiere/process/RoleAccessUpdate_IT.java
@@ -1,0 +1,307 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2021 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.compiere.process;
+
+import static org.adempiere.test.TestUtilities.randomString;
+import static org.compiere.Adempiere.startup;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.sql.Savepoint;
+import java.util.List;
+import java.util.Properties;
+
+import org.adempiere.test.CommonGWData;
+import org.compiere.model.I_AD_Window_Access;
+import org.compiere.model.MRole;
+import org.compiere.model.Query;
+import org.compiere.model.X_AD_Role;
+import org.compiere.model.X_AD_Window_Access;
+import org.compiere.util.Env;
+import org.compiere.util.Ini;
+import org.compiere.util.TimeUtil;
+import org.compiere.util.Trx;
+import org.eevolution.service.dsl.ProcessBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Given the GardenWorld Client ")
+class RoleAccessUpdate_IT {
+
+    // Can't extend the CommonGWSetup as the transaction
+    // has to be closed after each process run.
+    
+    private static final int AD_USER_ID = 100; // SuperUser
+    private static final int GARDEN_USER_ROLE_ID = 103;
+    private static final int SYSTEM_ADMIN_ROLE_ID = 0;
+    private static final int SYSTEM_CLIENT_ID = 0;
+    private static final int GARDEN_WORLD_CLIENT_ID = CommonGWData.AD_CLIENT_ID;
+    private static final int AD_ORG_ID = CommonGWData.AD_ORG_ID;
+    protected static final boolean IS_CLIENT = CommonGWData.IS_CLIENT;
+    private static Properties ctx;
+    private String trxName = null;
+    private Trx trx = null;
+    private Savepoint testSavepoint = null;
+
+    private int windowId = 193; // Note - access level ALL
+
+    @BeforeAll
+    public static void createGWContextAndConnect() {
+
+        ctx = Env.getCtx();
+        ctx.setProperty("#AD_Org_ID", Integer.toString(AD_ORG_ID));
+        ctx.setProperty("#AD_User_ID", Integer.toString(AD_USER_ID));
+        ctx.setProperty("#AD_Client_ID",
+                Integer.toString(GARDEN_WORLD_CLIENT_ID));
+        ctx.setProperty("#Date",
+                TimeUtil.getDay(System.currentTimeMillis()).toString());
+        ctx.setProperty("#AD_Language", "en");
+
+        Ini.setClient(IS_CLIENT);
+        Ini.loadProperties(false);
+        startup(IS_CLIENT);
+
+    }
+
+    @AfterAll
+    public static void tearDownAfterClass() {
+
+        ctx = null;
+
+    }
+
+    @BeforeEach
+    void createTransactionAndSavePoint() throws Exception {
+
+        trxName = Trx.createTrxName("TestRun_" + randomString(4));
+        trx = Trx.get(trxName, false);
+        testSavepoint = trx.setSavepoint("SingleTest_" + randomString(4));
+
+    }
+
+    @AfterEach
+    void rollbackSavePointAndCloseTransaction() throws Exception {
+
+        if (trx != null && trx.isActive() && testSavepoint != null) {
+            trx.rollback(testSavepoint);
+        }
+        trx.close();
+        trx = null;
+
+    }
+
+    private List<MRole> getAllAutomaticRoles() {
+
+        String where = X_AD_Role.COLUMNNAME_IsManual + "='N'";
+        return new Query(ctx, MRole.Table_Name, where, trxName)
+                .setOnlyActiveRecords(true)
+                .list(MRole.class);
+
+    }
+
+    private void assertAllRolesUpdated(int windowId) {
+
+        for (MRole role : getAllAutomaticRoles()) {
+            assertNotNull(role.getWindowAccess(windowId),
+                    "Role " + role.getName()
+                            + " does not have access to window "
+                            + windowId);
+        }
+
+    }
+
+    private void assertGWRolesUpdated(int windowId) {
+
+        for (MRole role : getAllAutomaticRoles()) {
+            if (role.getAD_Client_ID() == GARDEN_WORLD_CLIENT_ID) {
+                assertNotNull(role.getWindowAccess(windowId),
+                        "Role " + role.getName()
+                                + " of clientId " + role.getAD_Client_ID()
+                                + " does not have access to window "
+                                + windowId);
+            } else {
+                assertNull(role.getWindowAccess(windowId),
+                        "Role " + role.getName()
+                                + " of clientId " + role.getAD_Client_ID()
+                                + " does have access to window "
+                                + windowId);
+            }
+        }
+
+    }
+
+    private void assertNoRoleHasAccess(int windowId) {
+
+        for (MRole role : getAllAutomaticRoles()) {
+            assertNull(role.getWindowAccess(windowId),
+                    "Role " + role.getName()
+                            + " does have access to window "
+                            + windowId);
+        }
+
+    }
+
+    private void assertOnlyGWUserRoleUpdated(int windowId) {
+
+        for (MRole role : getAllAutomaticRoles()) {
+            if (role.getAD_Role_ID() == GARDEN_USER_ROLE_ID) {
+                assertNotNull(role.getWindowAccess(windowId),
+                        "Role " + role.getName()
+                                + " of clientId " + role.getAD_Client_ID()
+                                + " does not have access to window "
+                                + windowId);
+            } else {
+                assertNull(role.getWindowAccess(windowId),
+                        "Role " + role.getName()
+                                + " of clientId " + role.getAD_Client_ID()
+                                + " does have access to window "
+                                + windowId);
+            }
+        }
+
+    }
+
+    private void assertOnlySysAdmRoleUpdated(int windowId) {
+
+        for (MRole role : getAllAutomaticRoles()) {
+            if (role.getAD_Role_ID() == SYSTEM_ADMIN_ROLE_ID) {
+                assertNotNull(role.getWindowAccess(windowId),
+                        "Role " + role.getName()
+                                + " of clientId " + role.getAD_Client_ID()
+                                + " does not have access to window "
+                                + windowId);
+            } else {
+                assertNull(role.getWindowAccess(windowId),
+                        "Role " + role.getName()
+                                + " of clientId " + role.getAD_Client_ID()
+                                + " does have access to window "
+                                + windowId);
+            }
+        }
+
+    }
+
+    @Nested
+    @DisplayName("And given no window access")
+    class GivenNoWindowAccess {
+
+        @BeforeEach
+        void deleteWindowAccess() {
+
+            getAllAutomaticRoles().stream()
+                    .forEach(role -> {
+                        String where =
+                                X_AD_Window_Access.COLUMNNAME_AD_Window_ID + "="
+                                        + windowId
+                                        + " AND "
+                                        + X_AD_Window_Access.COLUMNNAME_AD_Role_ID
+                                        + "=" + role.getAD_Role_ID();
+                        new Query(ctx, I_AD_Window_Access.Table_Name, where,
+                                trxName)
+                                        .list().stream()
+                                        .forEach(wa -> wa.deleteEx(false));
+
+                    });
+
+        }
+
+        @Test
+        @DisplayName("When window access is checked, then no role has access")
+        final void whenAccessIsChecked_thenNoAccess() {
+
+            assertNoRoleHasAccess(windowId);
+
+        }
+
+        @Test
+        @DisplayName("When the Role Access Update is run for the System Client "
+                + "with no role selected, then all roles in the client are updated")
+        final void whenRunForSystemAndNoRole_thenAllRolesUpdated() {
+
+            ProcessBuilder
+                    .create(ctx)
+                    .process(RoleAccessUpdate.class)
+                    .withParameter(RoleAccessUpdate.AD_CLIENT_ID,
+                            SYSTEM_CLIENT_ID)
+                    .withParameter(RoleAccessUpdate.AD_ROLE_ID, null)
+                    .execute(trxName);
+
+            assertAllRolesUpdated(windowId);
+
+        }
+
+        @Test
+        @DisplayName("When the Role Access Update is run for the System Client "
+                + "with the System Admin role selected, then only the System "
+                + "Admin role is updated")
+        final void whenRunForSystemAndSysAdmRole_thenOnlySysAdmUpdated() {
+
+            ProcessBuilder
+                    .create(ctx)
+                    .process(RoleAccessUpdate.class)
+                    .withParameter(RoleAccessUpdate.AD_CLIENT_ID,
+                            SYSTEM_CLIENT_ID)
+                    .withParameter(RoleAccessUpdate.AD_ROLE_ID,
+                            SYSTEM_ADMIN_ROLE_ID)
+                    .execute(trxName);
+
+            assertOnlySysAdmRoleUpdated(windowId);
+
+        }
+
+        @Test
+        @DisplayName("When the Role Access Update is run for the GardenWorld Client "
+                + "with no role selected, then all roles in the client are updated")
+        final void whenRunForGWAndNoRole_thenAllGWRolesUpdated() {
+
+            ProcessBuilder
+                    .create(ctx)
+                    .process(RoleAccessUpdate.class)
+                    .withParameter(RoleAccessUpdate.AD_CLIENT_ID,
+                            GARDEN_WORLD_CLIENT_ID)
+                    .withParameter(RoleAccessUpdate.AD_ROLE_ID, null)
+                    .execute(trxName);
+
+            assertGWRolesUpdated(windowId);
+
+        }
+
+        @Test
+        @DisplayName("When the Role Access Update is run for the GardenWorld Client "
+                + "with the GardenUser role selected, then only that roles is updated")
+        final void whenRunForGWAndGardenUserRole_thenOnlyGardenUserUpdated() {
+
+            ProcessBuilder
+                    .create(ctx)
+                    .process(RoleAccessUpdate.class)
+                    .withParameter(RoleAccessUpdate.AD_CLIENT_ID,
+                            GARDEN_WORLD_CLIENT_ID)
+                    .withParameter(RoleAccessUpdate.AD_ROLE_ID,
+                            GARDEN_USER_ROLE_ID)
+                    .execute(trxName);
+
+            assertOnlyGWUserRoleUpdated(windowId);
+
+        }
+
+    }
+
+}

--- a/base/test/src/org/compiere/process/RoleAccessUpdate_IT.java
+++ b/base/test/src/org/compiere/process/RoleAccessUpdate_IT.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.adempiere.test.CommonGWData;
+import org.adempiere.test.IntegrationTestTag;
 import org.compiere.model.I_AD_Window_Access;
 import org.compiere.model.MRole;
 import org.compiere.model.Query;
@@ -41,10 +42,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("RoleAccessUpdate")
 @DisplayName("Given the GardenWorld Client ")
-class RoleAccessUpdate_IT {
+class RoleAccessUpdate_IT implements IntegrationTestTag{
 
     // Can't extend the CommonGWSetup as the transaction
     // has to be closed after each process run.

--- a/base/test/src/org/compiere/process/RoleAccessUpdate_Test.java
+++ b/base/test/src/org/compiere/process/RoleAccessUpdate_Test.java
@@ -1,0 +1,121 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2021 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.compiere.process;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+import org.adempiere.test.CommonUnitTestSetup;
+import org.compiere.model.MRole;
+import org.compiere.model.Query;
+import org.compiere.util.CLogger;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+class RoleAccessUpdate_Test extends CommonUnitTestSetup {
+
+    private RoleAccessUpdate roleAccessUpdate;
+
+    @Captor
+    ArgumentCaptor<String> whereCaptor;
+
+    static Stream<Arguments> argProviderRoleAndClient() {
+
+        return Stream.of(
+                arguments(0, null, ""),
+                arguments(0, new BigDecimal(-1), ""),
+                arguments(1, null, "AD_Client_ID=?"),
+                arguments(1, new BigDecimal(-1), "AD_Client_ID=?"));
+
+    }
+
+    @BeforeEach
+    void localSetup() {
+
+        Query queryMock = mock(Query.class);
+        lenient().doReturn(queryMock).when(queryMock)
+                .setOnlyActiveRecords(anyBoolean());
+        lenient().doReturn(queryMock).when(queryMock).setParameters(anyList());
+        lenient().doReturn(queryMock).when(queryMock).setOrderBy(anyString());
+        lenient().doReturn(new ArrayList<MRole>()).when(queryMock).list();
+
+        CLogger logMock = mock(CLogger.class);
+
+        roleAccessUpdate = spy(RoleAccessUpdate.class);
+        lenient().doReturn(queryMock).when(roleAccessUpdate)
+                .getRoleQuery(anyString());
+        lenient().doReturn(logMock).when(roleAccessUpdate).getProcessLog();
+
+    }
+
+    @ParameterizedTest(
+            name = "When ClientId = {0} and RoleId={1} then where clause is {3}")
+    @MethodSource("argProviderRoleAndClient")
+    @DisplayName("When role is -1(null) or zero and client is 0 or not 0, then "
+            + "the where clause should be set appropriately")
+    final void whenRoleNullOrNegOneAndClientSet_ThenWhereMatches(int clientId,
+            BigDecimal roleId, String expectedWhere) throws Exception {
+
+        doReturn(clientId).when(roleAccessUpdate)
+                .getParameterAsInt("AD_Client_ID");
+        doReturn(roleId).when(roleAccessUpdate).getParameter("AD_Role_ID");
+
+        roleAccessUpdate.prepare();
+        roleAccessUpdate.doIt();
+
+        verify(roleAccessUpdate).getRoleQuery(whereCaptor.capture());
+        assertEquals(expectedWhere, whereCaptor.getValue());
+
+    }
+
+    @Test
+    final void whenRoleIsNotNullOrNegOne_ThenRoleIsUpdated() throws Exception {
+
+        MRole roleMock = mock(MRole.class);
+        doReturn(1).when(roleAccessUpdate).getParameterAsInt("AD_Client_ID");
+        doReturn(Env.ONE).when(roleAccessUpdate).getParameter("AD_Role_ID");
+        doReturn(roleMock).when(roleAccessUpdate).getRole(1);
+
+        roleAccessUpdate.prepare();
+        roleAccessUpdate.doIt();
+
+        verify(roleAccessUpdate).getRole(1);
+        verify(roleAccessUpdate).updateRole(roleMock);
+
+    }
+
+}


### PR DESCRIPTION
Fixes #3427

Update RoleAccessUpdate to isolate constructors and static utilities to enable mocking for tests. Clean up the logic and fix the Main method.
In RoleAccessUpdateAbstract, change roleId to a BigDecimal and test for null in the getter.
Add unit and integration tests to show the application across all roles in all clients, all roles in the current client or a single role.

Unit and integration tests are included.

If the role is set, only that role is updated - even for the System Administration role
If the client is set to system, and role is not selected, all roles in all clients are updated
If the client is set other than system and the role is not selected, all roles in the selected client are updated
