### PR TITLE
Fix broken input method in single-row mode in Swing UI

### DIFF
--- a/client/src/org/compiere/grid/ed/VMemo.java
+++ b/client/src/org/compiere/grid/ed/VMemo.java
@@ -169,7 +169,7 @@ public class VMemo extends CTextArea implements VEditor, KeyListener, ActionList
 	 */
 	public void propertyChange (PropertyChangeEvent evt)
 	{
-		if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY))
+		if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY) && !getText().equals(evt.getNewValue()))
 			setValue(evt.getNewValue());
 	}   //  propertyChange
 

--- a/client/src/org/compiere/grid/ed/VText.java
+++ b/client/src/org/compiere/grid/ed/VText.java
@@ -161,7 +161,7 @@ public class VText extends CTextArea implements VEditor, KeyListener, ActionList
 	 */
 	public void propertyChange (PropertyChangeEvent evt)
 	{
-		if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY))
+		if (evt.getPropertyName().equals(org.compiere.model.GridField.PROPERTY) && !getText().equals(evt.getNewValue()))
 			setValue(evt.getNewValue());
 	}   //  propertyChange
 


### PR DESCRIPTION
In single-row mode, text input widgets and models behind them have
kind of two-way data bindings, which are established in GridController.

In order to mark data as modified as soon as possible. we currently
update model data more eagerly, as committed in #3592, which will cause
problem, i.e.:

1. user type characters in text widget
2. model got updated because of vetoable change
3. text widget got updated again because of property change

The third step not only adds an unneeded update operation, but also
cause problem if interfered with on-the-spot input methods, which will
make uncommitted characters to be saved in the text fields.

This commit tries to fix this problem by checking that text widgets
only set values triggered by property change in multi-row mode (i.e.
when those text input widgets are not shown).

Fixes #3613