### PR TITLE
Fixed error after press ok on Bank Statement Matcher

### DIFF
--- a/client/src/org/spin/apps/form/BankStatementMatchController.java
+++ b/client/src/org/spin/apps/form/BankStatementMatchController.java
@@ -77,8 +77,6 @@ public class BankStatementMatchController {
 	private Vector<Vector<Object>> paymentData = new Vector<Vector<Object>>();
 	/**	Account PO	*/
 	private MBankAccount account = null;
-	/**	is available for save	*/
-	private boolean isAvailableForSave = false;
 	/**	Amount From	*/
 	private BigDecimal amtFrom = null;
 	/**	Amount To	*/
@@ -183,22 +181,6 @@ public class BankStatementMatchController {
 	 */
 	public boolean isMatchedMode() {
 		return getMatchedMode() == MODE_MATCHED;
-	}
-	
-	/**
-	 * Set if is available for save
-	 * @param isAvailableForSave
-	 */
-	public void setIsAvailableForSave(boolean isAvailableForSave) {
-		this.isAvailableForSave = isAvailableForSave;
-	}
-	
-	/**
-	 * Is Available for save
-	 * @return
-	 */
-	public boolean isAvailableForSave() {
-		return isAvailableForSave;
 	}
 	
 	/**

--- a/client/src/org/spin/apps/form/VBankStatementMatch.java
+++ b/client/src/org/spin/apps/form/VBankStatementMatch.java
@@ -339,9 +339,6 @@ public class VBankStatementMatch extends BankStatementMatchController
 			changeMessageButton();
 			mainPanel.setCursor(Cursor.getDefaultCursor());
 		} else if(e.getActionCommand().equals(ConfirmPanel.A_OK)) {
-			if(!isAvailableForSave()) {
-				return;
-			}
 			if(ADialog.ask(getWindowNo(), frame.getContainer(), "SaveChanges?", getAskMatchMessage())) {
 				mainPanel.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 				saveData();
@@ -357,7 +354,6 @@ public class VBankStatementMatch extends BankStatementMatchController
 	 */
 	private void refresh() {
 		clear();
-		setIsAvailableForSave(false);
 		getParameters();
 		String message = validateParameters();
 		if(Util.isEmpty(message)) {
@@ -462,7 +458,6 @@ public class VBankStatementMatch extends BankStatementMatchController
 	 */
 	private void loadMatchedPaymentsFromMatch() {
 		Vector<Vector<Object>> matchedPayments = getMatchedPayments();
-		setIsAvailableForSave(matchedPayments != null && !matchedPayments.isEmpty());
 		fillMatchedPayments(matchedPayments);
 	}
 	
@@ -598,9 +593,6 @@ public class VBankStatementMatch extends BankStatementMatchController
 	 *  Save Data
 	 */
 	public void saveData() {
-		if(!isAvailableForSave()) {
-			return;
-		}
 		try {
 			Trx.run(new TrxRunnable() {
 				public void run(String trxName) {

--- a/zkwebui/WEB-INF/src/org/spin/apps/form/WBankStatementMatch.java
+++ b/zkwebui/WEB-INF/src/org/spin/apps/form/WBankStatementMatch.java
@@ -428,9 +428,6 @@ public class WBankStatementMatch extends BankStatementMatchController
 	 *  Save Data
 	 */
 	public void saveData() {
-		if(!isAvailableForSave()) {
-			return;
-		}
 		try {
 			Trx.run(new TrxRunnable() {
 				public void run(String trxName) {
@@ -454,7 +451,6 @@ public class WBankStatementMatch extends BankStatementMatchController
 	 */
 	private void refresh() {
 		clear();
-		setIsAvailableForSave(false);
 		getParameters();
 		String message = validateParameters();
 		if(Util.isEmpty(message)) {
@@ -558,7 +554,6 @@ public class WBankStatementMatch extends BankStatementMatchController
 	 */
 	private void loadMatchedPaymentsFromMatch() {
 		Vector<Vector<Object>> matchedPayments = getMatchedPayments();
-		setIsAvailableForSave(matchedPayments != null && !matchedPayments.isEmpty());
 		fillMatchedPayments(matchedPayments);
 	}
 	


### PR DESCRIPTION
## What is the bug?
The bank statement movements loaded previously should be imported after
press ok button on **Bank Statement Matcher** form when it is open from
**Bank Statement** window

## Step for Reproduce
- Create a new Bank Statement
- Load a Bank Statement Extract from process **Load Bank Statement**
- Open **Bank Statement Matcher** from **Bank Statement** window
- Search the No Matched imported payments
- Press Ok
- The result is nothing
- Note that is almost one payment is matched then all payments are
imported