### PR TITLE
Fixed error with File Storage for process

### DIFF
--- a/base/src/org/spin/process/SetupFileStorageSystem.java
+++ b/base/src/org/spin/process/SetupFileStorageSystem.java
@@ -85,10 +85,10 @@ public class SetupFileStorageSystem extends SetupFileStorageSystemAbstract {
 										try {
 											AttachmentUtil.getInstance(getCtx())
 												.withData(entry.getData())
-												.withFileHandlerId(getFileHandlerId())
 												.withAttachmentId(attachmentPair.getKey())
 												.withFileName(entry.getName())
 												.withDescription(Msg.getMsg(getCtx(), "CreatedFromSetupExternalStorage"))
+												.withFileHandlerId(getFileHandlerId())
 												.saveAttachment();
 											addLog(entry.getName() + ": @Ok@");
 											processed.incrementAndGet();
@@ -124,10 +124,10 @@ public class SetupFileStorageSystem extends SetupFileStorageSystemAbstract {
 						try {
 							AttachmentUtil.getInstance(getCtx())
 								.withData(image.getData())
-								.withFileHandlerId(getFileHandlerId())
 								.withImageId(image.getAD_Image_ID())
 								.withFileName(image.getName())
 								.withDescription(Msg.getMsg(getCtx(), "CreatedFromSetupExternalStorage"))
+								.withFileHandlerId(getFileHandlerId())
 								.saveAttachment();
 							addLog(image.getName() + ": @Ok@");
 							processed.incrementAndGet();
@@ -159,10 +159,10 @@ public class SetupFileStorageSystem extends SetupFileStorageSystemAbstract {
 							String fileName = archive.getName() + ".pdf";
 							AttachmentUtil.getInstance(getCtx())
 								.withData(archive.getBinaryData())
-								.withFileHandlerId(getFileHandlerId())
 								.withArchiveId(archive.getAD_Archive_ID())
 								.withFileName(fileName)
 								.withDescription(Msg.getMsg(getCtx(), "CreatedFromSetupExternalStorage"))
+								.withFileHandlerId(getFileHandlerId())
 								.saveAttachment();
 							addLog(fileName + ": @Ok@");
 							processed.incrementAndGet();

--- a/base/src/org/spin/process/SetupFileStorageSystem.java
+++ b/base/src/org/spin/process/SetupFileStorageSystem.java
@@ -79,7 +79,8 @@ public class SetupFileStorageSystem extends SetupFileStorageSystemAbstract {
 									int attachmentReferenceId = DB.getSQLValue(get_TrxName(), "SELECT AD_AttachmentReference_ID "
 											+ "FROM AD_AttachmentReference "
 											+ "WHERE AD_Attachment_ID = ? "
-											+ "AND FileName = ?", attachmentPair.getKey(), entry.getName());
+											+ "AND FileName = ? "
+											+ "AND FileHandler_ID = ?", attachmentPair.getKey(), entry.getName(), getAppSupportId());
 									if(attachmentReferenceId < 0) {
 										try {
 											AttachmentUtil.getInstance(getCtx())

--- a/base/src/org/spin/process/SetupFileStorageSystem.java
+++ b/base/src/org/spin/process/SetupFileStorageSystem.java
@@ -115,7 +115,7 @@ public class SetupFileStorageSystem extends SetupFileStorageSystemAbstract {
 		KeyNamePair [] imageArray = DB.getKeyNamePairs("SELECT AD_Image_ID, Name "
 				+ "FROM AD_Image "
 				+ "WHERE AD_Client_ID = ? "
-				+ "AND NOT EXISTS(SELECT 1 FROM AD_AttachmentReference ar WHERE ar.AD_Image_ID = AD_Image.AD_Image_ID)", false, getAD_Client_ID());
+				+ "AND NOT EXISTS(SELECT 1 FROM AD_AttachmentReference ar WHERE ar.AD_Image_ID = AD_Image.AD_Image_ID AND ar.FileHandler_ID = ?)", false, getAD_Client_ID(), getAppSupportId());
 		Arrays.asList(imageArray)
 			.forEach(imagePair -> {
 				Trx.run(new TrxRunnable() {
@@ -149,7 +149,7 @@ public class SetupFileStorageSystem extends SetupFileStorageSystemAbstract {
 		KeyNamePair [] archiveArray = DB.getKeyNamePairs("SELECT AD_Archive_ID, Name "
 				+ "FROM AD_Archive "
 				+ "WHERE AD_Client_ID = ? "
-				+ "AND NOT EXISTS(SELECT 1 FROM AD_AttachmentReference ar WHERE ar.AD_Archive_ID = AD_Archive.AD_Archive_ID)", false, getAD_Client_ID());
+				+ "AND NOT EXISTS(SELECT 1 FROM AD_AttachmentReference ar WHERE ar.AD_Archive_ID = AD_Archive.AD_Archive_ID AND ar.FileHandler_ID = ?)", false, getAD_Client_ID(), getAppSupportId());
 		Arrays.asList(archiveArray)
 			.forEach(archivePair -> {
 				Trx.run(new TrxRunnable() {

--- a/base/src/org/spin/util/AttachmentUtil.java
+++ b/base/src/org/spin/util/AttachmentUtil.java
@@ -107,6 +107,7 @@ public class AttachmentUtil {
 	 */
 	public AttachmentUtil withFileHandlerId(int fileHandlerId) {
 		this.fileHandlerId = fileHandlerId;
+		this.fileHandler = null;
 		return this;
 	}
 	
@@ -176,7 +177,8 @@ public class AttachmentUtil {
 	 */
 	public AttachmentUtil withClientId(int clientId) {
 		this.clientId = clientId;
-		getFileHandlerFromClient();
+		this.fileHandlerId = 0;
+		this.fileHandler = null;
 		return this;
 	}
 	
@@ -290,7 +292,9 @@ public class AttachmentUtil {
 		this.fileName = null;
 		this.description = null;
 		this.note = null;
-		this.transactionName = null; 
+		this.transactionName = null;
+		this.fileHandlerId = 0;
+		this.fileHandler = null;
 		return this;
 	}
 	
@@ -341,6 +345,11 @@ public class AttachmentUtil {
 	 * @return
 	 */
 	public List<String> getFileNameListFromAttachment() {
+		try {
+			getFileHandler();
+		} catch (Exception e) {
+			throw new AdempiereException(e);
+		}
 		List<MADAttachmentReference> list = MADAttachmentReference.getListByAttachmentId(context, fileHandlerId, attachmentId, transactionName);
 		List<String> fileNameList = new ArrayList<String>();
 		if(list != null) {

--- a/base/src/org/spin/util/AttachmentUtil.java
+++ b/base/src/org/spin/util/AttachmentUtil.java
@@ -176,6 +176,7 @@ public class AttachmentUtil {
 	 */
 	public AttachmentUtil withClientId(int clientId) {
 		this.clientId = clientId;
+		getFileHandlerFromClient();
 		return this;
 	}
 	


### PR DESCRIPTION
## Step by step
- Run Process **Setup File Storage for Files System**
- Select a New File Handler
- Run Process
- Logout
- Login
- Run Process **Setup File Storage for Files System** (For other file
handler)

## The bug
When the process is running, all files are ignored.

## What is the problem?
The current file storage is not setted from parameter for reference and
for get stream