### PR TITLE
Bad reference for price list create process

### DIFF
--- a/base/src/org/compiere/process/M_PriceList_Create.java
+++ b/base/src/org/compiere/process/M_PriceList_Create.java
@@ -375,8 +375,8 @@ public class M_PriceList_Create extends M_PriceList_CreateAbstract {
 						combinationMap.put(productPurchasing.getM_Product_ID(), 
 								new ProductCombination(productPurchasing.getM_Product_ID(), 
 										conversionRate, 
-										productPurchasing.getPriceList(), 
-										productPurchasing.getPriceList(), 
+										productPurchasing.getPricePO(), 
+										productPurchasing.getPricePO(), 
 										productPurchasing.getPricePO(), 
 										discountSchemaLine));
 					});

--- a/base/src/org/compiere/process/M_PriceList_Create.java
+++ b/base/src/org/compiere/process/M_PriceList_Create.java
@@ -375,7 +375,7 @@ public class M_PriceList_Create extends M_PriceList_CreateAbstract {
 						combinationMap.put(productPurchasing.getM_Product_ID(), 
 								new ProductCombination(productPurchasing.getM_Product_ID(), 
 										conversionRate, 
-										productPurchasing.getPricePO(), 
+										productPurchasing.getPriceList(), 
 										productPurchasing.getPricePO(), 
 										productPurchasing.getPricePO(), 
 										discountSchemaLine));
@@ -540,9 +540,21 @@ public class M_PriceList_Create extends M_PriceList_CreateAbstract {
 		public ProductCombination(int productId, BigDecimal conversionRate, BigDecimal priceList, BigDecimal priceStandard, BigDecimal priceLimit, MDiscountSchemaLine discountSchemaLine) {
 			this.productId = productId;
 			this.conversionRate = conversionRate;
-			this.priceList = Optional.ofNullable(priceList).orElse(Env.ZERO);
-			this.priceStandard = Optional.ofNullable(priceStandard).orElse(Env.ZERO);
-			this.priceLimit = Optional.ofNullable(priceLimit).orElse(Env.ZERO);
+			BigDecimal defaultPrice = Optional.ofNullable(priceList).orElseGet(() -> {
+				//	Standard
+				if(Optional.ofNullable(priceStandard).isPresent()) {
+					return priceStandard;
+				}
+				//	Limit
+				if(Optional.ofNullable(priceLimit).isPresent()) {
+					return priceLimit;
+				}
+				//	Default
+				return Env.ZERO;
+			});
+			this.priceList = Optional.ofNullable(priceList).orElse(defaultPrice);
+			this.priceStandard = Optional.ofNullable(priceStandard).orElse(defaultPrice);
+			this.priceLimit = Optional.ofNullable(priceLimit).orElse(defaultPrice);
 			this.discountSchemaLine = discountSchemaLine;
 		}
 		


### PR DESCRIPTION
When the process "Create Product Price" on Price List Version is runned
using a price list discount schema based on Product PO, the price used
for calculate is the **Price List** instead **Price PO**. This have a
problem because the real price is based on Price PO instead Price List
of Product PO.