### PR TITLE
Set default value for centrally maintained menu

### DIFF
--- a/base/src/org/compiere/model/MMenu.java
+++ b/base/src/org/compiere/model/MMenu.java
@@ -119,8 +119,13 @@ public class MMenu extends X_AD_Menu
 	protected boolean beforeSave (boolean newRecord)
 	{
 		//	Reset info
-		if (isSummary() && getAction() != null)
-			setAction(null);
+		if (isSummary()) {
+			if(getAction() != null) {
+				setAction(null);
+			}
+			//	For Centrally Maintained
+			setIsCentrallyMaintained(false);
+		}
 		String action = getAction();
 		if (action == null)
 			action = "";
@@ -142,38 +147,6 @@ public class MMenu extends X_AD_Menu
 			setAD_Process_ID(0);
 		return true;
 	}	//	beforeSave
-	
-	
-	/**
-	 * 	After Save
-	 *	@param newRecord new
-	 *	@param success success
-	 *	@return success
-	 */
-	//	Yamel Senih [ 9223372036854775807 ]
-	//	Change to PO
-//	protected boolean afterSave (boolean newRecord, boolean success)
-//	{
-//		if (newRecord)
-//			insert_Tree(MTree.TREETYPE_Menu);
-//		return success;
-//	}	//	afterSave
-	//	End Yamel Senih
-
-	/**
-	 * 	After Delete
-	 *	@param success
-	 *	@return deleted
-	 */
-	//	Yamel Senih [ 9223372036854775807 ]
-	//	Change to PO
-//	protected boolean afterDelete (boolean success)
-//	{
-//		if (success)
-//			delete_Tree(MTree.TREETYPE_Menu);
-//		return success;
-//	}	//	afterDelete
-	//	End Yamel Senih
 	
 	/**
 	 *  FR [ 1966326 ]

--- a/migration/393lts-394lts/07670_Add_default_false_for_summary_level_menu.xml
+++ b/migration/393lts-394lts/07670_Add_default_false_for_summary_level_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add default false for summary level menu" ReleaseNo="3.9.4" SeqNo="7670">
+    <Step DBType="ALL" Parse="N" SeqNo="10" StepType="SQL">
+      <SQLStatement>UPDATE AD_Menu SET IsCentrallyMaintained = 'N' WHERE IsSummary = 'Y' AND AD_Client_ID = 0</SQLStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
When a menu is flagged as summary level and also is flagged as centrally
maintained, the translation never is applied for him.

This change only ensure the the summary level is not central maintained

Note: please use squash for merge inside trunk