### PR TITLE
Fixed error when a Purchase order is voided

### DIFF
--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -2027,7 +2027,26 @@ public class MOrder extends X_C_Order implements DocAction
 		m_processMsg = ModelValidationEngine.get().fireDocValidate(this,ModelValidator.TIMING_BEFORE_VOID);
 		if (m_processMsg != null)
 			return false;
-
+		//	Validate if exists almost a receipt
+		if(!isSOTrx()) {
+			MDocType documentType = MDocType.get(getCtx(), getC_DocType_ID());
+			String docSubTypeSO = documentType.getDocSubTypeSO();
+			if(MDocType.DOCSUBTYPESO_WarehouseOrder.equals(docSubTypeSO)) {
+				createReversals(true);
+			} else {
+				StringBuffer receipts = new StringBuffer();
+				Arrays.asList(getShipments()).forEach(receipt -> {
+					receipts.append(Env.NL);
+					//	Add document no
+					receipts.append(receipt.getDocumentNo());
+				});
+				//	Verify
+				if(receipts.length() > 0) {
+					m_processMsg = "@SQLErrorReferenced@ @M_InOut_ID@ " + receipts.toString();
+					return false;
+				}
+			}
+		}
 		MOrderLine[] lines = getLines(true, MOrderLine.COLUMNNAME_M_Product_ID);
 		for (int i = 0; i < lines.length; i++)
 		{
@@ -2066,7 +2085,7 @@ public class MOrder extends X_C_Order implements DocAction
 		// UnLink All Requisitions
 		MRequisitionLine.unlinkC_Order_ID(getCtx(), get_ID(), get_TrxName());
 		
-		if (!createReversals())
+		if (!createReversals(false))
 			return false;
 		
 		/* globalqss - 2317928 - Reactivating/Voiding order must reset posted */
@@ -2087,10 +2106,10 @@ public class MOrder extends X_C_Order implements DocAction
 	 * 	Create Shipment/Invoice Reversals
 	 * 	@return true if success
 	 */
-	private boolean createReversals()
+	private boolean createReversals(boolean enforcePO)
 	{
 		//	Cancel only Sales 
-		if (!isSOTrx())
+		if (!isSOTrx() && !enforcePO)
 			return true;
 		
 		log.info("createReversals");
@@ -2155,7 +2174,7 @@ public class MOrder extends X_C_Order implements DocAction
 			}
 			else
 			{
-				m_processMsg = "Could not reverse Invoice " + invoice;
+				m_processMsg = "@Error@ " + invoice;
 				return false;
 			}
 			invoice.setDocAction(MInvoice.DOCACTION_None);
@@ -2348,7 +2367,7 @@ public class MOrder extends X_C_Order implements DocAction
 			|| MDocType.DOCSUBTYPESO_WarehouseOrder.equals(DocSubTypeSO)	//	(W)illCall(P)ickup	
 			|| MDocType.DOCSUBTYPESO_POSOrder.equals(DocSubTypeSO))			//	(W)alkIn(R)eceipt
 		{
-			if (!createReversals())
+			if (!createReversals(false))
 				return false;
 		}
 		else


### PR DESCRIPTION
## Step by Step
- Create a Purchase Order
- Create a Receipt from Purchase Order
- Void the PO


## What is wrong?
When the PO is voided, the MM Receipt is completed and exist a deadlock

The PR just add a validation for PO when is void for verify if exist a
receipt.

See the message:
![Screenshot_20210424_123024](https://user-images.githubusercontent.com/2333092/115966217-9f84ec80-a4fa-11eb-834b-fef2d03454af.png)


Note: when a PO is based on **Warehouse Order** the receipt are
automatically reversed

Please merge it with squash