### PR TITLE
Remove test that trxName be not null from DocumentEngine.postImmediate

### DIFF
--- a/base/src/org/compiere/process/DocumentEngine.java
+++ b/base/src/org/compiere/process/DocumentEngine.java
@@ -1455,7 +1455,6 @@ public class DocumentEngine implements DocAction
         requireNonNull(clientId);
         requireNonNull(tableId);
         requireNonNull(recordId);
-        requireNonNull(trxName);
         
         String tableName = MTable.getTableName(ctx, tableId);
         

--- a/serverRoot/src/test/server/org/compiere/acct/IT_DocumentPosting.java
+++ b/serverRoot/src/test/server/org/compiere/acct/IT_DocumentPosting.java
@@ -46,6 +46,7 @@ import org.adempiere.exceptions.PeriodClosedException;
 import org.adempiere.test.CommonGWData;
 import org.adempiere.test.CommonGWSetup;
 import org.adempiere.test.CommonIntegrationTestUtilities;
+import org.compiere.apps.AEnv;
 import org.compiere.db.CConnection;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.model.MAcctProcessor;
@@ -893,6 +894,50 @@ class IT_DocumentPosting extends CommonGWSetup {
 
             }
 
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Given an existing document "
+            + "and has no errors")
+    class GivenAnExistingDocumentWithNoErrors {
+        
+        private int invoiceId;
+        
+        @BeforeEach
+        void getExistingDocument() {
+            
+            int windowNo = 0;
+            invoiceId = 103;
+            MInvoice existingInvoice = new MInvoice(ctx, invoiceId, null);
+            Env.setContext(ctx, windowNo, "IsSOTrx", existingInvoice.isSOTrx());
+            Env.setContext(ctx, windowNo, "IsApproved", existingInvoice.isApproved());
+            Env.setContext(ctx, windowNo,  "C_Currency_ID", existingInvoice.getC_Currency_ID());
+            
+        }
+        
+        @Test
+        final void whenRepostedFromSwing_postingShouldSucceed() {
+            
+            String error = DocumentEngine.postImmediate(ctx, AD_CLIENT_ID, 
+                    I_C_Invoice.Table_ID, invoiceId, false, null);
+            assertNull(error);
+            MInvoice existingInvoice = new MInvoice(ctx, invoiceId, null);
+            assertTrue(existingInvoice.isPosted());
+            
+        }
+
+        @Test
+        final void whenRepostedFormZK_postingShouldSucceed() {
+            
+            MAcctSchema[] ass = MAcctSchema.getClientAcctSchema(ctx, AD_CLIENT_ID);
+            String error = Doc.postImmediate(ass, I_C_Invoice.Table_ID, invoiceId, false, null);
+
+            assertNull(error);
+            MInvoice existingInvoice = new MInvoice(ctx, invoiceId, null);
+            assertTrue(existingInvoice.isPosted());
+            
         }
 
     }


### PR DESCRIPTION
Fixes #3518.

A null trxName is a valid value.

![SwingDocPosting](https://user-images.githubusercontent.com/5507616/125443935-5745de22-52c3-42b1-8147-2373fc908c14.gif)

![ZKDocPosting](https://user-images.githubusercontent.com/5507616/125443954-0a9d7d8d-df12-4e8f-bea7-0154fcc4e13d.gif)
