### PR TITLE
Fixed selection on Smart Browse

### DIFF
--- a/zkwebui/WEB-INF/src/org/eevolution/grid/WBrowserListItemRenderer.java
+++ b/zkwebui/WEB-INF/src/org/eevolution/grid/WBrowserListItemRenderer.java
@@ -482,6 +482,13 @@ public class WBrowserListItemRenderer implements ListitemRenderer, EventListener
 						table.setCheckmark(true);
 						table.removeEventListener(Events.ON_SELECT, this);
 						table.addEventListener(Events.ON_SELECT, this);
+					}else
+					{
+						ListItem listItem = table.getItemAtIndex(rowIndex);
+						boolean selected = id.isSelected();
+						if (listItem != null && !listItem.isSelected() && selected) {
+							listItem.setSelected(true);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Currently, the selected records are clearing on sort by any column on smart browse functionality.

See this example:
![Bad-Selection-SB](https://user-images.githubusercontent.com/1847863/130689548-8f203c78-201a-4bb4-bf07-6bce6bf9bee9.gif)

After change:
![Fixed-Selection-SB](https://user-images.githubusercontent.com/1847863/130689592-7fb90100-31bf-4102-8b83-c68d1bdc7959.gif)
