### PR TITLE
Fixed error when save a new record and exists an search active

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/panel/AbstractADWindowPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/panel/AbstractADWindowPanel.java
@@ -1131,7 +1131,7 @@ public abstract class AbstractADWindowPanel extends AbstractUIPart implements To
 		}
 		else
 		{
-			newTabPanel.getGridTab().dataRefreshAll();
+			newTabPanel.getGridTab().dataRefreshAll(true,true);
 		}
 
 		currentTabIndex = newTabIndex;


### PR DESCRIPTION
When there is an active search and a new record is saved, the search is lost and all records in the window are loaded.
Example:
![Bad_Active_Search_ZK](https://user-images.githubusercontent.com/9552217/130990093-ab7be187-ece4-4db6-b731-bc09da95c884.gif)
Fixed:
![Fixed_Active_Search_ZK](https://user-images.githubusercontent.com/9552217/130990108-b8b6194f-1429-4cac-8c2a-f155d1691311.gif)
