### PR TITLE
Adempiere #3512 reverse accrual uses original movementdate

### DIFF
--- a/base/src/org/compiere/model/MInventory.java
+++ b/base/src/org/compiere/model/MInventory.java
@@ -783,6 +783,7 @@ public class MInventory extends X_M_Inventory implements DocAction, DocumentReve
 		if(dt.isCopyDocNoOnReversal()) {
 			reversal.setDocumentNo(getDocumentNo() + Msg.getMsg(getCtx(), "^"));
 		}
+		reversal.setMovementDate(reversalDate);
 		reversal.setDocStatus(DOCSTATUS_Drafted);
 		reversal.setDocAction(DOCACTION_Complete);
 		reversal.setIsApproved (false);


### PR DESCRIPTION
https://github.com/adempiere/adempiere/issues/3512

Similar to the other document classes reverse accrual should use the current date.