### PR TITLE
Fixed error with Dependent Entities for Record Access

### DIFF
--- a/base/src/org/compiere/model/MRole.java
+++ b/base/src/org/compiere/model/MRole.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Vector;
@@ -39,6 +40,8 @@ import org.adempiere.exceptions.AdempiereException;
 import org.compiere.util.CCache;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
+import org.compiere.util.DependentRecordAccess;
+import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Ini;
 import org.compiere.util.KeyNamePair;
@@ -642,6 +645,8 @@ public final class MRole extends X_AD_Role
 	private MRecordAccess[]			m_recordAccess = null;
 	/** List of Dependent Record Access		*/
 	private MRecordAccess[]			m_recordDependentAccess = null;
+	/**	Dependent Record Access Tables	*/
+	private DependentRecordAccess 	recordAccessTableDefinition = null;
 	
 	/**	Table Data Access Level	*/
 	private HashMap<Integer,String>		m_tableAccessLevel = null;
@@ -664,8 +669,6 @@ public final class MRole extends X_AD_Role
 	private HashMap<Integer,Boolean>	m_formAccess = null;
 	/**	Smart Browse Access				*/
 	private HashMap<Integer,Boolean>	m_browseAccess = null;
-	/**	Info Windows			*/
-	private HashMap<Integer, Boolean>	m_infoAccess = null;
 	/**	DashBoard Browse Access				*/
 	private HashMap<Integer,Boolean>	m_dashboardAccess = null;
 	
@@ -996,41 +999,32 @@ public final class MRole extends X_AD_Role
 	 * 	Load Record Access
 	 *	@param reload reload
 	 */
