### PR TITLE
Improve modification indication UX in Swing editor

### DIFF
--- a/client/src/org/compiere/grid/ed/VCellEditor.java
+++ b/client/src/org/compiere/grid/ed/VCellEditor.java
@@ -203,9 +203,10 @@ public final class VCellEditor extends AbstractCellEditor
 	{
 		if (m_table == null)
 			return;
+
 		log.fine(e.getPropertyName() + "=" + e.getNewValue());
-		//
-		((GridTable)m_table.getModel()).setChanged(true);
+
+		m_table.setValueAt(e.getNewValue(), m_table.getEditingRow(), m_table.getEditingColumn());
 	}   //  vetoableChange
 
 	/**

--- a/client/src/org/compiere/grid/ed/VMemo.java
+++ b/client/src/org/compiere/grid/ed/VMemo.java
@@ -20,8 +20,6 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
@@ -50,8 +48,7 @@ import org.compiere.util.Msg;
  *  @author 	Jorg Janke
  *  @version 	$Id: VMemo.java,v 1.2 2006/07/30 00:51:27 jjanke Exp $
  */
-public class VMemo extends CTextArea
-	implements VEditor, KeyListener, FocusListener, ActionListener
+public class VMemo extends CTextArea implements VEditor, KeyListener, ActionListener
 {
 	/**
 	 * 
@@ -113,7 +110,6 @@ public class VMemo extends CTextArea
 		super (fieldLength/80, 50);
 		super.setName(columnName);
 		LookAndFeel.installBorder(this, "TextField.border");
-		this.addFocusListener(this);    //  to activate editor
 
 		//  Create Editor
 		setColumns(displayLength>VString.MAXDISPLAY_LENGTH ? VString.MAXDISPLAY_LENGTH : displayLength);	//  46
@@ -122,7 +118,6 @@ public class VMemo extends CTextArea
 
 		setLineWrap(true);
 		setWrapStyleWord(true);
-		addFocusListener(this);
 		setInputVerifier(new CInputVerifier()); //Must be set AFTER addFocusListener in order to work
 		setMandatory(mandatory);
 		m_columnName = columnName;
@@ -155,7 +150,6 @@ public class VMemo extends CTextArea
 
 	private String		m_columnName;
 	private String		m_oldText = "";
-	private boolean		m_firstChange;
 	/**	Logger			*/
 	private static CLogger log = CLogger.getCLogger(VMemo.class);
 
@@ -167,9 +161,6 @@ public class VMemo extends CTextArea
 	{
 		super.setValue(value);
 		m_oldText = getText();
-		m_firstChange = true;
-		//	Always position Top 
-		setCaretPosition(0);
 	}	//	setValue
 
 	/**
@@ -243,44 +234,12 @@ public class VMemo extends CTextArea
 			setText(m_oldText);
 			return;
 		}
-	}	//	keyReleased
 
-	/**
-	 *	Focus Gained	- Save for Escape
-	 *  @param e
-	 */
-	public void focusGained (FocusEvent e)
-	{
-		log.config(e.paramString());
-		//if (e.getSource() instanceof VMemo)
-		//	requestFocus();
-		//else
-		//	m_oldText = getText();
-	}	//	focusGained
-
-	/**
-	 *	Data Binding to MTable (via GridController)
-	 *  @param e
-	 */
-	public void focusLost (FocusEvent e)
-	{
-		//  Indicate Change
-		log.fine( "focusLost");
-		
-		if (getText() == null && m_oldText == null)
-			return;
-		else if (getText().equals(m_oldText))
-			return;
-		//
-		try
-		{
-			String text = getText();
-			fireVetoableChange(m_columnName, m_oldText, text);
-			//m_oldText = text;  set by setValue();
-			return;
+		try {
+			fireVetoableChange(m_columnName, m_oldText, getText());
+		} catch (PropertyVetoException pve) {
 		}
-		catch (PropertyVetoException pve)	{}
-	}	//	focusLost
+	}	//	keyReleased
 
 	/*************************************************************************/
 

--- a/client/src/org/compiere/grid/ed/VString.java
+++ b/client/src/org/compiere/grid/ed/VString.java
@@ -21,8 +21,6 @@ import java.awt.Component;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -57,8 +55,7 @@ import org.compiere.util.Msg;
  *		<li> FR [ 146 ] Remove unnecessary class, add support for info to specific column
  *		@see https://github.com/adempiere/adempiere/issues/146
  */
-public final class VString extends CTextField
-	implements VEditor, ActionListener, FocusListener
+public final class VString extends CTextField implements VEditor, ActionListener
 {
 	/**
 	 * 
@@ -148,7 +145,6 @@ public final class VString extends CTextField
 
 		this.addKeyListener(this);
 		this.addActionListener(this);
-		this.addFocusListener(this);
 		addMouseListener(new VString_mouseAdapter(this));
 		//	Popup for Editor
 		if (fieldLength > displayLength)
@@ -186,10 +182,6 @@ public final class VString extends CTextField
 	private Obscure				m_obscure = null;
 	private Font				m_stdFont = null;
 	private Font				m_obscureFont = null;
-	/**	Setting new value			*/
-	private volatile boolean	m_setting = false;
-	/**	Field in focus				*/
-	private volatile boolean	m_infocus = false;
 
 	/**	Logger	*/
 	private static CLogger log = CLogger.getCLogger (VString.class);
@@ -205,14 +197,8 @@ public final class VString extends CTextField
 			m_oldText = "";
 		else
 			m_oldText = value.toString();
-		//	only set when not updated here
-		if (m_setting)
-			return;
 		setText (m_oldText);
 		m_initialText = m_oldText;
-		//	If R/O left justify 
-		if (!isEditable() || !isEnabled())
-			setCaretPosition(0);
 	}	//	setValue
 
 	/**
@@ -256,6 +242,11 @@ public final class VString extends CTextField
 		//  ESC
 		if (e.getKeyCode() == KeyEvent.VK_ESCAPE)
 			setText(m_initialText);
+
+		try {
+			fireVetoableChange(m_columnName, m_oldText, getText());
+		} catch (PropertyVetoException pve) {
+		}
 	}	//	keyReleased
 
 	/**
@@ -343,7 +334,7 @@ public final class VString extends CTextField
 	 */
 	public void setText (String text)
 	{
-		if (m_obscure != null && !m_infocus)
+		if (m_obscure != null)
 		{
 			super.setFont(m_obscureFont);
 			super.setText (m_obscure.getObscuredValue(text));
@@ -386,41 +377,6 @@ public final class VString extends CTextField
 	{
 		return this.m_VFormat;
 	}	//	getVFormat
-	
-	/**
-	 * 	Focus Gained.
-	 * 	Enabled with Obscure
-	 *	@param e event
-	 */
-	public void focusGained (FocusEvent e)
-	{
-		m_infocus = true;
-		setText(getText());		//	clear
-	}	//	focusGained
-
-	/**
-	 * 	Focus Lost
-	 * 	Enabled with Obscure
-	 *	@param e event
-	 */
-	public void focusLost (FocusEvent e)
-	{
-		m_setting = true;
-		try
-		{
-			String clear = getText();
-			if (clear.length() > m_fieldLength)
-				clear = clear.substring(0, m_fieldLength);
-			fireVetoableChange (m_columnName, m_oldText, clear);
-		}
-		catch (PropertyVetoException pve)	
-		{
-		}
-		m_setting = false;
-
-		m_infocus = false;
-		setText(getText());		//	obscure
-	}	//	focus Lost
 
 	@Override
 	public void setFont(Font f) {

--- a/client/src/org/compiere/grid/ed/VText.java
+++ b/client/src/org/compiere/grid/ed/VText.java
@@ -20,8 +20,6 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
@@ -51,8 +49,7 @@ import org.compiere.util.Msg;
  *		<li> FR [ 146 ] Remove unnecessary class, add support for info to specific column
  *		@see https://github.com/adempiere/adempiere/issues/146
  */
-public class VText extends CTextArea
-	implements VEditor, KeyListener, ActionListener, FocusListener
+public class VText extends CTextArea implements VEditor, KeyListener, ActionListener
 {
 	/**
 	 * 
@@ -118,7 +115,6 @@ public class VText extends CTextArea
 		if (isReadOnly || !isUpdateable)
 			setReadWrite(false);
 		addKeyListener(this);
-		addFocusListener(this);
 
 		//	Popup
 		addMouseListener(new VText_mouseAdapter(this));
@@ -143,7 +139,6 @@ public class VText extends CTextArea
 	private String				m_columnName;
 	private String				m_oldText;
 	private String				m_initialText;
-	private volatile boolean	m_setting = false;
 	private GridField m_mField;
 
 	/**
@@ -156,12 +151,8 @@ public class VText extends CTextArea
 			m_oldText = "";
 		else
 			m_oldText = value.toString();
-		if (m_setting)
-			return;
 		super.setValue(m_oldText);
 		m_initialText = m_oldText;
-		//	Always position Top 
-		setCaretPosition(0);
 	}	//	setValue
 
 	/**
@@ -237,6 +228,11 @@ public class VText extends CTextArea
 		//  ESC
 		if (e.getKeyCode() == KeyEvent.VK_ESCAPE)
 			setText(m_initialText);
+
+		try {
+			fireVetoableChange(m_columnName, m_oldText, getText());
+		} catch (PropertyVetoException pve) {
+		}
 	}	//	keyReleased
 
 	/**
@@ -254,20 +250,4 @@ public class VText extends CTextArea
 	public GridField getField() {
 		return m_mField;
 	}
-	
-	@Override
-	public void focusGained(FocusEvent e) {
-	}
-
-	@Override
-	public void focusLost(FocusEvent e) {
-		m_setting = true;
-		try
-		{
-			fireVetoableChange(m_columnName, m_oldText, getText());
-		}
-		catch (PropertyVetoException pve)	{}
-		m_setting = false;
-	}
-
 }	//	VText


### PR DESCRIPTION
Instead of indicating that data is modified only when focus is out of editor, this commit try to mark modification immediately after text in editor is changed.

With this change, user can type <F4> or click Save icon directly to save data after text editing is finished, without having to move focus out of editor.

BTW: I have only tested VString and VText, not sure where VMemo is used, may someone give me a hint?

Before:

![before](https://user-images.githubusercontent.com/517130/131206916-9fb92470-e644-4a06-ae0e-e2ba4463d442.gif)

After:

![after](https://user-images.githubusercontent.com/517130/131206922-703ad192-0381-47c5-95be-9c6b56de3577.gif)
