### PR TITLE
Fixed process selection when summary row is the first row

### DIFF
--- a/zkwebui/WEB-INF/src/org/eevolution/grid/WBrowserListItemRenderer.java
+++ b/zkwebui/WEB-INF/src/org/eevolution/grid/WBrowserListItemRenderer.java
@@ -815,7 +815,8 @@ public class WBrowserListItemRenderer implements ListitemRenderer, EventListener
 			WBrowserTable table = (WBrowserTable) event.getTarget();
 			if (table.isCheckmark()) {
 				int cnt = table.getRowCount();
-				if (cnt == 0 || !(table.getValueAt(0, 0) instanceof IDColumn))
+				if (table.getValueAt(0, 0) !=null && 
+						(cnt == 0 || !(table.getValueAt(0, 0) instanceof IDColumn)))
 					return;
 
 				//update IDColumn


### PR DESCRIPTION
## Problem
On Smart Browse when the summary row is the first row and selected another record, the selected records don't go to process.

## Steps for Reproduce
- Open an Bank Statement
- Create From Payment
- Sort By Document Number 
- When the summary row be the first row, select a row

![Bad_Selection_SB](https://user-images.githubusercontent.com/1847863/131371861-23a3a8be-ae94-4d49-9b9d-58f72d25197e.gif)

## After Fixed

![Fixed_Selection_SB](https://user-images.githubusercontent.com/1847863/131373054-b80a83cd-596e-40c2-acf8-ffe186b33957.gif)
