### PR TITLE
Add chart support for PA Goal

### DIFF
--- a/base/src/org/adempiere/apps/graph/GraphBuilder.java
+++ b/base/src/org/adempiere/apps/graph/GraphBuilder.java
@@ -17,6 +17,7 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Calendar;
 
+import org.compiere.model.MChart;
 import org.compiere.model.MGoal;
 import org.compiere.model.MMeasure;
 import org.compiere.model.X_PA_Goal;
@@ -58,33 +59,38 @@ public class GraphBuilder {
 	 * @return JFreeChart
 	 */
 	public JFreeChart createChart(String type) {
-		if(X_PA_Goal.CHARTTYPE_BarChart.equals(type))
-		{
-			return createBarChart();
-		}
-		else if (X_PA_Goal.CHARTTYPE_PieChart.equals(type))
-		{
-			return createPieChart();
-		}
-		else if (X_PA_Goal.CHARTTYPE_AreaChart.equals(type))
-		{
-			return createAreaChart();
-		}
-		else if (X_PA_Goal.CHARTTYPE_LineChart.equals(type))
-		{
-			return createLineChart();
-		}
-		else if (X_PA_Goal.CHARTTYPE_RingChart.equals(type))
-		{
-			return createRingChart();
-		}
-		else if (X_PA_Goal.CHARTTYPE_WaterfallChart.equals(type))
-		{
-			return createWaterfallChart();
-		}
-		else
-		{
-			throw new IllegalArgumentException("unknown chart type=" + type);
+		if(m_goal.getAD_Chart_ID() > 0) {
+			MChart chart = new MChart(m_goal.getCtx(), m_goal.getAD_Chart_ID(), m_goal.get_TrxName());
+			return chart.createChart();
+		} else {
+			if(X_PA_Goal.CHARTTYPE_BarChart.equals(type))
+			{
+				return createBarChart();
+			}
+			else if (X_PA_Goal.CHARTTYPE_PieChart.equals(type))
+			{
+				return createPieChart();
+			}
+			else if (X_PA_Goal.CHARTTYPE_AreaChart.equals(type))
+			{
+				return createAreaChart();
+			}
+			else if (X_PA_Goal.CHARTTYPE_LineChart.equals(type))
+			{
+				return createLineChart();
+			}
+			else if (X_PA_Goal.CHARTTYPE_RingChart.equals(type))
+			{
+				return createRingChart();
+			}
+			else if (X_PA_Goal.CHARTTYPE_WaterfallChart.equals(type))
+			{
+				return createWaterfallChart();
+			}
+			else
+			{
+				throw new IllegalArgumentException("unknown chart type=" + type);
+			}
 		}
 	}
 

--- a/base/src/org/compiere/model/I_AD_Chart.java
+++ b/base/src/org/compiere/model/I_AD_Chart.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for AD_Chart
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2
+ *  @version Release 3.9.3
  */
 public interface I_AD_Chart 
 {
@@ -230,19 +230,6 @@ public interface I_AD_Chart
 	  */
 	public String getTimeUnit();
 
-    /** Column name UUID */
-    public static final String COLUMNNAME_UUID = "UUID";
-
-	/** Set Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public void setUUID (String UUID);
-
-	/** Get Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public String getUUID();
-
     /** Column name Updated */
     public static final String COLUMNNAME_Updated = "Updated";
 
@@ -258,6 +245,19 @@ public interface I_AD_Chart
 	  * User who updated this records
 	  */
 	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
 
     /** Column name WinHeight */
     public static final String COLUMNNAME_WinHeight = "WinHeight";

--- a/base/src/org/compiere/model/I_PA_Goal.java
+++ b/base/src/org/compiere/model/I_PA_Goal.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for PA_Goal
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2
+ *  @version Release 3.9.3
  */
 public interface I_PA_Goal 
 {
@@ -40,6 +40,17 @@ public interface I_PA_Goal
     BigDecimal accessLevel = BigDecimal.valueOf(6);
 
     /** Load Meta Data */
+
+    /** Column name AD_Chart_ID */
+    public static final String COLUMNNAME_AD_Chart_ID = "AD_Chart_ID";
+
+	/** Set Chart	  */
+	public void setAD_Chart_ID (int AD_Chart_ID);
+
+	/** Get Chart	  */
+	public int getAD_Chart_ID();
+
+	public org.compiere.model.I_AD_Chart getAD_Chart() throws RuntimeException;
 
     /** Column name AD_Client_ID */
     public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
@@ -305,6 +316,19 @@ public interface I_PA_Goal
 
 	public org.compiere.model.I_PA_ColorSchema getPA_ColorSchema() throws RuntimeException;
 
+    /** Column name PA_Goal_ID */
+    public static final String COLUMNNAME_PA_Goal_ID = "PA_Goal_ID";
+
+	/** Set Goal.
+	  * Performance Goal
+	  */
+	public void setPA_Goal_ID (int PA_Goal_ID);
+
+	/** Get Goal.
+	  * Performance Goal
+	  */
+	public int getPA_Goal_ID();
+
     /** Column name PA_GoalParent_ID */
     public static final String COLUMNNAME_PA_GoalParent_ID = "PA_GoalParent_ID";
 
@@ -319,19 +343,6 @@ public interface I_PA_Goal
 	public int getPA_GoalParent_ID();
 
 	public org.compiere.model.I_PA_Goal getPA_GoalParent() throws RuntimeException;
-
-    /** Column name PA_Goal_ID */
-    public static final String COLUMNNAME_PA_Goal_ID = "PA_Goal_ID";
-
-	/** Set Goal.
-	  * Performance Goal
-	  */
-	public void setPA_Goal_ID (int PA_Goal_ID);
-
-	/** Get Goal.
-	  * Performance Goal
-	  */
-	public int getPA_Goal_ID();
 
     /** Column name PA_Measure_ID */
     public static final String COLUMNNAME_PA_Measure_ID = "PA_Measure_ID";
@@ -376,19 +387,6 @@ public interface I_PA_Goal
 	  */
 	public int getSeqNo();
 
-    /** Column name UUID */
-    public static final String COLUMNNAME_UUID = "UUID";
-
-	/** Set Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public void setUUID (String UUID);
-
-	/** Get Immutable Universally Unique Identifier.
-	  * Immutable Universally Unique Identifier
-	  */
-	public String getUUID();
-
     /** Column name Updated */
     public static final String COLUMNNAME_Updated = "Updated";
 
@@ -404,4 +402,17 @@ public interface I_PA_Goal
 	  * User who updated this records
 	  */
 	public int getUpdatedBy();
+
+    /** Column name UUID */
+    public static final String COLUMNNAME_UUID = "UUID";
+
+	/** Set Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public void setUUID (String UUID);
+
+	/** Get Immutable Universally Unique Identifier.
+	  * Immutable Universally Unique Identifier
+	  */
+	public String getUUID();
 }

--- a/base/src/org/compiere/model/MGoal.java
+++ b/base/src/org/compiere/model/MGoal.java
@@ -530,7 +530,7 @@ public class MGoal extends X_PA_Goal
 	//		setMeasureDisplay(getMeasureScope());
 		
 		//	Measure required if nor Summary
-		if (!isSummary() && getPA_Measure_ID() == 0)
+		if (!isSummary() && getPA_Measure_ID() == 0 && getAD_Chart_ID() == 0)
 		{
 			log.saveError("FillMandatory", Msg.getElement(getCtx(), "PA_Measure_ID"));
 			return false;

--- a/base/src/org/compiere/model/X_AD_Chart.java
+++ b/base/src/org/compiere/model/X_AD_Chart.java
@@ -22,14 +22,14 @@ import java.util.Properties;
 
 /** Generated Model for AD_Chart
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2 - $Id$ */
+ *  @version Release 3.9.3 - $Id$ */
 public class X_AD_Chart extends PO implements I_AD_Chart, I_Persistent 
 {
 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20191120L;
+	private static final long serialVersionUID = 20210713L;
 
     /** Standard Constructor */
     public X_AD_Chart (Properties ctx, int AD_Chart_ID, String trxName)

--- a/base/src/org/compiere/model/X_PA_Goal.java
+++ b/base/src/org/compiere/model/X_PA_Goal.java
@@ -26,14 +26,14 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Model for PA_Goal
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2 - $Id$ */
+ *  @version Release 3.9.3 - $Id$ */
 public class X_PA_Goal extends PO implements I_PA_Goal, I_Persistent 
 {
 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20191120L;
+	private static final long serialVersionUID = 20210713L;
 
     /** Standard Constructor */
     public X_PA_Goal (Properties ctx, int PA_Goal_ID, String trxName)
@@ -84,6 +84,31 @@ public class X_PA_Goal extends PO implements I_PA_Goal, I_Persistent
         .append(get_ID()).append("]");
       return sb.toString();
     }
+
+	public org.compiere.model.I_AD_Chart getAD_Chart() throws RuntimeException
+    {
+		return (org.compiere.model.I_AD_Chart)MTable.get(getCtx(), org.compiere.model.I_AD_Chart.Table_Name)
+			.getPO(getAD_Chart_ID(), get_TrxName());	}
+
+	/** Set Chart.
+		@param AD_Chart_ID Chart	  */
+	public void setAD_Chart_ID (int AD_Chart_ID)
+	{
+		if (AD_Chart_ID < 1) 
+			set_Value (COLUMNNAME_AD_Chart_ID, null);
+		else 
+			set_Value (COLUMNNAME_AD_Chart_ID, Integer.valueOf(AD_Chart_ID));
+	}
+
+	/** Get Chart.
+		@return Chart	  */
+	public int getAD_Chart_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Chart_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
 
 	public org.compiere.model.I_AD_Role getAD_Role() throws RuntimeException
     {
@@ -459,6 +484,29 @@ public class X_PA_Goal extends PO implements I_PA_Goal, I_Persistent
 		return ii.intValue();
 	}
 
+	/** Set Goal.
+		@param PA_Goal_ID 
+		Performance Goal
+	  */
+	public void setPA_Goal_ID (int PA_Goal_ID)
+	{
+		if (PA_Goal_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_PA_Goal_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_PA_Goal_ID, Integer.valueOf(PA_Goal_ID));
+	}
+
+	/** Get Goal.
+		@return Performance Goal
+	  */
+	public int getPA_Goal_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_PA_Goal_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
 	public org.compiere.model.I_PA_Goal getPA_GoalParent() throws RuntimeException
     {
 		return (org.compiere.model.I_PA_Goal)MTable.get(getCtx(), org.compiere.model.I_PA_Goal.Table_Name)
@@ -482,29 +530,6 @@ public class X_PA_Goal extends PO implements I_PA_Goal, I_Persistent
 	public int getPA_GoalParent_ID () 
 	{
 		Integer ii = (Integer)get_Value(COLUMNNAME_PA_GoalParent_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
-	}
-
-	/** Set Goal.
-		@param PA_Goal_ID 
-		Performance Goal
-	  */
-	public void setPA_Goal_ID (int PA_Goal_ID)
-	{
-		if (PA_Goal_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_PA_Goal_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_PA_Goal_ID, Integer.valueOf(PA_Goal_ID));
-	}
-
-	/** Get Goal.
-		@return Performance Goal
-	  */
-	public int getPA_Goal_ID () 
-	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_PA_Goal_ID);
 		if (ii == null)
 			 return 0;
 		return ii.intValue();

--- a/client/src/org/adempiere/apps/graph/PAPanel.java
+++ b/client/src/org/adempiere/apps/graph/PAPanel.java
@@ -141,7 +141,7 @@ public class PAPanel extends CPanel implements ActionListener
 	    
 		for (int i = 0; i < java.lang.Math.min(2, m_goals.length); i++)
 		{
-			if (m_goals[i].getMeasure() != null) //MGoal goal = pi.getGoal();
+			if (m_goals[i].getMeasure() != null || m_goals[i].getAD_Chart_ID() > 0) //MGoal goal = pi.getGoal();
 				boxH1.add ( new Graph(m_goals[i]), BorderLayout.SOUTH);
 		}
 	    boxV2.add(boxH1, BorderLayout.SOUTH);
@@ -176,7 +176,7 @@ public class PAPanel extends CPanel implements ActionListener
 			PerformanceIndicator pi = (PerformanceIndicator)e.getSource();
 			log.info(pi.getName());
 			MGoal goal = pi.getGoal();
-			if (goal.getMeasure() != null)
+			if (goal.getMeasure() != null || goal.getAD_Chart_ID() > 0)
 				new PerformanceDetail(goal);
 		}
 	}	//	actionPerformed

--- a/client/src/org/adempiere/apps/graph/ViewPI.java
+++ b/client/src/org/adempiere/apps/graph/ViewPI.java
@@ -138,7 +138,7 @@ implements FormPanel, ActionListener
 			PerformanceIndicator pi = (PerformanceIndicator)e.getSource();
 			log.info(pi.getName());
 			MGoal goal = pi.getGoal();
-			if (goal.getMeasure() != null)
+			if (goal.getMeasure() != null || goal.getAD_Chart_ID() > 0)
 				new PerformanceDetail(goal);
 		}
 	}	//	actionPerformed

--- a/db/ddlutils/oracle/views/RV_C_SALESDASHBOARD.sql
+++ b/db/ddlutils/oracle/views/RV_C_SALESDASHBOARD.sql
@@ -10,5 +10,6 @@ CREATE OR REPLACE VIEW rv_c_salesdashboard AS
     isactive,
     ad_user_id,
     name,
-    0 AS salespipeline
+    0 AS salespipeline,
+    uuid
    FROM ad_user;

--- a/db/ddlutils/postgresql/views/RV_C_SALESDASHBOARD.sql
+++ b/db/ddlutils/postgresql/views/RV_C_SALESDASHBOARD.sql
@@ -10,5 +10,6 @@ CREATE OR REPLACE VIEW rv_c_salesdashboard AS
     isactive,
     ad_user_id,
     name,
-    0 AS salespipeline
+    0 AS salespipeline,
+    uuid
    FROM ad_user;

--- a/migration/393lts-394lts/07940_Add_support_to_Chart_for_PA_Goal.xml
+++ b/migration/393lts-394lts/07940_Add_support_to_Chart_for_PA_Goal.xml
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add support to Chart for PA Goal" ReleaseNo="3.9.4" SeqNo="7940">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="I" Record_ID="99008" Table="AD_Column">
+        <Data AD_Column_ID="112" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="120" Column="IsParent">false</Data>
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn">true</Data>
+        <Data AD_Column_ID="6483" Column="IsSyncDatabase">N</Data>
+        <Data AD_Column_ID="119" Column="IsKey">false</Data>
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="56352" Column="FormatPattern" isNewNull="true"/>
+        <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
+        <Data AD_Column_ID="110" Column="Version">0</Data>
+        <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
+        <Data AD_Column_ID="116" Column="ColumnName">AD_Chart_ID</Data>
+        <Data AD_Column_ID="113" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="3360" Column="IsUpdateable">true</Data>
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="11617" Column="IsAlwaysUpdateable">false</Data>
+        <Data AD_Column_ID="128" Column="IsEncrypted">N</Data>
+        <Data AD_Column_ID="54358" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="56187" Column="IsAllowLogging">true</Data>
+        <Data AD_Column_ID="56149" Column="IsAutocomplete">false</Data>
+        <Data AD_Column_ID="68024" Column="IsRange">false</Data>
+        <Data AD_Column_ID="62199" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="127" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="6482" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">440</Data>
+        <Data AD_Column_ID="550" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2608" Column="AD_Element_ID">54268</Data>
+        <Data AD_Column_ID="227" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="115" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="118" Column="FieldLength">22</Data>
+        <Data AD_Column_ID="226" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="552" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84306" Column="UUID">aeb38e95-531c-455b-90ea-c8663b4f151f</Data>
+        <Data AD_Column_ID="3369" Column="AD_Process_ID" isNewNull="true"/>
+        <Data AD_Column_ID="92541" Column="RequiresSync">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isNewNull="true"/>
+        <Data AD_Column_ID="548" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90939" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="549" Column="Created">2021-07-13 11:17:55.973</Data>
+        <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="551" Column="Updated">2021-07-13 11:17:55.973</Data>
+        <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="109" Column="AD_Column_ID">99008</Data>
+        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="111" Column="Name">Chart</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="752" Action="I" Record_ID="99008" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12960" Column="Created">2021-07-13 11:17:59.091</Data>
+        <Data AD_Column_ID="12959" Column="IsActive">true</Data>
+        <Data AD_Column_ID="12952" Column="Updated">2021-07-13 11:17:59.091</Data>
+        <Data AD_Column_ID="12955" Column="AD_Column_ID">99008</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="12957" Column="Name">Chart</Data>
+        <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="12958" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="12956" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84310" Column="UUID">defd86b8-9efd-4c13-9062-1b09261086e0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="99008" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="22">10</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="true">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="101278" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">Chart</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2021-07-13 11:18:24.116</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2021-07-13 11:18:24.116</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo">0</Data>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth">0</Data>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">101278</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">240</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">99008</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">240</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">0</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">367</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">9ee88e92-df82-4b66-b287-c99c5fba42d7</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="101278" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">101278</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84323" Column="UUID">90a084dd-78ea-45f4-8dca-fb5229436bad</Data>
+        <Data AD_Column_ID="672" Column="Created">2021-07-13 11:18:25.052</Data>
+        <Data AD_Column_ID="674" Column="Updated">2021-07-13 11:18:25.052</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="287" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="286" Column="Name">Chart</Data>
+        <Data AD_Column_ID="288" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="101278" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="240">150</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="12775" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="150">160</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="12776" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="160">170</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="90" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="12778" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="170">180</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="100" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="12777" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="180">190</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="110" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="57343" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="190">200</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="120" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="4651" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="200">210</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="130" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="4653" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="210">220</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="140" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="4652" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="220">230</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="150" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="4656" Table="AD_Field">
+        <Data AD_Column_ID="181" Column="SeqNo" oldValue="230">240</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="160" StepType="AD">
+      <PO AD_Table_ID="101" Action="I" Record_ID="99009" Table="AD_Column">
+        <Data AD_Column_ID="112" Column="Description">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="548" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90939" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="549" Column="Created">2021-07-13 11:20:32.994</Data>
+        <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="551" Column="Updated">2021-07-13 11:20:32.994</Data>
+        <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="109" Column="AD_Column_ID">99009</Data>
+        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="111" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="120" Column="IsParent">false</Data>
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
+        <Data AD_Column_ID="6483" Column="IsSyncDatabase" isNewNull="true"/>
+        <Data AD_Column_ID="119" Column="IsKey">false</Data>
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="56352" Column="FormatPattern" isNewNull="true"/>
+        <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
+        <Data AD_Column_ID="110" Column="Version">0</Data>
+        <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
+        <Data AD_Column_ID="116" Column="ColumnName">UUID</Data>
+        <Data AD_Column_ID="113" Column="Help">"A surrogate key in a database is a unique identifier for either an entity in the modeled world or an object in the database. The surrogate key is not derived from application data, unlike a natural (or business) key which is derived from application data. " , According to Wikipedia http://en.wikipedia.org/wiki/Surrogate_key</Data>
+        <Data AD_Column_ID="3360" Column="IsUpdateable">false</Data>
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="11617" Column="IsAlwaysUpdateable">false</Data>
+        <Data AD_Column_ID="128" Column="IsEncrypted">N</Data>
+        <Data AD_Column_ID="54358" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="56187" Column="IsAllowLogging">true</Data>
+        <Data AD_Column_ID="56149" Column="IsAutocomplete">false</Data>
+        <Data AD_Column_ID="68024" Column="IsRange">false</Data>
+        <Data AD_Column_ID="62199" Column="IsAllowCopy">false</Data>
+        <Data AD_Column_ID="127" Column="SeqNo" isNewNull="true"/>
+        <Data AD_Column_ID="6482" Column="EntityType">ECA02</Data>
+        <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">53339</Data>
+        <Data AD_Column_ID="550" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2608" Column="AD_Element_ID">59595</Data>
+        <Data AD_Column_ID="227" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="115" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="118" Column="FieldLength">36</Data>
+        <Data AD_Column_ID="226" Column="AD_Reference_ID">10</Data>
+        <Data AD_Column_ID="552" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84306" Column="UUID">4b929c7c-220b-4415-b386-658565cea46f</Data>
+        <Data AD_Column_ID="3369" Column="AD_Process_ID" isNewNull="true"/>
+        <Data AD_Column_ID="92541" Column="RequiresSync">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="170" StepType="AD">
+      <PO AD_Table_ID="752" Action="I" Record_ID="99009" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12960" Column="Created">2021-07-13 11:20:34.138</Data>
+        <Data AD_Column_ID="12959" Column="IsActive">true</Data>
+        <Data AD_Column_ID="12952" Column="Updated">2021-07-13 11:20:34.138</Data>
+        <Data AD_Column_ID="12955" Column="AD_Column_ID">99009</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="12957" Column="Name">Immutable Universally Unique Identifier</Data>
+        <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="12958" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="12956" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84310" Column="UUID">f865d29a-d58e-44bc-8c28-23a18a4458f5</Data>
+      </PO>
+    </Step>
+    <Step DBType="Postgres" Parse="Y" SeqNo="180" StepType="SQL">
+      <SQLStatement>DROP VIEW rv_c_salesdashboard;
+
+CREATE OR REPLACE VIEW rv_c_salesdashboard AS
+ SELECT ad_client_id,
+    ad_org_id,
+    created,
+    createdby,
+    updated,
+    updatedby,
+    isactive,
+    ad_user_id,
+    name,
+    0 AS salespipeline,
+    uuid
+   FROM ad_user;</SQLStatement>
+      <RollbackStatement>DROP VIEW rv_c_salesdashboard;
+
+CREATE OR REPLACE VIEW rv_c_salesdashboard AS
+ SELECT ad_client_id,
+    ad_org_id,
+    created,
+    createdby,
+    updated,
+    updatedby,
+    isactive,
+    ad_user_id,
+    name,
+    0 AS salespipeline
+   FROM ad_user;</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="Y" SeqNo="190" StepType="SQL">
+      <SQLStatement>DROP VIEW rv_c_salesdashboard;
+
+CREATE OR REPLACE VIEW rv_c_salesdashboard AS
+ SELECT ad_client_id,
+    ad_org_id,
+    created,
+    createdby,
+    updated,
+    updatedby,
+    isactive,
+    ad_user_id,
+    name,
+    0 AS salespipeline,
+    uuid
+   FROM ad_user;</SQLStatement>
+      <RollbackStatement>DROP VIEW rv_c_salesdashboard;
+
+CREATE OR REPLACE VIEW rv_c_salesdashboard AS
+ SELECT ad_client_id,
+    ad_org_id,
+    created,
+    createdby,
+    updated,
+    updatedby,
+    isactive,
+    ad_user_id,
+    name,
+    0 AS salespipeline
+   FROM ad_user;</RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/graph/WPAPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/graph/WPAPanel.java
@@ -86,7 +86,7 @@ public class WPAPanel extends Panel implements EventListener
 			WPerformanceIndicator pi = (WPerformanceIndicator) e.getTarget();
 			log.info(pi.toString());
 			MGoal goal = pi.getGoal();
-			if (goal.getMeasure() != null)
+			if (goal.getMeasure() != null || goal.getAD_Chart_ID() > 0)
 				new WPerformanceDetail(goal);
 		}
 	}


