### PR TITLE
Disable default keymaps for F6 and F8 in JSplitPane

### DIFF
--- a/client/src/org/compiere/grid/GridController.java
+++ b/client/src/org/compiere/grid/GridController.java
@@ -237,6 +237,8 @@ public class GridController extends CPanel
 		splitPane.add(cardPanel, JSplitPane.RIGHT);
 		splitPane.setBorder(null);
 		splitPane.setName("gc_splitPane");
+		splitPane.getInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke("F6"), "none");
+		splitPane.getInputMap(WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke("F8"), "none");
 		//
 		cardPanel.setLayout(cardLayout);
 		cardPanel.add(vPane, "vPane");	//	Sequence Important!


### PR DESCRIPTION
# Description

Disable default keymaps for F6 and F8 in JSplitPane inside GridController, which conflict with shortcuts of "Lookup Record" and "Grid Toggle" in menu and toolbar.

# Test

Steps to reproduce the problem:

1. Login Swing client as GardenUser
2. Open Menu > Project Management > Project
3. Type F6 or F8 in keyboard

Before applying this PR, F6 and F8 will have no effect.

This is port from iDempiere: https://idempiere.atlassian.net/browse/IDEMPIERE-4934