### PR TITLE
Fixed error with Import ARXML of Print format

### DIFF
--- a/base/src/org/adempiere/pipo/handler/PrintFormatElementHandler.java
+++ b/base/src/org/adempiere/pipo/handler/PrintFormatElementHandler.java
@@ -46,7 +46,6 @@ public class PrintFormatElementHandler extends GenericPOHandler {
 			packOut.setLocalContext(ctx);
 		}
 		//	Task
-		packOut.createGenericPO(document, I_AD_PrintFormat.Table_ID, printFormatId, true, null);
 		List<MPrintFormat> printFormatList = new Query(ctx, I_AD_PrintFormat.Table_Name, "AD_PrintFormat_ID = ? "
 				+ "OR EXISTS(SELECT 1 FROM AD_PrintFormatItem pfi WHERE pfi.AD_PrintFormatChild_ID = AD_PrintFormat.AD_PrintFormat_ID AND pfi.AD_PrintFormat_ID = ?)", null)
 			.setParameters(printFormatId, printFormatId)
@@ -62,6 +61,7 @@ public class PrintFormatElementHandler extends GenericPOHandler {
 				packOut.createGenericPO(document, I_AD_PrintFormatItem.Table_ID, printFormatItem.getAD_PrintFormatItem_ID(), true, null);
 			}
 		}
+		packOut.createGenericPO(document, I_AD_PrintFormat.Table_ID, printFormatId, true, null);
 	}
 	
 	@Override


### PR DESCRIPTION
When a print format is header and line like is **Invoice Header** and the print format is exported as .arxml format. The definition is exported but when is imported in other ADempiere instance the lines are missing.

## Step by Step
- Login inside ADempiere
- Print a invoice
- Export format with format arxml
- Delete exported format in ADempiere
- Import the exported format: Note that the lines are missing

## Expected behavior
The header and lines should be present after import


Note: please use squash for merge inside trunk