### PR TITLE
Create Purchase Order from Requisition have a error

### DIFF
--- a/base/src/org/compiere/process/RequisitionPOCreate.java
+++ b/base/src/org/compiere/process/RequisitionPOCreate.java
@@ -396,9 +396,7 @@ public class RequisitionPOCreate extends RequisitionPOCreateAbstract
 
 		//	New Order - Different Vendor
 		if (purchaseOrder == null
-			|| purchaseOrder.getC_BPartner_ID() != partnerId
-			|| purchaseOrder.getDatePromised().compareTo(requisitionLine.getDateRequired()) != 0
-			)
+			|| purchaseOrder.getC_BPartner_ID() != partnerId)
 		{
 			newOrder(requisitionLine, partnerId);
 		}


### PR DESCRIPTION
## Step by Step
- Create a requisition:
  - Product: PChair
  - Quantity: 2
  - Required Date: 2021-04-22
- Create other requisition:
  - Product: Mulch
  - Quantity: 3
  - Required Date: 2021-04-16
- Go to Smart browser **Browse Requisition to Create PO from Requisition
Lines**
- Select Previous requisition generated
- Select a Business partner as vendor
- Check **Consolidate to one Document**
- Do it

## What is the problem?
If the flag **Consolidate to one Document** is true and a business
partner is selected in the process it will should generate one
**Purchase Order**, nevertheless, is generated two documents.

The origin of behavior is that is validate the required date of
requisition with promised date of **purchase order** header.

Note: the promised date exists also for **purchase order** line instead

## What is expected behavior?
With a vendor selected and consolidate flag selected it will should be
generated for one purchase