### PR TITLE
Remove c3p0 connection leak workaround

### DIFF
--- a/base/src/org/compiere/db/DB_MariaDB.java
+++ b/base/src/org/compiere/db/DB_MariaDB.java
@@ -457,17 +457,6 @@ public class DB_MariaDB implements AdempiereDatabase {
 			//
 			conn.setAutoCommit(autoCommit);
 			conn.setTransactionIsolation(transactionIsolation);
-
-			try {
-				int numConnections =  m_ds.getMaximumPoolSize(); //m_ds.getNumBusyConnections();
-				if (numConnections >= m_maxbusyconnections
-						&& m_maxbusyconnections > 0) {
-					log.warning(getStatus());
-					// hengsin: make a best effort to reclaim leak connection
-					Runtime.getRuntime().runFinalization();
-				}
-			} catch (Exception ex) {
-			}
 		}
 		return conn;
 	}

--- a/base/src/org/compiere/db/DB_MySQL.java
+++ b/base/src/org/compiere/db/DB_MySQL.java
@@ -492,17 +492,6 @@ public class DB_MySQL implements AdempiereDatabase {
 			//
 			conn.setAutoCommit(autoCommit);
 			conn.setTransactionIsolation(transactionIsolation);
-
-			try {
-				int numConnections = m_ds.getMaximumPoolSize(); //m_ds.getNumBusyConnections();
-				if (numConnections >= m_maxbusyconnections
-						&& m_maxbusyconnections > 0) {
-					log.warning(getStatus());
-					// hengsin: make a best effort to reclaim leak connection
-					Runtime.getRuntime().runFinalization();
-				}
-			} catch (Exception ex) {
-			}
 		}
 		return conn;
 	}

--- a/base/src/org/compiere/db/DB_Oracle.java
+++ b/base/src/org/compiere/db/DB_Oracle.java
@@ -667,22 +667,6 @@ public class DB_Oracle implements AdempiereDatabase
             exception = e;
         }
 
-        try
-        {
-        	if (conn != null) {
-        		int numConnections = m_ds.getMaximumPoolSize(); //m_ds.getNumBusyConnections();
-	            if(numConnections >= m_maxbusyconnections && m_maxbusyconnections > 0)
-	            {
-	                log.warning(getStatus());
-	                //hengsin: make a best effort to reclaim leak connection
-	                Runtime.getRuntime().runFinalization();
-	            }
-        	}
-        }
-        catch (Exception ex)
-        {
-
-        }
         if (exception != null)
             throw exception;
         return conn;

--- a/base/src/org/compiere/db/DB_PostgreSQL.java
+++ b/base/src/org/compiere/db/DB_PostgreSQL.java
@@ -530,19 +530,6 @@ public class DB_PostgreSQL implements AdempiereDatabase
 			//
 			conn.setAutoCommit(autoCommit);
 			conn.setTransactionIsolation(transactionIsolation);
-			
-			try
-	        {
-                int numConnections = m_ds.getMaximumPoolSize(); //m_ds.getNumBusyConnections();
-	            if(numConnections >= m_maxbusyconnections && m_maxbusyconnections > 0)
-	            {
-	                log.warning(getStatus());
-	                //hengsin: make a best effort to reclaim leak connection
-	                Runtime.getRuntime().runFinalization();
-	            }
-	        }
-	        catch (Exception ex)
-	        {}
 		}
 		return conn;
 	}	//	getCachedConnection


### PR DESCRIPTION
As mentioned in comments of #3585, c3p0 connection leak workaround is
not needed anymore, as we have changed to use HikariCP instead.

I have only tested in PostgreSQL, may someone who has MariaDB, MySQL and Oracle environments can help to have a check.