### PR TITLE
Issue #3309 - Refactoring part 3: Add methods to MPeriod to find min and max dates in calendar.

### DIFF
--- a/base/src/org/compiere/model/MPeriod.java
+++ b/base/src/org/compiere/model/MPeriod.java
@@ -735,26 +735,89 @@ public class MPeriod extends X_C_Period
     
 	/**
 	 * Get Calendar for Organization
-	 * @param ctx Context
-	 * @param AD_Org_ID Organization
+	 * @param ctx Context with Client
+	 * @param orgId Organization
 	 * @return
 	 */
-    public static int getC_Calendar_ID(Properties ctx,int AD_Org_ID)
+    public static int getC_Calendar_ID(Properties ctx,int orgId)
     {	
-        int C_Calendar_ID = 0;
-        if (AD_Org_ID != 0)
+        int clientId = Env.getAD_Client_ID(ctx);
+        return getC_Calendar_ID(ctx, clientId, orgId, null);
+    }
+    
+    /**
+     * Get Calendar for Organization
+     * @param ctx Context
+     * @param clientId The AD_Client_ID to use
+     * @param orgId the AD_Org_ID Organization to use
+     * @return
+     */
+    public static int getC_Calendar_ID(Properties ctx,int clientId, int orgId, String trxName)
+    {   
+
+        int calendarId = 0;
+        if (orgId != 0)
         {
-            MOrgInfo info = MOrgInfo.get(ctx, AD_Org_ID, null);
-            C_Calendar_ID = info == null ? 0 : info.getC_Calendar_ID();
+            MOrgInfo info = MOrgInfo.get(ctx, orgId, trxName);
+            calendarId = info == null ? 0 : info.getC_Calendar_ID();
         }
         
-        if (C_Calendar_ID == 0)
+        if (calendarId == 0)
         {
-            MClientInfo cInfo = MClientInfo.get(ctx);
-            C_Calendar_ID = cInfo.getC_Calendar_ID();
+            MClientInfo cInfo = MClientInfo.get(ctx, clientId, trxName);
+            calendarId = cInfo.getC_Calendar_ID();
         }
         
-      return C_Calendar_ID;
+      return calendarId;
     }   //  getC_Calendar_ID
     
+
+    /**
+     * Get the minimum period start date for the calendar for a client and org.
+     * The search will attempt to find a calendar for the organization. If 
+     * none is found the standard client calendar will be used.
+     * @param ctx
+     * @param clientId the AD_Client_ID to use
+     * @param orgId the AD_Org_ID to use.
+     * @param trxName
+     * @return the minimum start date for all periods or null if none found
+     */
+    public static Timestamp getMinPeriodStartDate(Properties ctx, int clientId, int orgId, String trxName) {
+
+        int calendarId = getC_Calendar_ID(ctx, clientId, orgId, trxName);
+        String where = "AD_Client_ID=? AND C_Year_ID IN "
+                + "(SELECT C_Year_ID FROM C_Year WHERE C_Calendar_ID= ?)";
+        return new Query(ctx, I_C_Period.Table_Name, where, trxName)
+                .setOnlyActiveRecords(true)
+                .setParameters(clientId, calendarId)
+                .aggregate(I_C_Period.COLUMNNAME_StartDate, Query.AGGREGATE_MIN,
+                        Timestamp.class);
+
+    }
+
+    /**
+     * Get the maximum period end date for the calendar for a client and org. 
+     * The search will attempt to find a calendar for the organization. If 
+     * none is found the standard client calendar will be used.
+     * @param ctx
+     * @param clientId the AD_Client_ID to use.  This could be different then
+     * the client in the context.
+     * @param orgId the AD_Org_ID to use. An organization in the client or zero.
+     * @param trxName
+     * @return the maximum start date for all periods or null if none found
+     */
+    public static Timestamp getMaxPeriodEndDate(Properties ctx, int clientId, int orgId, String trxName) {
+
+        int calendarId = getC_Calendar_ID(ctx, clientId, orgId, trxName);
+        String where = "AD_Client_ID=? AND C_Year_ID IN "
+                + "(SELECT C_Year_ID FROM C_Year WHERE C_Calendar_ID= ?)";
+
+        return new Query(ctx, I_C_Period.Table_Name, where, trxName)
+                .setOnlyActiveRecords(true)
+                .setParameters(clientId, calendarId)
+                .aggregate(I_C_Period.COLUMNNAME_EndDate, Query.AGGREGATE_MAX,
+                        Timestamp.class);
+
+    }
+
 }	//	MPeriod