-	private void loadRecordAccess(boolean reload)
-	{
+	private void loadRecordAccess(boolean reload) {
 		if (!(reload || m_recordAccess == null || m_recordDependentAccess == null))
 			return;
 		ArrayList<MRecordAccess> list = new ArrayList<MRecordAccess>();
 		ArrayList<MRecordAccess> dependent = new ArrayList<MRecordAccess>();
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-		String sql = "SELECT * FROM AD_Record_Access "
-			+ "WHERE AD_Role_ID=? AND IsActive='Y' ORDER BY AD_Table_ID";
-		try
-		{
-			pstmt = DB.prepareStatement(sql, get_TrxName());
-			pstmt.setInt(1, getAD_Role_ID());
-			rs = pstmt.executeQuery();
-			while (rs.next())
-			{
-				MRecordAccess ra = new MRecordAccess(getCtx(), rs, get_TrxName());
-				list.add(ra);
-				if (ra.isDependentEntities())
-					dependent.add(ra);
-			} 
+		String whereClause = "AD_Role_ID=?";
+		if(MColumn.getColumn_ID("AD_Record_Access", "AD_User_ID") != 0) {
+			whereClause = "(AD_Role_ID=? OR AD_User_ID = " + m_AD_User_ID + ")";
 		}
-		catch (Exception e)
-		{
-			log.log(Level.SEVERE, sql, e);
-		}
-		finally
-		{
-			DB.close(rs, pstmt);
-		}
+		//	Add standard access
+		new Query(getCtx(), I_AD_Record_Access.Table_Name, whereClause, get_TrxName())
+			.setParameters(getAD_Role_ID())
+			.setOnlyActiveRecords(true)
+			.setOrderBy(I_AD_Record_Access.COLUMNNAME_AD_Table_ID)
+			.<MRecordAccess>list()
+			.forEach(access -> {
+				list.add(access);
+				if (access.isDependentEntities()) {
+					dependent.add(access);
+				}
+			});	
 		m_recordAccess = new MRecordAccess[list.size()];
 		list.toArray(m_recordAccess);
 		m_recordDependentAccess = new MRecordAccess[dependent.size()];
 		dependent.toArray(m_recordDependentAccess);
+		recordAccessTableDefinition = new DependentRecordAccess(getCtx());
 		log.fine("#" + m_recordAccess.length + " - Dependent #" + m_recordDependentAccess.length); 
 	}	//	loadRecordAccess
 
@@ -2145,8 +2139,10 @@ public final class MRole extends X_AD_Role
 			String TableName = ti[i].getTableName();
 			
 			//[ 1644310 ] Rev. 1292 hangs on start
-			if (TableName.toUpperCase().endsWith("_TRL")) continue;
-			if (isView(TableName)) continue;
+			if (TableName.toUpperCase().endsWith("_TRL")) 
+				continue;
+			if (isView(TableName)) 
+				continue;
 			
 			int AD_Table_ID = getAD_Table_ID (TableName);
 			//	Data Table Access
@@ -2172,7 +2168,8 @@ public final class MRole extends X_AD_Role
 				keyColumnName += ".";
 			}
 			//keyColumnName += TableName + "_ID";	//	derived from table
-			if (getIdColumnName(TableName) == null) continue;
+			if (getIdColumnName(TableName) == null) 
+				continue;
 			keyColumnName += getIdColumnName(TableName); 
 	
 			//log.fine("addAccessSQL - " + TableName + "(" + AD_Table_ID + ") " + keyColumnName);
@@ -2191,6 +2188,7 @@ public final class MRole extends X_AD_Role
 		String whereColumnName = null;
 		ArrayList<Integer> includes = new ArrayList<Integer>();
 		ArrayList<Integer> excludes = new ArrayList<Integer>();
+		Map<Integer, List<Integer>> foreignAccess = new HashMap<>();
 		for (int i = 0; i < m_recordDependentAccess.length; i++)
 		{
 			String columnName = m_recordDependentAccess[i].getKeyColumnName
@@ -2207,48 +2205,154 @@ public final class MRole extends X_AD_Role
 				 MColumn column = table.getColumn(columnName);
 				 if (column == null || column.isVirtualColumn() || !column.isActive())
 					 continue;
-			} else {
-				int posColumn = getIndexOfColumn(mainSql, columnName);
-				if (posColumn == -1)
-					continue;
-				//	we found the column name - make sure it's a column name
-				char charCheck = mainSql.charAt(posColumn-1);	//	before
-				if (!(charCheck == ',' || charCheck == '.' || charCheck == ' ' || charCheck == '('))
-					continue;
-				charCheck = mainSql.charAt(posColumn+columnName.length());	//	after
-				if (!(charCheck == ',' || charCheck == ' ' || charCheck == ')'))
-					continue;
+			} else {				
+				if(!recordAccessTableDefinition.isMatchedForTable(MTable.getTableName(getCtx(), m_recordDependentAccess[i].getAD_Table_ID()), tableName)) {
+					//	Find whole word for SQL instead approximation
+					int posColumn = getIndexOfColumn(mainSql, columnName);
+					if (posColumn == -1)
+						continue;
+					//	we found the column name - make sure it's a column name
+					char charCheck = mainSql.charAt(posColumn-1);	//	before
+					if (!(charCheck == ',' || charCheck == '.' || charCheck == ' ' || charCheck == '('))
+						continue;
+					charCheck = mainSql.charAt(posColumn+columnName.length());	//	after
+					if (!(charCheck == ',' || charCheck == ' ' || charCheck == ')'))
+						continue;
+				} else {
+					List<Integer> currentRecords = foreignAccess.get(m_recordDependentAccess[i].getAD_Table_ID());
+					if(currentRecords == null) {
+						currentRecords = new ArrayList<>();
+					}
+					currentRecords.add(m_recordDependentAccess[i].getRecord_ID());
+					foreignAccess.put(m_recordDependentAccess[i].getAD_Table_ID(), currentRecords);
+				}
 			}
-			//	
-			if (AD_Table_ID != 0 && AD_Table_ID != m_recordDependentAccess[i].getAD_Table_ID()) {
-				retSQL.append(getDependentAccess(whereColumnName, includes, excludes));
-				//	Yamel Senih
-				//	Initialize values when table is changed
-				includes = new ArrayList<Integer>();
-				excludes = new ArrayList<Integer>();
-				//	End Yamel Senih
+			//	All based on reference of column
+			if(foreignAccess.isEmpty()) {
+				if (AD_Table_ID != 0 && AD_Table_ID != m_recordDependentAccess[i].getAD_Table_ID()) {
+					retSQL.append(getDependentAccess(whereColumnName, includes, excludes));
+					//	Yamel Senih
+					//	Initialize values when table is changed
+					includes = new ArrayList<Integer>();
+					excludes = new ArrayList<Integer>();
+					//	End Yamel Senih
+				}
+				
+				AD_Table_ID = m_recordDependentAccess[i].getAD_Table_ID();
+				//	*** we found the column in the main query
+				if (m_recordDependentAccess[i].isExclude())
+				{
+					excludes.add(m_recordDependentAccess[i].getRecord_ID());
+					log.fine("Exclude " + columnName + " - " + m_recordDependentAccess[i]);
+				}
+				else if (!rw || !m_recordDependentAccess[i].isReadOnly())
+				{
+					includes.add(m_recordDependentAccess[i].getRecord_ID());
+					log.fine("Include " + columnName + " - " + m_recordDependentAccess[i]);
+				}
+				whereColumnName = getDependentRecordWhereColumn (mainSql, columnName);
 			}
-			
-			AD_Table_ID = m_recordDependentAccess[i].getAD_Table_ID();
-			//	*** we found the column in the main query
-			if (m_recordDependentAccess[i].isExclude())
-			{
-				excludes.add(m_recordDependentAccess[i].getRecord_ID());
-				log.fine("Exclude " + columnName + " - " + m_recordDependentAccess[i]);
-			}
-			else if (!rw || !m_recordDependentAccess[i].isReadOnly())
-			{
-				includes.add(m_recordDependentAccess[i].getRecord_ID());
-				log.fine("Include " + columnName + " - " + m_recordDependentAccess[i]);
-			}
-			whereColumnName = getDependentRecordWhereColumn (mainSql, columnName);
 		}	//	for all dependent records
 		retSQL.append(getDependentAccess(whereColumnName, includes, excludes));
+		retSQL.append(getDependentAccessOfForeignTables(tableName, foreignAccess));
 		//
 		retSQL.append(orderBy);
 		log.finest(retSQL.toString());
 		return retSQL.toString();
 	}	//	addAccessSQL
