### PR TITLE
Fix NPE when changing themes from Nimbus in Swing

### DIFF
--- a/base/src/org/adempiere/plaf/PLAFEditorPanel.java
+++ b/base/src/org/adempiere/plaf/PLAFEditorPanel.java
@@ -185,7 +185,7 @@ public class PLAFEditorPanel extends CPanel {
 		updatePreviewComponents();
 		setLFSelection();
 		setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
-		this.repaint();
+		previewPanel.paint(previewPanel.getGraphics());
 	}
 
 	/**
@@ -204,7 +204,7 @@ public class PLAFEditorPanel extends CPanel {
 		updatePreviewComponents();
 		setLFSelection();
 		setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
-		this.repaint();
+		previewPanel.paint(previewPanel.getGraphics());
 	}
 
 	private void updatePreviewComponents() {
@@ -419,6 +419,7 @@ class PreviewPanel extends CPanel {
 					UIManager.setLookAndFeel(laf);
 				} catch (UnsupportedLookAndFeelException e) {
 				}
+				SwingUtilities.updateComponentTreeUI(this);
 				laf = null;
 				theme = null;
 			}


### PR DESCRIPTION
# Description

According to document of javax.swing.plaf.metal.MetalLookAndFeel.setCurrentTheme(), a call to SwingUtilities.updateComponentTreeUI() is needed after theme change.

This commit contains two modifications:

1. An asynchronous repaint() may cause problem if some other components are scheduled to repaint before previewPanel, and those components have not been updated by updateComponentTreeUI(). This commit try to call previewPanel.paint() directly to do a synchronized redraw, so that original theme can be restored immediately after preview image is captured.

2. After restoring original theme in previewPanel.paint(), call updateComponentTreeUI() for previewPanel again.

# Test

Steps to reproduce:

1. Login Swing client with GardenUser
2. Open Tools > Preference > User Interface Theme, select "Nimbus", click "OK" button
3. Open Tools > Preference > User Interface Theme, try to select "Metal"

Before this PR, step 3 will cause a NullPointerException.

This PR is port from iDempiere: https://idempiere.atlassian.net/browse/IDEMPIERE-4930