### PR DESCRIPTION
Just add support to charts based on **AD_Chart** table

Is nice this change because can join the current measure with Adaxa
implementation for Charts

See the definition:
![Screenshot_20210713_114708](https://user-images.githubusercontent.com/2333092/125483704-6e42abf0-47dc-45b3-80b3-99c1d984f81d.png)

![Screenshot_20210713_114729](https://user-images.githubusercontent.com/2333092/125483609-9a3fddf2-4414-4f94-9945-576bb5d58046.png)
![Screenshot_20210713_114753](https://user-images.githubusercontent.com/2333092/125483664-daa3ece1-27d4-4568-8295-0f613e39567d.png)

![Screenshot_20210713_114825](https://user-images.githubusercontent.com/2333092/125483745-36a95f72-14ef-4b4d-a56f-d290e1e9c12a.png)

![Screenshot_20210713_114853](https://user-images.githubusercontent.com/2333092/125483963-e7ff439e-0eea-41bc-8afe-635fb7266644.png)
![Screenshot_20210713_114922](https://user-images.githubusercontent.com/2333092/125483967-258fcca0-fc13-40f5-8907-dfeac6b126cf.png)


![Screenshot_20210713_114631](https://user-images.githubusercontent.com/2333092/125483447-50b760b5-aabd-4738-8440-2bad93e943ea.png)