+	
+	/**
+	 * Get Access based on references of tables
+	 * @param mainTableName
+	 * @param foreignAccess
+	 * @return
+	 */
+	private String getDependentAccessOfForeignTables(String mainTableName, 
+			Map<Integer, List<Integer>> foreignAccess) {
+		if(foreignAccess.isEmpty()) {
+			return "";
+		}
+		//	
+		StringBuffer where = new StringBuffer();
+		foreignAccess.keySet().forEach(tableId -> {
+			List<Integer> foreignColumnAccess = recordAccessTableDefinition.getColumnIds(MTable.getTableName(getCtx(), tableId), mainTableName);
+			if(foreignColumnAccess != null
+					&& foreignColumnAccess.size() > 0) {
+				foreignColumnAccess.forEach(columnId -> {
+					where.append(getDependentAccessBasedOnForeignTables(mainTableName, columnId, tableId, new ArrayList<Integer>(), foreignAccess.get(tableId)));
+				});
+			}
+		});
+		//	Return where
+		return where.toString();
+	}
+	
+	/**
+	 * 	Get Dependent Access 
+	 *	@param columnId column
+	 *	@param referencedTableId
+	 *	@param includes ids to include
+	 *	@param excludes ids to exclude
+	 *	@return where clause starting with AND or ""
+	 */
+	private String getDependentAccessBasedOnForeignTables(String tableName, int columnId, int referencedTableId, List<Integer> includes, List<Integer> excludes) {
+		//	
+		if (includes.size() == 0 && excludes.size() == 0)
+			return "";
+		if (includes.size() != 0 && excludes.size() != 0)
+			log.warning("Mixing Include and Excluse rules - Will not return values");
+		//	
+		MColumn column = MColumn.get(getCtx(), columnId);
+		MTable table = null;
+		if(DisplayType.isLookup(column.getAD_Reference_ID()) && column.getAD_Reference_Value_ID() > 0) {
+			MRefTable referenceToTable = MRefTable.getById(getCtx(), column.getAD_Reference_Value_ID());
+			table = MTable.get(getCtx(), referenceToTable.getAD_Table_ID());
+		} else {
+			table = MTable.get(getCtx(), column.getColumnName().replaceAll("_ID", ""));
+		}
+		//	Reference
+		MTable referencedTable = MTable.get(getCtx(), referencedTableId);
+		MColumn referencedColumn = referencedTable.getColumn(referencedTable.getTableName() + "_ID");
+		if(referencedColumn == null
+				|| table == null) {
+			return "";
+		}
+		String select = "EXISTS(SELECT 1 FROM " + table.getTableName() 
+				+ " WHERE " + tableName + "." +  column.getColumnName() + " = " + table.getTableName() + "." + table.getTableName() + "_ID AND ";
+		//	
+		StringBuffer where = new StringBuffer(" AND (");
+		if (includes.size() == 1) {
+			where.append(select).append(table.getTableName() + "." + referencedColumn.getColumnName()).append("=").append(includes.get(0));
+		} else if (includes.size() > 1) {
+			where.append(select).append(table.getTableName() + "." + referencedColumn.getColumnName()).append(" IN (");
+			for (int ii = 0; ii < includes.size(); ii++)
+			{
+				if (ii > 0)
+					where.append(",");
+				where.append(includes.get(ii));
+			}
+			where.append(")");
+		}
+		
+		if (excludes.size() == 1) {
+			where.append("NOT ").append(select)
+				.append("(").append(table.getTableName() + "." + referencedColumn.getColumnName()).append("=").append(excludes.get(0)).append(" OR ").append(table.getTableName() + "." + referencedColumn.getColumnName()).append(" IS NULL)");
+		} else if (excludes.size() > 1) {
+			where.append("NOT ").append(select).append(table.getTableName() + "." + referencedColumn.getColumnName()).append(" IN (");
+			for (int ii = 0; ii < excludes.size(); ii++)
+			{
+				if (ii > 0)
+					where.append(",");
+				where.append(excludes.get(ii));
+			}
+			where.append(")");
+		}
+		where.append("))");
+		log.finest(where.toString());
+		return where.toString();
+	}	//	getDependentAccess
+	
+	
 	
 	/**
 	 * Get Index of column from SQL finding with whole word

--- a/base/src/org/compiere/model/MRole.java
+++ b/base/src/org/compiere/model/MRole.java
@@ -2385,10 +2385,11 @@ public final class MRole extends X_AD_Role
 			log.warning("Mixing Include and Excluse rules - Will not return values");
 		
 		StringBuffer where = new StringBuffer(" AND ");
-		if (includes.size() == 1)
-			where.append(whereColumnName).append("=").append(includes.get(0));
-		else if (includes.size() > 1)
-		{
+		if (includes.size() == 1) {
+			where.append("(" + whereColumnName + " IS NULL OR ");
+			where.append(whereColumnName).append("=").append(includes.get(0)).append(")");
+		} else if (includes.size() > 1) {
+			where.append("(").append(whereColumnName).append(" IS NULL OR "); // @Trifon
 			where.append(whereColumnName).append(" IN (");
 			for (int ii = 0; ii < includes.size(); ii++)
 			{
@@ -2396,6 +2397,7 @@ public final class MRole extends X_AD_Role
 					where.append(",");
 				where.append(includes.get(ii));
 			}
+			where.append(")");
 			where.append(")");
 		}
 		else if (excludes.size() == 1)

--- a/base/src/org/compiere/model/MRole.java
+++ b/base/src/org/compiere/model/MRole.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.Vector;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -2349,8 +2350,10 @@ public final class MRole extends X_AD_Role
 	 * @return
 	 */
 	private String getMatchClause(String referencedColumnName, String sourceTableName, String sourceColumnName, List<Integer> ids) {
-		String sourceIdColumn = sourceTableName + "." + sourceTableName + "_ID";
-		StringBuffer whereClause = new StringBuffer("EXISTS(SELECT 1 FROM " + sourceTableName + " WHERE " + sourceIdColumn + " = " + referencedColumnName + " AND ");
+		String uniqAlias = UUID.randomUUID().toString().replaceAll("-", "").replaceAll("[0-9]", "").toLowerCase().substring(0, 4);
+		String sourceIdColumn = uniqAlias + "." + sourceTableName + "_ID";
+		sourceColumnName = sourceColumnName.replace(sourceTableName + ".", uniqAlias + ".");
+		StringBuffer whereClause = new StringBuffer("EXISTS(SELECT 1 FROM " + sourceTableName + " AS " + uniqAlias + " WHERE " + sourceIdColumn + " = " + referencedColumnName + " AND ");
 		if (ids.size() == 1) {
 			whereClause.append(sourceColumnName).append("=").append(ids.get(0));
 		} else if (ids.size() > 1) {

--- a/base/src/org/compiere/util/DependentRecordAccess.java
+++ b/base/src/org/compiere/util/DependentRecordAccess.java
@@ -55,11 +55,12 @@ public class DependentRecordAccess {
 			return;
 		}
 		List<KeyNamePair> referencedColumns = new ArrayList<KeyNamePair>();
-		String whereClause = "EXISTS(SELECT 1 FROM AD_Column c "
+		String whereClause = "AD_Column.ColumnSQL IS NULL "
+				+ "AND EXISTS(SELECT 1 FROM AD_Column c "
 				+ "						LEFT JOIN AD_Ref_Table rt ON(rt.AD_Reference_ID = c.AD_Reference_Value_ID) "
 				+ "						LEFT JOIN AD_Column rc ON(rc.AD_Column_ID = rt.AD_Key) "
 				+ "						LEFT JOIN AD_Table rrt ON(rrt.TableName || '_ID' = c.ColumnName) "
-				+ "						LEFT JOIN AD_Column dtc ON(dtc.AD_Table_ID = COALESCE(rrt.AD_Table_ID, rc.AD_Table_ID)) "
+				+ "						LEFT JOIN AD_Column dtc ON(dtc.AD_Table_ID = COALESCE(rrt.AD_Table_ID, rc.AD_Table_ID) AND dtc.ColumnSQL IS NULL) "
 				+ "						LEFT JOIN AD_Ref_Table rrrt ON(rrrt.AD_Reference_ID = dtc.AD_Reference_Value_ID) "
 				+ "						LEFT JOIN AD_Column rrc ON(rrc.AD_Column_ID = rrrt.AD_Key) "
 				+ "						LEFT JOIN AD_Table errt ON(errt.TableName || '_ID' = dtc.ColumnName) "

--- a/base/src/org/compiere/util/DependentRecordAccess.java
+++ b/base/src/org/compiere/util/DependentRecordAccess.java
@@ -1,0 +1,119 @@
+/****************************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                                 *
+ * This program is free software; you can redistribute it and/or modify it              *
+ * under the terms version 2 or later of the GNU General Public License as published    *
+ * by the Free Software Foundation. This program is distributed in the hope             *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied           *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+ * See the GNU General Public License for more details.                                 *
+ * You should have received a copy of the GNU General Public License along              *
+ * with this program; if not, write to the Free Software Foundation, Inc.,              *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                               *
+ * For the text or an alternative of this public license, you may reach us              *
+ * Copyright (C) 2003-Present E.R.P. Consultores y Asociados, C.A.                      *
+ * All Rights Reserved.                                                                 *
+ * Contributor(s): Yamel Senih www.erpcya.com                                           *
+ ****************************************************************************************/
+package org.compiere.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import org.compiere.model.I_AD_Column;
+import org.compiere.model.MColumn;
+import org.compiere.model.MTable;
+import org.compiere.model.Query;
+
+/**
+ * Add for get tables of accesses
+ * @author Yamel Senih, ysenih@erpya.com, ERPCyA http://www.erpya.com
+ *
+ */
+public class DependentRecordAccess {
+	
+	/**
+	 * default constructor
+	 * @param context
+	 */
+	public DependentRecordAccess(Properties context) {
+		this.context = context;
+	}
+	private Properties context;
+	/**	Map wit tables	*/
+	private Map<String, List<KeyNamePair>> referencedColumnsMap = new HashMap<>();
+	
+	/**
+	 * Load tables, this apply when a record access is configured as dependent entities
+	 */
+	private void loadReferencedTables(String tableName) {
+		if(referencedColumnsMap.containsKey(tableName)) {
+			return;
+		}
+		List<KeyNamePair> referencedColumns = new ArrayList<KeyNamePair>();
+		String whereClause = "EXISTS(SELECT 1 FROM AD_Column c "
+				+ "						LEFT JOIN AD_Ref_Table rt ON(rt.AD_Reference_ID = c.AD_Reference_Value_ID) "
+				+ "						LEFT JOIN AD_Column rc ON(rc.AD_Column_ID = rt.AD_Key) "
+				+ "						LEFT JOIN AD_Table rrt ON(rrt.TableName || '_ID' = c.ColumnName) "
+				+ "						LEFT JOIN AD_Column dtc ON(dtc.AD_Table_ID = COALESCE(rrt.AD_Table_ID, rc.AD_Table_ID)) "
+				+ "						LEFT JOIN AD_Ref_Table rrrt ON(rrrt.AD_Reference_ID = dtc.AD_Reference_Value_ID) "
+				+ "						LEFT JOIN AD_Column rrc ON(rrc.AD_Column_ID = rrrt.AD_Key) "
+				+ "						LEFT JOIN AD_Table errt ON(errt.TableName || '_ID' = dtc.ColumnName) "
+				+ "						WHERE c.AD_Column_ID = AD_Column.AD_Column_ID "
+				+ "						AND (errt.TableName = ? OR errt.AD_Table_ID = ?)"
+				+ ") "
+				+ "AND EXISTS(SELECT 1 FROM AD_Table t "
+				+ "						WHERE t.AD_Table_ID = AD_Column.AD_Table_ID"
+				+ "						AND t.TableName || '_ID' <> AD_Column.ColumnName"
+				+ "						AND ? || '_ID' <> AD_Column.ColumnName)";
+		new Query(context, I_AD_Column.Table_Name, whereClause, null)
+		.setParameters(tableName, MTable.getTable_ID(tableName), tableName)
+			.getIDsAsList().forEach(columnId -> {
+				Optional.ofNullable(MColumn.get(context, columnId)).ifPresent(column -> {
+					referencedColumns.add(new KeyNamePair(column.getAD_Column_ID(), MTable.getTableName(context, column.getAD_Table_ID())));
+				});
+			});
+		//	Put values
+		referencedColumnsMap.put(tableName, referencedColumns);
+	}
+	
+	/**
+	 * Validate if a table match with dependents
+	 * @param accessTableName
+	 * @param tableName
+	 * @return
+	 */
+	public boolean isMatchedForTable(String accessTableName, String tableName) {
+		loadReferencedTables(accessTableName);
+		if(!referencedColumnsMap.containsKey(accessTableName)) {
+			return false;
+		}
+		return referencedColumnsMap.get(accessTableName)
+				.stream()
+				.filter(column -> column.getName().equals(tableName))
+				.findFirst()
+				.isPresent();
+	}
+	
+	/**
+	 * Get Column Ids
+	 * @param accessTableName
+	 * @param tableName
+	 * @return
+	 */
+	public List<Integer> getColumnIds(String accessTableName, String tableName) {
+		loadReferencedTables(accessTableName);
+		if(!referencedColumnsMap.containsKey(accessTableName)) {
+			return null;
+		}
+		return referencedColumnsMap.get(accessTableName)
+				.stream()
+				.filter(column -> column.getName().equals(tableName))
+				.map(column -> column.getKey())
+				.collect(Collectors.toList());
+	}
+}


### PR DESCRIPTION
## What is the bug?
When a record is add to record access for exclude and using dependent
entities flag it work fine for windows but not work for reports.

## Step for reproduce
### Setup Role
- Login into ADempiere as **GardenAdmin** role
- Go to Role
- Lookup **GardenWorld Admin**
- Set to true the flags: **Personal Lock** and **Personal Access**
![Lock](https://user-images.githubusercontent.com/2333092/119857123-4cc79780-bee1-11eb-9661-a0d7ab7d8f54.gif)
- Re-Login
### Recreate Bug
- Login into ADempiere as **GardenAdmin** role
- Go to **Document Type**
- Lookup **POS Order** record
- On Tool Bar press **Ctrl** + **Lock Button**
- On Record Access Dialog:
  - Press new record
  - Set flag **Exclude** and **Dependent Entities** to true
  - Press **Ok** button
- Logout
- Note: If you open **Sales Order** window you can see 5 Orders:
  - 3 as **POS Order**
  - 1 as **On Credit Orde**
  - 1 as **Standard Order**
![Screenshot_20210527_113652](https://user-images.githubusercontent.com/2333092/119857168-59e48680-bee1-11eb-990a-c9f780079611.png)
### Verify Bug
- Login into ADempiere as **Garden User**
- Go to **Sales Order** window, now you can see only:
  - 1 as **On Credit Orde**
  - 1 as **Standard Order**
 ![Screenshot_20210527_113958](https://user-images.githubusercontent.com/2333092/119857214-61a42b00-bee1-11eb-9327-0cc4fab88437.png)
- Go to **Quote-to-Invoice** -> **Sales Orders** -> **Order Detail**
- Set flag **Sales Transaction** to true
- Run report
- Open Print Format and remove **Document Type** column
- Note that you can see 5 **Sales Orders** instead 2
