### PR TITLE
change wrong validation for user on notifier

### DIFF
--- a/base/src/org/spin/queue/notification/DefaultNotifier.java
+++ b/base/src/org/spin/queue/notification/DefaultNotifier.java
@@ -309,7 +309,7 @@ public class DefaultNotifier extends QueueManager {
 			throw new AdempiereException("@Text@ @IsMandatory@");
 		}
 		if(getApplicationType().equals(DefaultNotificationType_UserDefined)
-				&& getUserId() == 0) {
+				&& !getRecipients().stream().filter(recipient -> recipient.getKey() > 0).findFirst().isPresent()) {
 			throw new AdempiereException("@AD_User_ID@ @IsMandatory@");
 		}
 		//	for default

--- a/migration/393lts-394lts/09260_Remove_Mandatory_Account_Name_of_Notification_Recipient.xml
+++ b/migration/393lts-394lts/09260_Remove_Mandatory_Account_Name_of_Notification_Recipient.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Remove Mandatory Account Name of Notification Recipient" ReleaseNo="3.9.4" SeqNo="9260">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="98960" Table="AD_Column">
+        <Data AD_Column_ID="124" Column="IsMandatory" oldValue="true">false</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">AccountName</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
The current validation verify that exists the user for notification if
the notification type is defined as "User Defined".

The problem is that this validation must be by user of recipient instead
user sender