### PR TITLE
Fixed error with NPE for system reports

### DIFF
--- a/base/src/org/compiere/print/MPrintFormatItem.java
+++ b/base/src/org/compiere/print/MPrintFormatItem.java
@@ -146,7 +146,6 @@ public class MPrintFormatItem extends X_AD_PrintFormatItem
 			return printFormatItem;
 
 		printFormatItem = new Query(ctx , Table_Name , COLUMNNAME_AD_PrintFormatItem_ID + "=?" , trxName)
-				.setClient_ID()
 				.setParameters(printFormatItemId)
 				.first();
 		if (printFormatItem != null && printFormatItem.get_ID() > 0) {


### PR DESCRIPTION
When a print format is created from system and called from a company is
throwed a error NPE:

```Java
Exception in thread "Physical Inventory  IFM-15  ySenih (Compañía
Estándar Admin) @ Compañía Estándar.Organización
[MyAppsServer{192.168.9.63-SEED_TEST-adempiere}]-1032743"
java.lang.NullPointerException
	at org.compiere.print.DataEngine.loadPrintData(DataEngine.java:1061)
	at org.compiere.print.DataEngine.getPrintData(DataEngine.java:237)
	at org.compiere.print.ReportEngine.setPrintData(ReportEngine.java:274)
	at org.compiere.print.ReportEngine.setQuery(ReportEngine.java:246)
	at org.compiere.print.ReportEngine.<init>(ReportEngine.java:157)
	at org.compiere.print.ReportEngine.get(ReportEngine.java:898)
	at org.compiere.print.ReportCtl.startStandardReport(ReportCtl.java:225)
	at org.compiere.print.ReportCtl.start(ReportCtl.java:171)
	at org.compiere.print.ReportCtl.start(ReportCtl.java:105)
	at org.compiere.apps.ProcessCtl.run(ProcessCtl.java:401)
	at java.lang.Thread.run(Thread.java:745)
```

For replicate this error just modify any print format of Sales Order and
change the lines to system report.


Note: please use squash for merge inside trunk
Best regards