### PR TITLE
Fixed wrong search for concept acct

### DIFF
--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/compiere/acct/Doc_HRProcess.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/compiere/acct/Doc_HRProcess.java
@@ -135,7 +135,7 @@ public class   Doc_HRProcess extends Doc
 			//	Get Concept Account
 			X_HR_Concept_Acct conceptAcct = concept.getConceptAcct(
 					Optional.ofNullable(payrollDocLine.getAccountSchemaId()),
-					Optional.ofNullable(payrollDocLine.getPayrollId()),
+					Optional.ofNullable(process.getHR_Payroll_ID()),
 					Optional.ofNullable(payrollDocLine.getC_BP_Group_ID()));
 
 			if(conceptAcct == null) {
@@ -148,23 +148,23 @@ public class   Doc_HRProcess extends Doc
 				if (conceptAcct.isBalancing()) {
 					MAccount accountBPD = MAccount.getValidCombination (getCtx(), conceptAcct.getHR_Expense_Acct() , getTrxName());
 					FactLine debitLine = fact.createLine(line, accountBPD, getC_Currency_ID(),sumAmount, null);
-					debitLine.setDescription(process.getName() + " " + concept.getValue() + " " + concept.getName());
+					debitLine.setDescription(process.getDocumentNo() + " " + process.getName() + " " + concept.getValue() + " " + concept.getName());
 					debitLine.saveEx();
 					MAccount accountBPC = MAccount.getValidCombination (getCtx(), conceptAcct.getHR_Revenue_Acct() , getTrxName());
 					FactLine creditLine = fact.createLine(line,accountBPC, getC_Currency_ID(),null,sumAmount);
-					creditLine.setDescription(process.getName() + " " + concept.getValue() + " " + concept.getName());
+					creditLine.setDescription(process.getDocumentNo() + " " + process.getName() + " " + concept.getValue() + " " + concept.getName());
 					creditLine.saveEx();
 				} else {
 					if (MHRConcept.ACCOUNTSIGN_Debit.equals(payrollDocLine.getAccountSign())) {
 						MAccount accountBPD = MAccount.getValidCombination (getCtx(), conceptAcct.getHR_Expense_Acct() , getTrxName());
 						FactLine debitLine = fact.createLine(line, accountBPD, getC_Currency_ID(),sumAmount, null);
-						debitLine.setDescription(process.getName() + " " + concept.getValue() + " " + concept.getName());
+						debitLine.setDescription(process.getDocumentNo() + " " + process.getName() + " " + concept.getValue() + " " + concept.getName());
 						debitLine.saveEx();
 						totalDebit = totalDebit.add(sumAmount);
 					} else if (MHRConcept.ACCOUNTSIGN_Credit.equals(payrollDocLine.getAccountSign())) {
 						MAccount accountBPC = MAccount.getValidCombination (getCtx(), conceptAcct.getHR_Revenue_Acct(), getTrxName());
 						FactLine creditLine = fact.createLine(line,accountBPC, getC_Currency_ID(),null,sumAmount);
-						creditLine.setDescription(process.getName() + " " + concept.getValue() + " " + concept.getName());
+						creditLine.setDescription(process.getDocumentNo() + " " + process.getName() + " " + concept.getValue() + " " + concept.getName());
 						creditLine.saveEx();
 						totalCredit = totalCredit.add(sumAmount);
 					}


### PR DESCRIPTION
When a **Payroll Process** is processed and is create facts, the account
from concept is created based on Account Schema, payroll of process and
business partner group.

## What is the problem?
The payroll concept used for search account configuration is based on
line of payroll process but the line just have the payroll defined by
employee for save in historic it.


## What is the expected behavior?
The payroll used for search account from concept should be the running
payroll instead.