### PR TITLE
Fix root source marked as test source in IntelliJ's adempiere.iml

### DIFF
--- a/adempiere.iml
+++ b/adempiere.iml
@@ -220,7 +220,6 @@
       <sourceFolder url="file://$MODULE_DIR$/org.spin.finance_management/src/main/java/base" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/org.compiere.mobile/WEB-INF/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/org.spin.store/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$" type="java-test-resource" />
     </content>
     <orderEntry type="jdk" jdkName="11" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
In the adempiere.iml file, root source is selected as test source, this PR remove this selection when the project is handled by IntelliJ.
![image](https://user-images.githubusercontent.com/14218144/126844804-8af255c2-aef1-4c2e-be1f-0f39346f5a50.png)
