### PR TITLE
Fix: When the email address is malformed, not log this message

### DIFF
--- a/base/src/org/spin/queue/notification/support/EMailSender.java
+++ b/base/src/org/spin/queue/notification/support/EMailSender.java
@@ -61,6 +61,7 @@ public class EMailSender implements INotification {
 	public void sendNotification(MADNotificationQueue notification) {
 		StringBuffer errorMessage = new StringBuffer();
 		notification.getRecipients().forEach(recipient -> {
+			StringBuffer recipientErrorMessage = new StringBuffer();
 			MClient client = MClient.get(notification.getCtx(), notification.getAD_Client_ID());
 			String eMailFrom = client.getRequestEMail();
 			MUser fromUser = null;
@@ -71,10 +72,10 @@ public class EMailSender implements INotification {
 			EMail email = new EMail(client, eMailFrom, recipient.getAccountName(), notification.getDescription(), notification.getText());
 			if (!email.isValid() && !email.isValid(true)) {
 				log.warning("NOT VALID - " + email);
-				if(errorMessage.length() > 0) {
-					errorMessage.append(Env.NL);
+				if(recipientErrorMessage.length() > 0) {
+					recipientErrorMessage.append(Env.NL);
 				}
-				errorMessage.append("NOT VALID - " + email);
+				recipientErrorMessage.append("NOT VALID - " + email);
 			} else {
 				//	For Custom EMail Server
 				if(fromUser != null && fromUser.getAD_EMailConfig_ID() > 0) {
@@ -103,13 +104,11 @@ public class EMailSender implements INotification {
 		            log.fine("EMail Sent: " + recipient.getAccountName());
 		            recipient.setProcessed(true);
 		        } else {
-		        	if(errorMessage.length() > 0) {
-						errorMessage.append(Env.NL);
+		        	if(recipientErrorMessage.length() > 0) {
+						recipientErrorMessage.append(Env.NL);
 					}
-		        	errorMessage.append("Error: Sending to: " + recipient.getAccountName());
-		        	recipient.setErrorMsg("Error: Sending to: " + recipient.getAccountName());
+		        	recipientErrorMessage.append("Error: Sending to: " + recipient.getAccountName());
 		        }
-				recipient.saveEx();
 				//	Backward compatibility
 				if(recipient.getAD_User_ID() > 0) {
 					X_AD_UserMail userMail = new X_AD_UserMail(notification.getCtx(), 0, notification.get_TrxName());
@@ -125,6 +124,13 @@ public class EMailSender implements INotification {
 					}
 					userMail.saveEx();
 				}
+			}
+			if (recipientErrorMessage.length() > 0) {
+				errorMessage.append(recipientErrorMessage);
+				recipient.setErrorMsg(recipientErrorMessage.toString());
+			}
+			if (recipient.is_Changed()) {
+				recipient.saveEx();
 			}
 		});
 		if(errorMessage.length() > 0) {


### PR DESCRIPTION
Hi @yamelsenih , I see in the EmailSender that when the error is in the address (malformed), the error is not loggined in the ErrorMsg field in AD_NotificationRecipient table.

This PR fix this case and fill the field like this.
![image](https://user-images.githubusercontent.com/14218144/128413522-cc2539d6-21c1-44e1-8d94-f35dbb98e93e.png)
