### PR TITLE
Invoice with price list that includes taxes

### DIFF
--- a/base/src/org/compiere/acct/Doc_Invoice.java
+++ b/base/src/org/compiere/acct/Doc_Invoice.java
@@ -50,6 +50,10 @@ import org.compiere.util.Env;
  *  	<li>BF: 2797257	Landed Cost Detail is not using allocation qty
  *  
  *  @version  $Id: Doc_Invoice.java,v 1.2 2006/07/30 00:53:33 jjanke Exp $
+ *
+ *	@author Nicolas Sarlabos, nicolas.sarlabos@openupsolutions.com, http://www.openupsolutions.com
+ *			<li> FR [ 1459 ] Invoice with price list that includes taxes
+ *			@see https://github.com/adempiere/adempiere/issues/1459
  */
 public class Doc_Invoice extends Doc
 {
@@ -166,6 +170,7 @@ public class Doc_Invoice extends Doc
 			docLine.setQty(cm ? Qty.negate() : Qty, invoice.isSOTrx());
 			//
 			BigDecimal LineNetAmt = line.getLineNetAmt();
+			BigDecimal LineTotalAmt = line.getLineTotalAmt();
 			BigDecimal PriceList = line.getPriceList();
 			int C_Tax_ID = docLine.getC_Tax_ID();
 			//	Correct included Tax
@@ -174,9 +179,9 @@ public class Doc_Invoice extends Doc
 				MTax tax = MTax.get(getCtx(), C_Tax_ID);
 				if (!tax.isZeroTax())
 				{
-					BigDecimal LineNetAmtTax = tax.calculateTax(LineNetAmt, true, getStdPrecision());
+					BigDecimal LineNetAmtTax = tax.calculateTax(LineTotalAmt, true, getStdPrecision());
 					log.fine("LineNetAmt=" + LineNetAmt + " - Tax=" + LineNetAmtTax);
-					LineNetAmt = LineNetAmt.subtract(LineNetAmtTax);
+					LineNetAmt = LineTotalAmt.subtract(LineNetAmtTax);
 					for (int t = 0; t < m_taxes.length; t++)
 					{
 						if (m_taxes[t].getC_Tax_ID() == C_Tax_ID)

--- a/base/src/org/compiere/model/MInvoice.java
+++ b/base/src/org/compiere/model/MInvoice.java
@@ -67,6 +67,9 @@ import org.eevolution.model.MPPProductBOMLine;
  *  @author Yamel Senih, ysenih@erpcya.com, ERPCyA http://www.erpcya.com
  *			<a href="https://github.com/adempiere/adempiere/issues/887">
  * 			@see FR [ 887 ] System Config reversal invoice DocNo</a>
+ *	@author Nicolas Sarlabos, nicolas.sarlabos@openupsolutions.com, http://www.openupsolutions.com
+ *			<li> FR [ 1459 ] Invoice with price list that includes taxes
+ *			@see https://github.com/adempiere/adempiere/issues/1459
  */
 public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversalEnabled
 {
@@ -1621,8 +1624,7 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 				invoiceTax.deleteEx(true);
 				invoiceTax.saveEx();
 			} else {
-				if (!isTaxIncluded())
-					grandTotal.getAndUpdate(total -> total.add(invoiceTax.getTaxAmt()));
+				grandTotal.getAndUpdate(total -> total.add(invoiceTax.getTaxAmt()));
 			}
 		});
 		//

--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -69,6 +69,9 @@ import org.eevolution.model.MPPProductBOMLine;
  * @author Yamel Senih, ysenih@erpya.com, ERPCyA http://www.erpya.com
  *		<a href="https://github.com/adempiere/adempiere/issues/1455">
  * 		@see FR [ 1455 ] Add Sales Region to Order and Invoice</a>
+ *	@author Nicolas Sarlabos, nicolas.sarlabos@openupsolutions.com, http://www.openupsolutions.com
+ *			<li> FR [ 1459 ] Invoice with price list that includes taxes
+ *			@see https://github.com/adempiere/adempiere/issues/1459
  */
 public class MOrder extends X_C_Order implements DocAction
 {
@@ -1597,8 +1600,7 @@ public class MOrder extends X_C_Order implements DocAction
 						orderTax.deleteEx(true);
 						orderTax.saveEx();
 					} else {
-						if (!isTaxIncluded())
-							grandTotal.getAndUpdate(total -> total.add(orderTax.getTaxAmt()));
+						grandTotal.getAndUpdate(total -> total.add(orderTax.getTaxAmt()));
 					}
 				});
 		setTotalLines(totalLines.get());

