### PR TITLE
Add support to data type as mapping from entities

### DIFF
--- a/org.spin.store/src/main/java/org/spin/model/validator/VueStoreFront.java
+++ b/org.spin.store/src/main/java/org/spin/model/validator/VueStoreFront.java
@@ -200,7 +200,7 @@ public class VueStoreFront implements ModelValidator {
 		} else if(type == TYPE_AFTER_DELETE) {
 			if(po instanceof MProduct) {
 				MProduct product = (MProduct) po;
-				ElasticSearchHelper.getInstance().connect().index(Product.newInstance().withProduct(product)).close();
+				ElasticSearchHelper.getInstance().connect().delete(Product.newInstance().withProduct(product)).close();
 			} else if(po instanceof MWCategory) {
 				MWCategory group = (MWCategory) po;
 				ElasticSearchHelper.getInstance().connect().delete(Category.newInstance().withCategoy(group)).close();
@@ -210,19 +210,19 @@ public class VueStoreFront implements ModelValidator {
 			} else if(po instanceof MTax) {
 				MTax tax = (MTax) po;
 				MTaxCategory taxCategory = (MTaxCategory) tax.getC_TaxCategory();
-				ElasticSearchHelper.getInstance().connect().index(TaxCategory.newInstance().withTaxCategory(taxCategory)).close();
+				ElasticSearchHelper.getInstance().connect().delete(TaxCategory.newInstance().withTaxCategory(taxCategory)).close();
 			} else if(po instanceof MAttribute) {
 				MAttribute attribute = (MAttribute) po;
 				ElasticSearchHelper.getInstance().connect().delete(Attribute.newInstance().withAttribute(attribute)).close();
 			} else if(po instanceof MAttributeValue) {
 				MAttributeValue attributeValue = (MAttributeValue) po;
 				MAttribute attribute = (MAttribute) attributeValue.getM_Attribute();
-				ElasticSearchHelper.getInstance().connect().index(Attribute.newInstance().withAttribute(attribute)).close();
+				ElasticSearchHelper.getInstance().connect().delete(Attribute.newInstance().withAttribute(attribute)).close();
 			} else if(po instanceof MAttachment) {
 				MAttachment attachment = (MAttachment) po;
 				if(attachment.getAD_Table_ID() == MProduct.Table_ID) {
 					MProduct product = MProduct.get(attachment.getCtx(), attachment.getRecord_ID());
-					ElasticSearchHelper.getInstance().connect().index(Product.newInstance().withProduct(product)).close();
+					ElasticSearchHelper.getInstance().connect().delete(Product.newInstance().withProduct(product)).close();
 				}
 			} else if(po.get_TableName().equals(I_W_Basket.Table_Name)) {
 				X_W_Basket basket = (X_W_Basket) po;

--- a/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/Attribute.java
+++ b/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/Attribute.java
@@ -146,4 +146,9 @@ public class Attribute implements IPersistenceWrapper {
 	public IPersistenceWrapper withWebStoreId(int webStoreId) {
 		return this;
 	}
+
+	@Override
+	public Map<String, Object> getMapping() {
+		return null;
+	}
 }

--- a/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/ElasticSearch.java
+++ b/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/ElasticSearch.java
@@ -40,6 +40,8 @@ import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.spin.model.MADAppRegistration;
 import org.spin.support.IExternalCache;
@@ -189,6 +191,20 @@ public class ElasticSearch implements IExternalCache, IAppSupport {
 			if(exist(entity)) {
 				return update(entity);
 			}
+			try {
+				GetIndexRequest getRequest = new GetIndexRequest(getCatalogName(entity.getCatalogName()));
+				if(!client.indices().exists(getRequest, RequestOptions.DEFAULT)) {
+					CreateIndexRequest indexDefinition = new CreateIndexRequest(getCatalogName(entity.getCatalogName()));
+					Map<String, Object> mapping = entity.getMapping();
+					if(Optional.ofNullable(mapping).isPresent()) {
+						indexDefinition.mapping(mapping);
+						client.indices().create(indexDefinition, RequestOptions.DEFAULT);
+					}
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			//	Create
 			IndexRequest indexRequest = new IndexRequest(getCatalogName(entity.getCatalogName())).id(entity.getKeyValue()).source(entity.getMap());
 			indexRequest.opType(DocWriteRequest.OpType.CREATE);
 			IndexResponse indexResponse = client.index(indexRequest, RequestOptions.DEFAULT);
@@ -312,6 +328,11 @@ public class ElasticSearch implements IExternalCache, IAppSupport {
 
 				@Override
 				public IPersistenceWrapper withWebStoreId(int webStoreId) {
+					return null;
+				}
+
+				@Override
+				public Map<String, Object> getMapping() {
 					return null;
 				}
 			});

--- a/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/IPersistenceWrapper.java
+++ b/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/IPersistenceWrapper.java
@@ -30,6 +30,12 @@ public interface IPersistenceWrapper {
 	public Map<String, Object> getMap();
 	
 	/**
+	 * Get Mapping of entity using data type
+	 * @return
+	 */
+	public Map<String, Object> getMapping();
+	
+	/**
 	 * Get value of key for index
 	 * @return
 	 */

--- a/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/Product.java
+++ b/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/Product.java
@@ -91,7 +91,6 @@ public class Product implements IPersistenceWrapper {
 			map.put("image", getImageName(product));
 			map.put("sku", product.getSKU());
 			map.put("url_key", getValidValue(product.getName()));
-			map.put("url_path", product.getDescriptionURL());
 			map.put("type_id", getProductTypeFromProduct(product));
 			map.put("price", getPrice(product));
 //		    "special_price": 0,
@@ -126,20 +125,27 @@ public class Product implements IPersistenceWrapper {
 			List<String> categoriesIds = new ArrayList<>();
 			//	Groups
 			List<MWCategory> productGroups = MWCategory.getOfProduct(product.getCtx(), product.getM_Product_ID(), product.get_TrxName());
+			StringBuffer urlPath = new StringBuffer();
 			if(productGroups != null
 					&& productGroups.size() > 0) {
 				productGroups.forEach(group -> {
 					Category wrapperOfGroup = Category.newInstance().withCategoy(group);
-					Map<String, Object> categoryMap = new HashMap<String, Object>();
-					categoryMap.put("id", group.getW_Category_ID());
-					categoryMap.put("name", group.getName());
-					categoryMap.put("slug", wrapperOfGroup.getURLKey(true));
-					categoryMap.put("path", wrapperOfGroup.getURLPath());
+//					categoryMap.put("id", group.getW_Category_ID());
+//					categoryMap.put("category_id", group.getW_Category_ID());
+//					categoryMap.put("name", group.getName());
+//					categoryMap.put("slug", wrapperOfGroup.getURLKey(true));
+//					categoryMap.put("path", wrapperOfGroup.getURLPath());
 					//	Add
-					categories.add(categoryMap);
+					categories.add(wrapperOfGroup.getMap());
 					categoriesIds.add(wrapperOfGroup.getKeyValue());
+					if(urlPath.length() == 0) {
+						urlPath.append(wrapperOfGroup.getURLPath());
+					}
 				});
 			}
+			urlPath.append("/").append(getValidValue(product.getName() + "-" + product.getM_Product_ID())).append(".html");
+			map.put("slug", getValidValue(product.getName() + "-" + product.getM_Product_ID()));
+			map.put("url_path", urlPath.toString());
 			//	Categories
 			map.put("category_ids", categoriesIds);
 			map.put("category", categories);
@@ -413,5 +419,34 @@ public class Product implements IPersistenceWrapper {
 			webStore = MStore.get(product.getCtx(), webStoreId);
 		}
 		return this;
+	}
+
+	@Override
+	public Map<String, Object> getMapping() {
+		Map<String, Object> createdAt = new HashMap<>();
+		createdAt.put("type", "date");
+		createdAt.put("format", ElasticSearch.DATE_FORMAT);
+		Map<String, Object> updatedAt = new HashMap<>();
+		updatedAt.put("type", "date");
+		updatedAt.put("format", ElasticSearch.DATE_FORMAT);
+		Map<String, Object> properties = new HashMap<>();
+		properties.put("created_at", createdAt);
+		properties.put("updated_at", updatedAt);
+		Map<String, Object> slug = new HashMap<>();
+		slug.put("type", "keyword");
+		properties.put("slug", slug);
+		Map<String, Object> urlPath = new HashMap<>();
+		urlPath.put("type", "keyword");
+		properties.put("url_path", urlPath);
+		Map<String, Object> urlKey = new HashMap<>();
+		urlKey.put("type", "keyword");
+		properties.put("url_key", urlKey);
+		Map<String, Object> sku = new HashMap<>();
+		sku.put("type", "keyword");
+		properties.put("sku", sku);
+		//	Return mapping properties
+		Map<String, Object> mapping = new HashMap<>();
+		mapping.put("properties", properties);
+		return mapping;
 	}
 }

--- a/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/TaxCategory.java
+++ b/org.spin.store/src/main/java/org/spin/util/support/elasticsearch/TaxCategory.java
@@ -137,7 +137,7 @@ public class TaxCategory implements IPersistenceWrapper {
 
 	@Override
 	public String getCatalogName() {
-		return "tax_rule";
+		return "taxrule";
 	}
 
 	@Override
@@ -146,5 +146,10 @@ public class TaxCategory implements IPersistenceWrapper {
 			webStore = MStore.get(taxCategory.getCtx(), webStoreId);
 		}
 		return this;
+	}
+
+	@Override
+	public Map<String, Object> getMapping() {
+		return null;
 	}
 }


### PR DESCRIPTION
# What is the problem?
When all data is generated from ADempiere to ElasticSearch, not exist a way for determinate the data type for object and isn necessary run a rebuild based on proxy-adempiere-api. This method is very unuseful because all data type send from ADempiere should be sent with default types like keyword for search or date for sorting based on [ElasticSearch Data Type](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html)