--- a/base/test/src/org/compiere/model/IT_MPeriod.java
+++ b/base/test/src/org/compiere/model/IT_MPeriod.java
@@ -1,0 +1,36 @@
+package org.compiere.model;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.sql.Timestamp;
+
+import org.adempiere.test.CommonGWData;
+import org.adempiere.test.CommonSystemSetup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("Model")
+@Tag("MPeriod")
+@DisplayName("Given the MPeriod class and current database")
+class IT_MPeriod extends CommonSystemSetup {
+
+    @Test
+    final void getMinPeriodStartDate_shouldReturnNonNullResult() {
+
+        Timestamp min = MPeriod.getMinPeriodStartDate(ctx,
+                CommonGWData.AD_CLIENT_ID, 0, trxName);
+        assertNotNull(min);
+
+    }
+
+    @Test
+    final void getMaxPeriodEndDate_shouldReturnNotNullResult() {
+
+        Timestamp max = MPeriod.getMaxPeriodEndDate(ctx,
+                CommonGWData.AD_CLIENT_ID, 0, trxName);
+        assertNotNull(max);
+
+    }
+
+}

--- a/org.adempiere.test/src/test/java/org/adempiere/test/CommonSystemSetup.java
+++ b/org.adempiere.test/src/test/java/org/adempiere/test/CommonSystemSetup.java
@@ -1,0 +1,138 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2020 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.adempiere.test;
+
+import static org.adempiere.test.TestUtilities.randomString;
+import static org.compiere.Adempiere.startup;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.sql.Timestamp;
+import java.util.Properties;
+
+import org.compiere.model.MUOM;
+import org.compiere.util.Env;
+import org.compiere.util.Ini;
+import org.compiere.util.TimeUtil;
+import org.compiere.util.Trx;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class CommonSystemSetup extends CommonIntegrationTestUtilities 
+							implements IntegrationTestTag {
+
+	protected static Properties ctx;
+	protected static final int AD_USER_ID = 0;
+	protected static final int AD_CLIENT_ID = 0;
+	protected static final int AD_ORG_ID = 0;
+	protected static final boolean IS_CLIENT = true;
+
+	protected static String trxName = null;
+	protected static Trx trx = null;
+	protected static Savepoint mainSavepoint = null;
+	protected Savepoint testSavepoint = null;
+	protected static Timestamp today = null;
+	
+	@BeforeAll
+	public static void setUpBeforeClass() {
+		
+		today = TimeUtil.getDay(System.currentTimeMillis());
+		ctx = Env.getCtx();
+		ctx.setProperty("#AD_Org_ID", Integer.toString(AD_ORG_ID));
+		ctx.setProperty("#AD_User_ID", Integer.toString(AD_USER_ID));
+		ctx.setProperty("#AD_Client_ID", Integer.toString(AD_CLIENT_ID));
+		ctx.setProperty("#Date", TimeUtil.getDay(System.currentTimeMillis()).toString());
+		ctx.setProperty("#AD_Language", "en");
+
+		Ini.setClient (IS_CLIENT);
+		Ini.loadProperties(false);
+		startup(IS_CLIENT);
+
+		trxName = Trx.createTrxName("TestRun_" + randomString(4));
+		trx = Trx.get(trxName, false);
+		
+		try {
+			mainSavepoint = trx.setSavepoint("AllTests_" + randomString(4));
+		} catch (SQLException e) {
+			fail(e.getMessage());
+		}
+
+	}
+
+	@AfterAll
+	public static void tearDownAfterClass() {
+	
+		try {
+			tryToRollback(mainSavepoint);
+			trx.close();
+		}
+		catch(SQLException e) {
+			fail("Unable to rollback. " + e.getMessage());
+			
+		}
+		finally {
+			trx.close();
+			trx = null;
+			ctx = null;
+		}
+		
+	}
+
+	@BeforeEach
+	public void setUp() {
+
+		try {
+			testSavepoint = trx.setSavepoint("SingleTest_"+randomString(4));
+		} catch (SQLException e) {
+			fail(e.getMessage());
+		}
+		
+	}
+
+	@AfterEach
+	public void tearDown() {
+		
+		try {
+			tryToRollback(testSavepoint);
+		} catch (SQLException e) {
+			fail("Unable to rollback. " + e.getMessage());
+		}	
+		
+	}
+
+	private static void tryToRollback(Savepoint savePoint) throws SQLException {
+		
+		if (trx != null && trx.isActive() && savePoint != null) { 
+			trx.rollback(savePoint);
+		}
+	
+	}
+	
+	public String get_TrxName() {
+	    return trxName;
+	}
+
+    public String getTrxName() {
+        return trxName;
+    }
+
+	public Properties getCtx() {
+	    return ctx;
+	}
+}


### PR DESCRIPTION
Required by the GardenWorldCleanup process, these methods provide a way to find the min/max dates in a calendar.

Update MPeriod getC_Calendar_ID method to allow a different client id to be used.  This is necessary when the System account tries to access calendar dates from other clients.  Used in GardenWorldCleanup as the process is run using the system context.