### PR TITLE
fix: BP Group getSQlWhere in Forecast Run Create.

### DIFF
--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/model/MPPForecastDefinitionLine.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/model/MPPForecastDefinitionLine.java
@@ -112,12 +112,10 @@ public class MPPForecastDefinitionLine extends X_PP_ForecastDefinitionLine {
 			whereClause.append("=").append(getC_BPartner_ID()).append(" AND ");
 		}
 		if (getC_BP_Group_ID() > 0) {
-			whereClause.append(alias)
-				.append(".")
-				.append(MSalesHistory.COLUMNNAME_C_BP_Group_ID)
-				.append("=")
-				.append(getC_BP_Group_ID())
-				.append(" AND ");
+			whereClause.append(alias).append(".");
+			whereClause.append(MSalesHistory.COLUMNNAME_C_BP_Group_ID);
+			whereClause.append("=").append(getC_BP_Group_ID())
+					.append(" AND ");
 		}
 
 		if (getC_SalesRegion_ID() > 0) {

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/model/MPPForecastDefinitionLine.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/model/MPPForecastDefinitionLine.java
@@ -26,6 +26,10 @@ import org.compiere.util.DB;
  * 
  * @author victor.perez@e-evolution.com , www.e-evolution.com
  * 
+ * @author Edwin Betancourt, EdwinBetanc0urt@outlook.com, ERPCyA http://www.erpcya.com
+ * 		<a href="https://github.com/adempiere/adempiere/issues/3492">
+ * 		@see BR [ 3492 ] The Calculate Forecast process gets the value of C_BP_Group_ID wrong in the where clause.</a>
+ *
  */
 public class MPPForecastDefinitionLine extends X_PP_ForecastDefinitionLine {
 
@@ -108,10 +112,12 @@ public class MPPForecastDefinitionLine extends X_PP_ForecastDefinitionLine {
 			whereClause.append("=").append(getC_BPartner_ID()).append(" AND ");
 		}
 		if (getC_BP_Group_ID() > 0) {
-			whereClause.append(alias).append(".");
-			whereClause.append(MSalesHistory.COLUMNNAME_C_BP_Group_ID);
-			whereClause.append("=").append(getM_Product_Group_ID())
-					.append(" AND ");
+			whereClause.append(alias)
+				.append(".")
+				.append(MSalesHistory.COLUMNNAME_C_BP_Group_ID)
+				.append("=")
+				.append(getC_BP_Group_ID())
+				.append(" AND ");
 		}
 
 		if (getC_SalesRegion_ID() > 0) {


### PR DESCRIPTION
The value of C_BP_Group_ID in the sql where clause is correctly set.

![set_bp_group_fix](https://user-images.githubusercontent.com/20288327/122709782-f7a34b00-d22c-11eb-8b4d-9349084fc48d.png)


fixes https://github.com/adempiere/adempiere/issues/3492