### PR TITLE
Fixed error with tender type for create payment selection from payment

### DIFF
--- a/base/src/org/compiere/model/MPaySelectionCheck.java
+++ b/base/src/org/compiere/model/MPaySelectionCheck.java
@@ -99,11 +99,10 @@ public final class MPaySelectionCheck extends X_C_PaySelectionCheck
 			paymentRule = PAYMENTRULE_CreditCard;
 		else if (payment.getTenderType().equals(X_C_Payment.TENDERTYPE_DirectDebit))
 			paymentRule = PAYMENTRULE_DirectDebit;
-		else if (payment.getTenderType().equals(X_C_Payment.TENDERTYPE_DirectDeposit))
+		else if (payment.getTenderType().equals(X_C_Payment.TENDERTYPE_DirectDeposit)
+				|| payment.getTenderType().equals(MPayment.TENDERTYPE_MobilePaymentInterbank)
+				|| payment.getTenderType().equals(MPayment.TENDERTYPE_MobilePaymentInterbank))
 			paymentRule = PAYMENTRULE_DirectDeposit;
-	//	else if (payment.getTenderType().equals(MPayment.TENDERTYPE_Check))
-	//		PaymentRule = MPaySelectionCheck.PAYMENTRULE_Check;
-		
 		//	Create new PaySelection
 		MPaySelection paySelection = new MPaySelection(ctx, 0, trxName);
 		paySelection.setC_DocType_ID();

--- a/base/src/org/compiere/model/MPaySelectionCheck.java
+++ b/base/src/org/compiere/model/MPaySelectionCheck.java
@@ -101,7 +101,7 @@ public final class MPaySelectionCheck extends X_C_PaySelectionCheck
 			paymentRule = PAYMENTRULE_DirectDebit;
 		else if (payment.getTenderType().equals(X_C_Payment.TENDERTYPE_DirectDeposit)
 				|| payment.getTenderType().equals(MPayment.TENDERTYPE_MobilePaymentInterbank)
-				|| payment.getTenderType().equals(MPayment.TENDERTYPE_MobilePaymentInterbank))
+				|| payment.getTenderType().equals(MPayment.TENDERTYPE_Zelle))
 			paymentRule = PAYMENTRULE_DirectDeposit;
 		//	Create new PaySelection
 		MPaySelection paySelection = new MPaySelection(ctx, 0, trxName);


### PR DESCRIPTION
When a payment selection is created automatically from Payment (after print) and the payment is created with Zelle or Mobile Payment, the payment rule of payment selection is created as Check instead **Direct Deposit** This pull request just allows create the payment selection with **Direct Deposit** for payments with tender types **Zelle** or **Mobile Payment**

Note: please use squash for merge inside trunk