--- a/base/src/org/compiere/process/InvoiceCreateFrom.java
+++ b/base/src/org/compiere/process/InvoiceCreateFrom.java
@@ -40,6 +40,9 @@ import org.compiere.util.Env;
  * 	@author Yamel Senih, ysenih@erpcya.com, ERPCyA http://www.erpcya.com
  *	@author Victor Perez , victor.perez@e-evolution.com, http://e-evolution.com
  *  @version Release 3.8.0
+ *  @author Nicolas Sarlabos, nicolas.sarlabos@openupsolutions.com, http://www.openupsolutions.com
+ *  *			<li> FR [ 1459 ] Invoice with price list that includes taxes
+ *  *			@see https://github.com/adempiere/adempiere/issues/1459
  */
 public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 
@@ -112,6 +115,10 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 				MOrderLine orderLine = new MOrderLine (getCtx(), key, get_TrxName());
 				//	Set reference
 				referenceId.set(orderLine.getC_Order_ID());
+				if (invoice.getC_Order_ID() == 0) {
+					MOrder order = (MOrder) orderLine.getC_Order();
+					invoice.setM_PriceList_ID(order.getM_PriceList_ID());
+				}
 				invoiceLine.setOrderLine(orderLine);
 			} else if(createFromType.equals(INVOICE)) {
 				MInvoiceLine fromLine = new MInvoiceLine(getCtx(), key, get_TrxName());

--- a/migration/393lts-394lts/07940_3519_Invoice_with_price_list_that_includes_taxes.xml
+++ b/migration/393lts-394lts/07940_3519_Invoice_with_price_list_that_includes_taxes.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="07940_3519_Invoice_with_price_list_that_includes_taxes" ReleaseNo="3.9.4" SeqNo="7940">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="2235" Table="AD_Column">
+        <Data AD_Column_ID="1692" Column="Callout" isOldNull="true">org.compiere.model.CalloutOrder.amt</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="814" Action="I" Record_ID="50057" Table="AD_UserQuery">
+        <Data AD_Column_ID="14353" Column="Created">2021-07-12 21:48:22.984</Data>
+        <Data AD_Column_ID="14352" Column="IsActive">true</Data>
+        <Data AD_Column_ID="14351" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="14349" Column="AD_UserQuery_ID">50057</Data>
+        <Data AD_Column_ID="14350" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="14356" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="14355" Column="Updated">2021-07-12 21:48:22.984</Data>
+        <Data AD_Column_ID="14358" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="14360" Column="AD_Table_ID">53217</Data>
+        <Data AD_Column_ID="14361" Column="Code">AD_Migration_ID&lt;^&gt;=&lt;^&gt;5000&lt;^&gt;&lt;^&gt;AND&lt;^&gt;&lt;^&gt;</Data>
+        <Data AD_Column_ID="14357" Column="Name">** Last Query **</Data>
+        <Data AD_Column_ID="14354" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="53251" Column="AD_Tab_ID">53233</Data>
+        <Data AD_Column_ID="14359" Column="AD_User_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84456" Column="UUID">fd645bb0-dfd9-4841-a320-691a3158eb68</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="814" Action="I" Record_ID="50058" Table="AD_UserQuery">
+        <Data AD_Column_ID="14353" Column="Created">2021-07-12 21:48:43.188</Data>
+        <Data AD_Column_ID="14352" Column="IsActive">true</Data>
+        <Data AD_Column_ID="14351" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="14349" Column="AD_UserQuery_ID">50058</Data>
+        <Data AD_Column_ID="14350" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="14356" Column="UpdatedBy">0</Data>
+        <Data AD_Column_ID="14355" Column="Updated">2021-07-12 21:48:43.188</Data>
+        <Data AD_Column_ID="14358" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="14360" Column="AD_Table_ID">53217</Data>
+        <Data AD_Column_ID="14361" Column="Code">AD_Migration_ID&lt;^&gt;=&lt;^&gt;50000&lt;^&gt;&lt;^&gt;AND&lt;^&gt;&lt;^&gt;</Data>
+        <Data AD_Column_ID="14357" Column="Name">** Last Query **</Data>
+        <Data AD_Column_ID="14354" Column="CreatedBy">0</Data>
+        <Data AD_Column_ID="53251" Column="AD_Tab_ID">53233</Data>
+        <Data AD_Column_ID="14359" Column="AD_User_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84456" Column="UUID">fdd90237-c341-4dd5-acfd-cdfbec423740</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
 - The system determines if it is a list with tax included by means of a variable that is loaded when saving the head of the invoice, for which the price list to select must have previously marked the check of tax included as appropriate, if it is marked after saving the invoice header will have no effect.

- Tax rates must have the "Document Level" check unmarked
