### PR TITLE
Minor Change: Write C_POS_ID reference on invoice

### DIFF
--- a/base/src/org/compiere/model/MInvoice.java
+++ b/base/src/org/compiere/model/MInvoice.java
@@ -317,6 +317,7 @@ public class MInvoice extends X_C_Invoice implements DocAction , DocumentReversa
 		setC_BPartner_ID(order.getBill_BPartner_ID());
 		setC_BPartner_Location_ID(order.getBill_Location_ID());
 		setAD_User_ID(order.getBill_User_ID());
+		setC_POS_ID(order.getC_POS_ID());
 	}	//	MInvoice
 
 	/**


### PR DESCRIPTION
Just write C_POS_ID reference on invoice when it is created from a Sales
Order with POS setted