### PR TITLE
Issue #3309 - Refactoring part 1: Move a utility function to TimeUtil

### DIFF
--- a/base/src/org/compiere/util/TimeUtil.java
+++ b/base/src/org/compiere/util/TimeUtil.java
@@ -16,11 +16,15 @@
  *****************************************************************************/
 package org.compiere.util;
 
+import static java.util.Objects.requireNonNull;
+
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.BitSet;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.Objects;
+import java.util.TimeZone;
 
 import org.compiere.model.MCalendar;
 
@@ -1354,4 +1358,19 @@ public class TimeUtil
         //	Value
         return weeks;
 	}
+	
+	/**
+	 * Get the year (GMT) as an int.
+	 * @param date a Timestamp. Not null.
+	 * @return year as an int
+	 */
+    public static int getYearFromTimestamp(Timestamp date) {
+
+        Timestamp time = requireNonNull(date);
+        Calendar todayCal = Calendar.getInstance();
+        todayCal.setTimeZone(TimeZone.getTimeZone("GMT"));
+        todayCal.setTimeInMillis(time.getTime());
+        return todayCal.get(Calendar.YEAR);
+
+    }
 }	//	TimeUtil

--- a/base/test/src/org/compiere/util/TimeUtilTest.java
+++ b/base/test/src/org/compiere/util/TimeUtilTest.java
@@ -577,4 +577,39 @@ class TimeUtilTest extends CommonUnitTestSetup {
 
     }
 
+    static Stream<Arguments> dateToYearProvider() {
+
+        return Stream.of(
+
+                arguments(1970, 01, 01),
+                arguments(2001, 12, 31),
+                arguments(2010, 05, 10));
+
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateToYearProvider")
+    void getYearFromTimestamp(int yr, int m, int d) {
+
+        assertEquals(yr,
+                TimeUtil.getYearFromTimestamp(TimeUtil.getDay(yr, m, d)));
+
+    }
+
+    @Test
+    void whenPassedNull_getYearFromTimestampThrowsNPE() {
+
+        assertThrows(NullPointerException.class, () -> {
+            TimeUtil.getYearFromTimestamp(null);
+        });
+
+    }
+
+    @Test
+    void whenPassedZero_getYearFromTimestampReturns1970() {
+
+        assertEquals(1970, TimeUtil.getYearFromTimestamp(new Timestamp(0)));
+
+    }
+
 }


### PR DESCRIPTION
Related to the GardenWorldCleanup refactoring, this moves a method from GardenWorldCleanup into the TimeUtil class.  Tests are included.