### PR TITLE
Retain selected row when sorting grid table

### DIFF
--- a/base/src/org/compiere/model/GridTab.java
+++ b/base/src/org/compiere/model/GridTab.java
@@ -2079,10 +2079,16 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 		log.fine("#" + m_vo.TabNo + " - " + e.toString());
 		int oldCurrentRow = e.getCurrentRow();
 		m_DataStatusEvent = e;          //  save it
-		//  when sorted set current row to 0
+		//  when sorted set current row
 		String msg = m_DataStatusEvent.getAD_Message();
 		if (msg != null && msg.equals("Sorted"))
-			setCurrentRow(0, true);
+		{
+			oldCurrentRow = m_currentRow;
+			if (e.getCurrentRow() >= 0)
+				setCurrentRow(e.getCurrentRow());
+			else
+				setCurrentRow(0, true);
+		}
 		//  set current row
 		m_DataStatusEvent = e;          //  setCurrentRow clear it, need to save again
 		m_DataStatusEvent.setCurrentRow(m_currentRow);
@@ -2355,6 +2361,8 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 			}
 		}
 		loadDependentInfo();
+
+		m_mTable.setCurrentRow(m_currentRow);
 
 		if (!fireEvents)    //  prevents informing twice
 			return m_currentRow;

--- a/base/src/org/compiere/model/GridTable.java
+++ b/base/src/org/compiere/model/GridTable.java
@@ -898,6 +898,9 @@ public class GridTable extends AbstractTableModel
 		Object[] changedRow = m_rowChanged >= 0 ? getDataAtRow(m_rowChanged) : null;
 
 		GridField field = getField (col);
+
+		MSort currentRow = m_currentRow >= 0 && m_currentRow < m_sort.size() ? (MSort)m_sort.get(m_currentRow) : null;
+
 		//	RowIDs are not sorted
 		if (field.getDisplayType() == DisplayType.RowID)
 			return;
@@ -949,12 +952,15 @@ public class GridTable extends AbstractTableModel
 			for (int i = 0; i < m_sort.size(); i++)
 			{
 				m_sort.get(i).data = null;
+
+				if (currentRow != null && m_sort.get(i) == currentRow)
+					m_currentRow = i;
 			}
 		}
+		//  Info detected by MTab.dataStatusChanged
+		fireDataStatusIEvent("Sorted", "#" + m_sort.size());
 		//	update UI
 		fireTableDataChanged();
-		//  Info detected by MTab.dataStatusChanged and current row set to 0
-		fireDataStatusIEvent("Sorted", "#" + m_sort.size());
 	}	//	sort
 
 	/**
@@ -2454,6 +2460,8 @@ public class GridTable extends AbstractTableModel
 	/**	LOB Info				*/
 	private ArrayList<PO_LOB>	m_lobInfo = null;
 
+	private int m_currentRow = -1;
+
 	/**
 	 * 	Reset LOB info
 	 */
@@ -3305,6 +3313,8 @@ public class GridTable extends AbstractTableModel
 	{
 		DataStatusEvent e = createDSE();
 		e.setInfo(AD_Message, info, false,false);
+		if (AD_Message.equals("Sorted"))
+			e.setCurrentRow(m_currentRow);
 		fireDataStatusChanged (e);
 	}   //  fireDataStatusEvent
 
@@ -3829,4 +3839,11 @@ public class GridTable extends AbstractTableModel
 		return true;
 	}
 
+	/**
+	 * set current row of gridtable container (gridtab). use in sort to create dse event with new current row (after sort) data
+	 * @param m_currentRow
+	 */
+	protected void setCurrentRow(int m_currentRow) {
+		this.m_currentRow = m_currentRow;
+	}
 }

--- a/client/src/org/compiere/grid/GridController.java
+++ b/client/src/org/compiere/grid/GridController.java
@@ -761,14 +761,6 @@ public class GridController extends CPanel
 			return;
 		cardLayout.first(cardPanel);
 		m_singleRow = true;
-		
-		// Refresh the data to ensure embedded tabs are updated with
-		// the selected row. Check if the table model is open before 
-		// trying to refresh.  It may not have been opened yet, in 
-		// which case, the refresh will cause an error. See issue #421
-		if (m_mTab.getTableModel().isOpen()) 
-			m_mTab.dataRefresh(m_mTab.getCurrentRow());  // Fix for #421
-		
 		dynamicDisplay(0);
 	//	vPanel.requestFocus();
 	}   //  switchSingleRow


### PR DESCRIPTION
Fixes #3606
This commit choose another way to fix #421, i.e. instead of updating embedded tabs after sorting, this commit tries to retain selected row after sorting, so no update is needed.

The implementation is ported from iDempiere, with small tweaks.

It works both in Swing and ZK UI.

Code added by #2088 and #2238 have been reverted, as it will cause problem as described in #3606.