### PR TITLE
Enlarge length for Description on Order and Invoice

### DIFF
--- a/migration/393lts-394lts/09240_Enlarge_length_for_Description_on_Order_and_Invoice.xml
+++ b/migration/393lts-394lts/09240_Enlarge_length_for_Description_on_Order_and_Invoice.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Enlarge length for Description on Order and Invoice" ReleaseNo="3.9.4" SeqNo="9240">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="3782" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="255">16000</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">Description</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="3839" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="255">16000</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">Description</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="2174" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="255">16000</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">Description</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="2220" Table="AD_Column">
+        <Data AD_Column_ID="118" Column="FieldLength" oldValue="255">16000</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">Description</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Increase size of columns:

- `C_Order.Description`
- `C_OrderLine.Description`
- `C_Invoice.Description`
- `C_InvoiceLine.Description`

This allows define a wide description for clients like services where is
used the sales order with specification of contracts