### PR TITLE
Add Included and Excluded Payments for bank statement

### DIFF
--- a/base/src/org/compiere/impexp/BankStatementMatcherInterface.java
+++ b/base/src/org/compiere/impexp/BankStatementMatcherInterface.java
@@ -16,6 +16,8 @@
  *****************************************************************************/
 package org.compiere.impexp;
 
+import java.util.List;
+
 import org.compiere.model.MBankStatementLine;
 import org.compiere.model.X_I_BankStatement;
 
@@ -29,16 +31,20 @@ public interface BankStatementMatcherInterface
 	/**
 	 * 	Match Bank Statement Line
 	 *	@param bsl bank statement line
+	 *	@param includedPayments
+	 *	@param exludedPayments
 	 *	@return found matches or null
 	 */
-	public BankStatementMatchInfo findMatch (MBankStatementLine bsl);
+	public BankStatementMatchInfo findMatch (MBankStatementLine bsl, List<Integer> includedPayments, List<Integer> exludedPayments);
 
 
 	/**
 	 * 	Match Bank Statement Import Line
 	 *	@param ibs bank statement import line
+	 *	@param includedPayments
+	 *	@param exludedPayments
 	 *	@return found matches or null
 	 */
-	public BankStatementMatchInfo findMatch (X_I_BankStatement ibs);
+	public BankStatementMatchInfo findMatch (X_I_BankStatement ibs, List<Integer> includedPayments, List<Integer> exludedPayments);
 
 }

