### PR TITLE
Fixed error with Garden World CleanUp process

### DIFF
--- a/base/src/org/compiere/process/GardenWorldCleanUp.java
+++ b/base/src/org/compiere/process/GardenWorldCleanUp.java
@@ -209,10 +209,10 @@ public class GardenWorldCleanUp extends SvrProcess
 			 if(dateAcctColumn != null) {
 			 
 				 log.fine("Table: " + tableName + " dateAcctColumn: " + dateAcctColumn);
-				String updatePeriodSql="update "+tableName+" set "
-						+ " C_Period_ID=(SELECT C_Period_ID from C_Period WHERE "+dateAcctColumn
-						+ " BETWEEN StartDate and EndDate and AD_Client_ID=" + gw_client_id 
-						+ ") WHERE AD_Client_ID=" + gw_client_id;
+				String updatePeriodSql="UPDATE "+tableName+" SET "
+						+ " C_Period_ID=(SELECT C_Period_ID FROM C_Period WHERE " + tableName + "." + dateAcctColumn + " BETWEEN StartDate AND EndDate AND AD_Client_ID=" + gw_client_id + ") "
+						+ "WHERE EXISTS(SELECT 1 FROM C_Period WHERE " + tableName + "." + dateAcctColumn + " BETWEEN StartDate AND EndDate AND AD_Client_ID = " + gw_client_id + ") "
+						+ "AND AD_Client_ID=" + gw_client_id;
 				
 				PreparedStatement pstm = null;
 				try {
@@ -266,6 +266,11 @@ public class GardenWorldCleanUp extends SvrProcess
 	}
 	
 	private void clearSessionLog() {
+		//	Delete change log
+		DB.executeUpdateEx("DELETE FROM AD_ChangeLog WHERE AD_Client_ID = " + gw_client_id, get_TrxName());
+		//	Delete process instance
+		DB.executeUpdateEx("DELETE FROM AD_PInstance WHERE AD_Client_ID = " + gw_client_id, get_TrxName());
+		//	
 		String deleteSessionLogSQL = "DELETE FROM AD_Session where AD_Client_ID=" + gw_client_id;
 		PreparedStatement pstm=null;
 		 try {


### PR DESCRIPTION
When GardenWorld CleanUp is running over a database with data on garden
it is throw a error deleting all transactions

```Java
Total time: 77 minutes 4 seconds
     *** 2021-04-14 17:40:12.199 Adempiere Log (CLogConsole) ***
     ===========> GardenWorldCleanUp.setPeriods: ERROR: null value in column "c_period_id" of relation "gl_journal" violates not-null constraint
       Detail: Failing row contains (100, 11, 11, Y, 2002-08-10 18:40:29, 100, 2002-08-11 13:30:45, 0, 101, 115, 1001, CO, --, Y, N, Intercompany, A, null, 108, 2021-04-14 00:00:00, 2021-04-14 00:00:00, null, 100, 1, 100, 100, 100, 0, N, Y, N, 114, null, 1029004829000, null). [1]
     ===========> GardenWorldCleanUp.setPeriods: ERROR: null value in column "c_period_id" of relation "gl_journal" violates not-null constraint
       Detail: Failing row contains (100, 11, 11, Y, 2002-08-10 18:40:29, 100, 2002-08-11 13:30:45, 0, 101, 115, 1001, CO, --, Y, N, Intercompany, A, null, 108, 2021-04-14 00:00:00, 2021-04-14 00:00:00, null, 100, 1, 100, 100, 100, 0, N, Y, N, 114, null, 1029004829000, null). [1]
     ===========> GardenWorldCleanUp.process: Problem in updating periods according to new accounting values. [1]
     org.postgresql.util.PSQLException: ERROR: null value in column "c_period_id" of relation "gl_journal" violates not-null constraint
       Detail: Failing row contains (100, 11, 11, Y, 2002-08-10 18:40:29, 100, 2002-08-11 13:30:45, 0, 101, 115, 1001, CO, --, Y, N, Intercompany, A, null, 108, 2021-04-14 00:00:00, 2021-04-14 00:00:00, null, 100, 1, 100, 100, 100, 0, N, Y, N, 114, null, 1029004829000, null).; State=23502; ErrorCode=0
     	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2497)
     	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2233)
     	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:310)
     	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:446)
     	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:370)
     	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:149)
     	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:124)
     	at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeUpdate(NewProxyPreparedStatement.java:105)
     	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
     	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
     	at java.lang.reflect.Method.invoke(Method.java:498)
     	at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
     	at com.sun.proxy.$Proxy2.executeUpdate(Unknown Source)
     	at org.compiere.process.GardenWorldCleanUp.setPeriods(GardenWorldCleanUp.java:220)
     	at org.compiere.process.GardenWorldCleanUp.updatePeriods(GardenWorldCleanUp.java:154)
     	at org.compiere.process.GardenWorldCleanUp.doIt(GardenWorldCleanUp.java:109)
     	at org.compiere.process.SvrProcess.process(SvrProcess.java:177)
     	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:130)
     	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:168)
     	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:113)
     	at org.compiere.process.ServerProcessCtl.startProcess(ServerProcessCtl.java:358)
     	at org.compiere.process.ServerProcessCtl.run(ServerProcessCtl.java:199)
     
     ===========> GardenWorldCleanUp.process: Problem in updating periods according to new accounting values. [1]
     org.postgresql.util.PSQLException: ERROR: null value in column "c_period_id" of relation "gl_journal" violates not-null constraint
       Detail: Failing row contains (100, 11, 11, Y, 2002-08-10 18:40:29, 100, 2002-08-11 13:30:45, 0, 101, 115, 1001, CO, --, Y, N, Intercompany, A, null, 108, 2021-04-14 00:00:00, 2021-04-14 00:00:00, null, 100, 1, 100, 100, 100, 0, N, Y, N, 114, null, 1029004829000, null).; State=23502; ErrorCode=0
     	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2497)
     	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2233)
     	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:310)
     	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:446)
     	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:370)
     	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:149)
     	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:124)
     	at com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeUpdate(NewProxyPreparedStatement.java:105)
     	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
     	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
     	at java.lang.reflect.Method.invoke(Method.java:498)
     	at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
     	at com.sun.proxy.$Proxy2.executeUpdate(Unknown Source)
     	at org.compiere.process.GardenWorldCleanUp.setPeriods( .java:220)
     	at org.compiere.process.GardenWorldCleanUp.updatePeriods(GardenWorldCleanUp.java:154)
     	at org.compiere.process.GardenWorldCleanUp.doIt(GardenWorldCleanUp.java:109)
     	at org.compiere.process.SvrProcess.process(SvrProcess.java:177)
     	at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:130)
     	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:168)
     	at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:113)
     	at org.compiere.process.ServerProcessCtl.startProcess(ServerProcessCtl.java:358)
     	at org.compiere.process.ServerProcessCtl.run(ServerProcessCtl.java:199)
     
     17:40:12.196 Trx.rollback: **** TrxRun_f03512a2-f22c-4710-bf66-4390a15f3276 [1]
     org.adempiere.exceptions.AdempiereException: Process failed during execution Error:  Problem in updating periods according to new accounting values.
     	at org.eevolution.service.dsl.ProcessBuilder.execute(ProcessBuilder.java:274)
     	at org.eevolution.service.dsl.ProcessBuilder.executeUsingSystemRole(ProcessBuilder.java:257)
     	at org.adempiere.process.MigrationLoader.main(MigrationLoader.java:132)
     
     terminated abnormally
Error: Process completed with exit code 1.
```