### PR TITLE
Issue #3309 - Refactoring part 2: Move knowledge of the Doc classes to the Doc Classes

### DIFF
--- a/base/src/org/compiere/acct/Doc_BankStatement.java
+++ b/base/src/org/compiere/acct/Doc_BankStatement.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 
+import org.compiere.model.I_C_BankStatement;
 import org.compiere.model.MAccount;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MBankAccount;
@@ -301,4 +302,9 @@ public class Doc_BankStatement extends Doc
 		return ba.getAD_Org_ID();
 	}	//	getBank_Org_ID
 
+	public static String getDateAcctColumnName() {
+	    
+	    return I_C_BankStatement.COLUMNNAME_StatementDate;
+	    
+	}
 }   //  Doc_Bank

--- a/base/src/org/compiere/acct/Doc_Inventory.java
+++ b/base/src/org/compiere/acct/Doc_Inventory.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 
+import org.compiere.model.I_M_Inventory;
 import org.compiere.model.MAccount;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MCostDetail;
@@ -27,6 +28,7 @@ import org.compiere.model.MInventory;
 import org.compiere.model.MInventoryLine;
 import org.compiere.model.ProductCost;
 import org.compiere.util.Env;
+import org.eevolution.model.I_DD_Order;
 
 /**
  *  Post Inventory Documents.
@@ -238,5 +240,11 @@ public class Doc_Inventory extends Doc
 		facts.add(fact);
 		return facts;
 	}   //  createFact
+
+	   public static String getDateAcctColumnName() {
+	        
+	        return I_M_Inventory.COLUMNNAME_MovementDate;
+	        
+	    }
 
 }   //  Doc_Inventory

--- a/base/src/org/compiere/acct/Doc_Movement.java
+++ b/base/src/org/compiere/acct/Doc_Movement.java
@@ -19,6 +19,8 @@ package org.compiere.acct;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.ArrayList;
+
+import org.compiere.model.I_M_Movement;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MCostDetail;
 import org.compiere.model.MMovement;
@@ -198,4 +200,10 @@ public class Doc_Movement extends Doc
 		facts.add(fact);
 		return facts;
 	}   //  createFact
+	
+	public static String getDateAcctColumnName() {
+	    
+	     return I_M_Movement.COLUMNNAME_MovementDate;
+	}
+	
 }   //  Doc_Movement

--- a/base/src/org/compiere/acct/Doc_Production.java
+++ b/base/src/org/compiere/acct/Doc_Production.java
@@ -22,6 +22,8 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.logging.Level;
 
+import org.compiere.model.I_M_Movement;
+import org.compiere.model.I_M_Production;
 import org.compiere.model.MAccount;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MCost;
@@ -256,6 +258,12 @@ public class Doc_Production extends Doc
 		facts.add(fact);
 		return facts;
 	}   //  createFact
+	
+   public static String getDateAcctColumnName() {
+        
+         return I_M_Production.COLUMNNAME_MovementDate;
+    }
+
 
 	/**
 	 *  Create Facts (the accounting logic) for

--- a/base/src/org/compiere/acct/Doc_ProductionBatch.java
+++ b/base/src/org/compiere/acct/Doc_ProductionBatch.java
@@ -20,6 +20,8 @@ import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 
+import org.compiere.model.I_M_Movement;
+import org.compiere.model.I_M_ProductionBatch;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MProductionBatch;
 import org.compiere.util.Env;
@@ -107,4 +109,10 @@ public class Doc_ProductionBatch extends Doc
 		
 		return facts;
 	} // createFacts
+	
+	public static String getDateAcctColumnName() {
+        
+         return I_M_ProductionBatch.COLUMNNAME_MovementDate;
+    }
+
 } // Doc_ProductionBatch

--- a/base/src/org/compiere/acct/Doc_ProjectIssue.java
+++ b/base/src/org/compiere/acct/Doc_ProjectIssue.java
@@ -23,6 +23,8 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.logging.Level;
 
+import org.compiere.model.I_C_ProjectIssue;
+import org.compiere.model.I_M_Movement;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MCostDetail;
 import org.compiere.model.MProduct;
@@ -264,5 +266,11 @@ public class Doc_ProjectIssue extends Doc
 		}		
 		return retValue;
 	}	//	getLaborCost
+
+	public static String getDateAcctColumnName() {
+        
+         return I_C_ProjectIssue.COLUMNNAME_MovementDate;
+         
+    }
 
 }	//	DocProjectIssue

--- a/base/src/org/compiere/acct/Doc_Requisition.java
+++ b/base/src/org/compiere/acct/Doc_Requisition.java
@@ -21,6 +21,8 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.logging.Level;
 
+import org.compiere.model.I_M_Movement;
+import org.compiere.model.I_M_Requisition;
 import org.compiere.model.MAccount;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MRequisition;
@@ -154,4 +156,11 @@ public class Doc_Requisition extends Doc
 		
 		return facts;
 	} // createFact
+	
+	public static String getDateAcctColumnName() {
+        
+         return I_M_Requisition.COLUMNNAME_DateDoc;
+         
+    }
+
 } // Doc_Requisition

--- a/org.eevolution.manufacturing/src/main/java/base/org/compiere/acct/Doc_DDOrder.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/compiere/acct/Doc_DDOrder.java
@@ -20,10 +20,12 @@ import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 
+import org.compiere.model.I_C_BankStatement;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MDocType;
 import org.compiere.model.MOrder;
 import org.compiere.util.Env;
+import org.eevolution.model.I_DD_Order;
 import org.eevolution.model.MDDOrder;
 
 /**
@@ -78,4 +80,11 @@ public class Doc_DDOrder extends Doc
 	{
 		return new ArrayList<Fact>();
 	}   //  createFact
+	
+   public static String getDateAcctColumnName() {
+        
+        return I_DD_Order.COLUMNNAME_DateOrdered;
+        
+    }
+
 }   //  Doc Cost Collector

--- a/org.eevolution.manufacturing/src/main/java/base/org/compiere/acct/Doc_PPCostCollector.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/compiere/acct/Doc_PPCostCollector.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.compiere.model.I_M_CostElement;
+import org.compiere.model.I_M_Movement;
 import org.compiere.model.MAccount;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MCostDetail;
@@ -32,6 +33,7 @@ import org.compiere.model.ProductCost;
 import org.compiere.model.Query;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
+import org.eevolution.model.I_PP_Cost_Collector;
 import org.eevolution.model.I_PP_Order;
 import org.eevolution.model.MPPCostCollector;
 import org.eevolution.model.RoutingService;
@@ -409,4 +411,10 @@ public class Doc_PPCostCollector extends Doc
 	}
 	
 	private List<MCostDetail> costDetails = null;
+	
+   public static String getDateAcctColumnName() {
+        
+         return I_PP_Cost_Collector.COLUMNNAME_MovementDate;
+    }
+
 }   //  Doc Cost Collector

--- a/org.eevolution.manufacturing/src/main/java/base/org/compiere/acct/Doc_PPOrder.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/compiere/acct/Doc_PPOrder.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MDocType;
 import org.compiere.util.Env;
+import org.eevolution.model.I_PP_Order;
 import org.eevolution.model.MDDOrder;
 import org.eevolution.model.MPPOrder;
 
@@ -76,4 +77,10 @@ public class Doc_PPOrder extends Doc
 	{		
 		return null;
 	}   //  createFact
+	
+	public static String getDateAcctColumnName() {
+	    
+	    return I_PP_Order.COLUMNNAME_DateOrdered;
+	    
+	}
 }   //  Doc Cost Collector

--- a/org.eevolution.manufacturing/src/test/java/base/org/compiere/acct/TestDoc.java
+++ b/org.eevolution.manufacturing/src/test/java/base/org/compiere/acct/TestDoc.java
@@ -1,0 +1,90 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2021 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.compiere.acct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+
+import org.adempiere.test.CommonUnitTestSetup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+@Tag("Doc")
+@Tag("Accounting")
+@DisplayName("Given the Doc class")
+class TestDoc extends CommonUnitTestSetup {
+
+    static Stream<Arguments> tableAndColumnNameProvider() {
+
+        return Stream.of(
+
+                arguments("C_Order", "DateAcct"),
+                arguments("C_BankStatement", "StatementDate"),
+                arguments("DD_Order", "DateOrdered"),
+                arguments("M_Inventory", "MovementDate"),
+                arguments("M_Movement", "MovementDate"),
+                arguments("PP_Cost_Collector", "MovementDate"),
+                arguments("M_Production", "MovementDate"),
+                arguments("M_ProductionBatch", "MovementDate"),
+                arguments("M_ProjectIssue", "MovementDate"),
+                arguments("M_Requisition", "DateDoc"),
+                arguments("PP_Order", "DateOrdered")
+
+        );
+
+    }
+
+    @ParameterizedTest(name="For table {0}, the dateColumn is {1}")
+    @MethodSource("tableAndColumnNameProvider")
+    @DisplayName("When provided a table name, "
+            + "getDateAcctColumnName(tableName) returns the correct column "
+            + "name used for the Fact.DateAcct")
+    final void getDateAcctColumnNameFindsCorrectName(String tableName,
+            String expectedColumnName) {
+
+        assertEquals(expectedColumnName, Doc.getDateAcctColumnName(tableName));
+
+    }
+    
+    @ParameterizedTest
+    @NullAndEmptySource
+    @DisplayName("When provided a null or empty table name, "
+            + "getDateAcctColumnName(tableName) returns null")
+    final void getDateAcctColumnNameFindsCorrectName(String tableName) {
+
+        assertNull(Doc.getDateAcctColumnName(tableName));
+
+    }
+    
+
+    @Test
+    @DisplayName("Then getDateAcctColumnName() returns the "
+            + "default \"DateAcct\" column name")
+    final void testGetDateAcctColumnNameString() {
+
+        assertEquals("DateAcct", Doc.getDateAcctColumnName());
+
+    }
+
+}


### PR DESCRIPTION
The GardenWorldCleanup code needs to know which document columns represent the DateAcct to use when adjusting dates.  Several documents do not use the standard column name DateAcct.  When docs have been added that do not use the standard, the GardenWorldCleanup may not take these dates into account.

This commit reduces model dependencies in GardenWorldCleanup where the code needs to know which columns in the model to use for accounting dates.  This knowledge should be the responsibility of the Doc classes.  Add methods to the Doc class to determine the column name that acts as DateAcct.  Not all documents use the same
column name for this.  The Doc class provides an implementation for the getDateAcctColumnName which child classes can override if required.  Tests for these methods are provided.  The tests were put in the manufacturing model as the tests depend on the manufacturing document classes.