--- a/base/src/org/compiere/process/BankStatementMatcher.java
+++ b/base/src/org/compiere/process/BankStatementMatcher.java
@@ -94,7 +94,7 @@ public class BankStatementMatcher extends SvrProcess
 		{
 			if (m_matchers[i].isMatcherValid())
 			{
-				info = m_matchers[i].getMatcher().findMatch(ibs);
+				info = m_matchers[i].getMatcher().findMatch(ibs, null, null);
 				if (info != null && info.isMatched())
 				{
 					if (info.getC_Payment_ID() > 0)
@@ -128,7 +128,7 @@ public class BankStatementMatcher extends SvrProcess
 		{
 			if (m_matchers[i].isMatcherValid())
 			{
-				info = m_matchers[i].getMatcher().findMatch(bsl);
+				info = m_matchers[i].getMatcher().findMatch(bsl, null, null);
 				if (info != null && info.isMatched())
 				{
 					if (info.getC_Payment_ID() > 0)

--- a/base/src/org/spin/util/impexp/GenericBankMatcher.java
+++ b/base/src/org/spin/util/impexp/GenericBankMatcher.java
@@ -40,18 +40,30 @@ public class GenericBankMatcher implements BankStatementMatcherInterface {
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(MBankStatementLine bsl) {
+	public BankStatementMatchInfo findMatch(MBankStatementLine bsl, List<Integer> includedPayments, List<Integer> exludedPayments) {
 		System.out.println(bsl);
 		return null;
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs) {
+	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs, List<Integer> includedPayments, List<Integer> exludedPayments) {
+		StringBuffer paymentWhereClause = new StringBuffer();
+		if(includedPayments != null
+				&& includedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" IN").append(includedPayments.toString().replace('[','(').replace(']',')'));
+		}
+		if(exludedPayments != null
+				&& exludedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" NOT IN").append(exludedPayments.toString().replace('[','(').replace(']',')'));
+		}
 		BankStatementMatchInfo info = new BankStatementMatchInfo();
 		String ORDERVALUE = " DESC NULLS LAST";
 		StringBuffer sql = new StringBuffer("SELECT p.C_Payment_ID "
 				+ "FROM C_Payment p "
 				+ "WHERE p.AD_Client_ID = ? ");
+		if(paymentWhereClause.length() > 0) {
+			sql.append(paymentWhereClause);
+		}
 		//	Were
 		StringBuffer where = new StringBuffer();
 		StringBuffer orderByClause = new StringBuffer(" ORDER BY ");

--- a/base/src/org/spin/util/impexp/ReferenceNoLeftLike_BankMatcher.java
+++ b/base/src/org/spin/util/impexp/ReferenceNoLeftLike_BankMatcher.java
@@ -46,12 +46,21 @@ public class ReferenceNoLeftLike_BankMatcher implements BankStatementMatcherInte
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(MBankStatementLine bsl) {
+	public BankStatementMatchInfo findMatch(MBankStatementLine bsl, List<Integer> includedPayments, List<Integer> exludedPayments) {
 		return null;
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs) {
+	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs, List<Integer> includedPayments, List<Integer> exludedPayments) {
+		StringBuffer paymentWhereClause = new StringBuffer();
+		if(includedPayments != null
+				&& includedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" IN").append(includedPayments.toString().replace('[','(').replace(']',')'));
+		}
+		if(exludedPayments != null
+				&& exludedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" NOT IN").append(exludedPayments.toString().replace('[','(').replace(']',')'));
+		}
 		BankStatementMatchInfo info = new BankStatementMatchInfo();
 		//	Validate
 		if(ibs.getC_Payment_ID() != 0) {
@@ -62,6 +71,9 @@ public class ReferenceNoLeftLike_BankMatcher implements BankStatementMatcherInte
 		StringBuffer sql = new StringBuffer("SELECT p.C_Payment_ID "
 				+ "FROM C_Payment p "
 				+ "WHERE p.AD_Client_ID = ? ");
+		if(paymentWhereClause.length() > 0) {
+			sql.append(paymentWhereClause);
+		}
 		//	Were
 		StringBuffer where = new StringBuffer();
 		StringBuffer orderByClause = new StringBuffer(" ORDER BY ");

--- a/base/src/org/spin/util/impexp/ReferenceNoLikeWithImport_BankMatcher.java
+++ b/base/src/org/spin/util/impexp/ReferenceNoLikeWithImport_BankMatcher.java
@@ -46,12 +46,21 @@ public class ReferenceNoLikeWithImport_BankMatcher implements BankStatementMatch
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(MBankStatementLine bsl) {
+	public BankStatementMatchInfo findMatch(MBankStatementLine bsl, List<Integer> includedPayments, List<Integer> exludedPayments) {
 		return null;
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs) {
+	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs, List<Integer> includedPayments, List<Integer> exludedPayments) {
+		StringBuffer paymentWhereClause = new StringBuffer();
+		if(includedPayments != null
+				&& includedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" IN").append(includedPayments.toString().replace('[','(').replace(']',')'));
+		}
+		if(exludedPayments != null
+				&& exludedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" NOT IN").append(exludedPayments.toString().replace('[','(').replace(']',')'));
+		}
 		BankStatementMatchInfo info = new BankStatementMatchInfo();
 		//	Validate
 		if(ibs.getC_Payment_ID() != 0) {
@@ -62,6 +71,9 @@ public class ReferenceNoLikeWithImport_BankMatcher implements BankStatementMatch
 		StringBuffer sql = new StringBuffer("SELECT p.C_Payment_ID "
 				+ "FROM C_Payment p "
 				+ "WHERE p.AD_Client_ID = ? ");
+		if(paymentWhereClause.length() > 0) {
+			sql.append(paymentWhereClause);
+		}
 		//	Were
 		StringBuffer where = new StringBuffer();
 		StringBuffer orderByClause = new StringBuffer(" ORDER BY ");

--- a/base/src/org/spin/util/impexp/ReferenceNoLikeWithPayment_BankMatcher.java
+++ b/base/src/org/spin/util/impexp/ReferenceNoLikeWithPayment_BankMatcher.java
@@ -46,12 +46,21 @@ public class ReferenceNoLikeWithPayment_BankMatcher implements BankStatementMatc
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(MBankStatementLine bsl) {
+	public BankStatementMatchInfo findMatch(MBankStatementLine bsl, List<Integer> includedPayments, List<Integer> exludedPayments) {
 		return null;
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs) {
+	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs, List<Integer> includedPayments, List<Integer> exludedPayments) {
+		StringBuffer paymentWhereClause = new StringBuffer();
+		if(includedPayments != null
+				&& includedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" IN").append(includedPayments.toString().replace('[','(').replace(']',')'));
+		}
+		if(exludedPayments != null
+				&& exludedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" NOT IN").append(exludedPayments.toString().replace('[','(').replace(']',')'));
+		}
 		BankStatementMatchInfo info = new BankStatementMatchInfo();
 		//	Validate
 		if(ibs.getC_Payment_ID() != 0) {
@@ -62,6 +71,9 @@ public class ReferenceNoLikeWithPayment_BankMatcher implements BankStatementMatc
 		StringBuffer sql = new StringBuffer("SELECT p.C_Payment_ID "
 				+ "FROM C_Payment p "
 				+ "WHERE p.AD_Client_ID = ? ");
+		if(paymentWhereClause.length() > 0) {
+			sql.append(paymentWhereClause);
+		}
 		//	Were
 		StringBuffer where = new StringBuffer();
 		StringBuffer orderByClause = new StringBuffer(" ORDER BY ");

--- a/base/src/org/spin/util/impexp/ReferenceNoLike_BankMatcher.java
+++ b/base/src/org/spin/util/impexp/ReferenceNoLike_BankMatcher.java
@@ -46,12 +46,21 @@ public class ReferenceNoLike_BankMatcher implements BankStatementMatcherInterfac
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(MBankStatementLine bsl) {
+	public BankStatementMatchInfo findMatch(MBankStatementLine bsl, List<Integer> includedPayments, List<Integer> exludedPayments) {
 		return null;
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs) {
+	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs, List<Integer> includedPayments, List<Integer> exludedPayments) {
+		StringBuffer paymentWhereClause = new StringBuffer();
+		if(includedPayments != null
+				&& includedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" IN").append(includedPayments.toString().replace('[','(').replace(']',')'));
+		}
+		if(exludedPayments != null
+				&& exludedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" NOT IN").append(exludedPayments.toString().replace('[','(').replace(']',')'));
+		}
 		BankStatementMatchInfo info = new BankStatementMatchInfo();
 		//	Validate
 		if(ibs.getC_Payment_ID() != 0) {
@@ -62,6 +71,9 @@ public class ReferenceNoLike_BankMatcher implements BankStatementMatcherInterfac
 		StringBuffer sql = new StringBuffer("SELECT p.C_Payment_ID "
 				+ "FROM C_Payment p "
 				+ "WHERE p.AD_Client_ID = ? ");
+		if(paymentWhereClause.length() > 0) {
+			sql.append(paymentWhereClause);
+		}
 		//	Were
 		StringBuffer where = new StringBuffer();
 		StringBuffer orderByClause = new StringBuffer(" ORDER BY ");

--- a/base/src/org/spin/util/impexp/ReferenceNoRightLike_BankMatcher.java
+++ b/base/src/org/spin/util/impexp/ReferenceNoRightLike_BankMatcher.java
@@ -46,12 +46,21 @@ public class ReferenceNoRightLike_BankMatcher implements BankStatementMatcherInt
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(MBankStatementLine bsl) {
+	public BankStatementMatchInfo findMatch(MBankStatementLine bsl, List<Integer> includedPayments, List<Integer> exludedPayments) {
 		return null;
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs) {
+	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs, List<Integer> includedPayments, List<Integer> exludedPayments) {
+		StringBuffer paymentWhereClause = new StringBuffer();
+		if(includedPayments != null
+				&& includedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" IN").append(includedPayments.toString().replace('[','(').replace(']',')'));
+		}
+		if(exludedPayments != null
+				&& exludedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" NOT IN").append(exludedPayments.toString().replace('[','(').replace(']',')'));
+		}
 		BankStatementMatchInfo info = new BankStatementMatchInfo();
 		//	Validate
 		if(ibs.getC_Payment_ID() != 0) {
@@ -62,6 +71,9 @@ public class ReferenceNoRightLike_BankMatcher implements BankStatementMatcherInt
 		StringBuffer sql = new StringBuffer("SELECT p.C_Payment_ID "
 				+ "FROM C_Payment p "
 				+ "WHERE p.AD_Client_ID = ? ");
+		if(paymentWhereClause.length() > 0) {
+			sql.append(paymentWhereClause);
+		}
 		//	Were
 		StringBuffer where = new StringBuffer();
 		StringBuffer orderByClause = new StringBuffer(" ORDER BY ");

--- a/base/src/org/spin/util/impexp/ReferenceNo_BankMatcher.java
+++ b/base/src/org/spin/util/impexp/ReferenceNo_BankMatcher.java
@@ -45,12 +45,21 @@ public class ReferenceNo_BankMatcher implements BankStatementMatcherInterface {
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(MBankStatementLine bsl) {
+	public BankStatementMatchInfo findMatch(MBankStatementLine bsl, List<Integer> includedPayments, List<Integer> exludedPayments) {
 		return null;
 	}
 
 	@Override
-	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs) {
+	public BankStatementMatchInfo findMatch(X_I_BankStatement ibs, List<Integer> includedPayments, List<Integer> exludedPayments) {
+		StringBuffer paymentWhereClause = new StringBuffer();
+		if(includedPayments != null
+				&& includedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" IN").append(includedPayments.toString().replace('[','(').replace(']',')'));
+		}
+		if(exludedPayments != null
+				&& exludedPayments.size() > 0) {
+			paymentWhereClause.append(" AND ").append("p.C_Payment_ID").append(" NOT IN").append(exludedPayments.toString().replace('[','(').replace(']',')'));
+		}
 		BankStatementMatchInfo info = new BankStatementMatchInfo();
 		//	Validate
 		if(ibs.getC_Payment_ID() != 0) {
@@ -61,6 +70,9 @@ public class ReferenceNo_BankMatcher implements BankStatementMatcherInterface {
 		StringBuffer sql = new StringBuffer("SELECT p.C_Payment_ID "
 				+ "FROM C_Payment p "
 				+ "WHERE p.AD_Client_ID = ? ");
+		if(paymentWhereClause.length() > 0) {
+			sql.append(paymentWhereClause);
+		}
 		//	Were
 		StringBuffer where = new StringBuffer();
 		StringBuffer orderByClause = new StringBuffer(" ORDER BY ");

--- a/client/src/org/spin/apps/form/BankStatementMatchController.java
+++ b/client/src/org/spin/apps/form/BankStatementMatchController.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import org.compiere.impexp.BankStatementMatchInfo;
 import org.compiere.minigrid.IDColumn;
@@ -813,7 +814,7 @@ public class BankStatementMatchController {
 			}
 			for (MBankStatementMatcher matcher : matchersList) {
 				if (matcher.isMatcherValid()) {
-					BankStatementMatchInfo info = matcher.getMatcher().findMatch(currentBankStatementImport);
+					BankStatementMatchInfo info = matcher.getMatcher().findMatch(currentBankStatementImport, currentPaymentHashMap.keySet().stream().collect(Collectors.toList()), matchedPaymentHashMap.keySet().stream().collect(Collectors.toList()));
 					if (info != null && info.isMatched()) {
 						//	Duplicate match
 						if(matchedPaymentHashMap.containsKey(info.getC_Payment_ID())) {


### PR DESCRIPTION
Currently not exists a way for know if a payment already exists inside
matched payments when the form for **Match Payments** is used, then each
matcher go to find any payments without know if a payment already exists
as matched with a previous matcher.

## How test it?
- Create three payments with the same amount and currency
- Load a Bank Statement: Enforce it for load four lines, three with the
same amount that the previous payments created and one distinct
- Go to **Bank Statement Match** form
- Simulate a match
- Note that only one payment is matched

## What is the problem?
Each matcher make a search to db with a criteria and the first run get a
payment. After this run, the second matcher find the same payment that
the previous and is ignored.