### PR TITLE
fixed error with create from on current payment

### DIFF
--- a/base/src/org/spin/process/PaymentCreateFromInvoice.java
+++ b/base/src/org/spin/process/PaymentCreateFromInvoice.java
@@ -153,6 +153,8 @@ public class PaymentCreateFromInvoice extends PaymentCreateFromInvoiceAbstract {
 	private void createPayment(int businessPartnerId, int currencyId) {
 		if(getRecord_ID() > 0) {	//	Already exists
 			payment = new MPayment(getCtx(), getRecord_ID(), get_TrxName());
+			remaining = getPayAmt();
+			return;
 		} else {
 			payment = new MPayment(getCtx(), 0, get_TrxName());
 			//	

--- a/base/src/org/spin/process/PaymentCreateFromInvoice.java
+++ b/base/src/org/spin/process/PaymentCreateFromInvoice.java
@@ -153,7 +153,7 @@ public class PaymentCreateFromInvoice extends PaymentCreateFromInvoiceAbstract {
 	private void createPayment(int businessPartnerId, int currencyId) {
 		if(getRecord_ID() > 0) {	//	Already exists
 			payment = new MPayment(getCtx(), getRecord_ID(), get_TrxName());
-			remaining = getPayAmt();
+			remaining = payment.getPayAmt();
 			return;
 		} else {
 			payment = new MPayment(getCtx(), 0, get_TrxName());


### PR DESCRIPTION
When the Smart Browser for create payment from Invoices is nice for
generate payments but when is created over a current payment, all values
are overwrited from parameters

![Screenshot_20210713_122333](https://user-images.githubusercontent.com/2333092/125489305-46e9e3f0-08a4-4e2f-8349-7786fe0932a8.png)
