### PR TITLE
Improve sidebar UI for Compiere theme in Swing

### DIFF
--- a/base/src/org/compiere/plaf/CompiereButtonUI.java
+++ b/base/src/org/compiere/plaf/CompiereButtonUI.java
@@ -48,17 +48,6 @@ public class CompiereButtonUI extends MetalButtonUI
 	/** UI shared   */
 	private static CompiereButtonUI s_buttonUI = new CompiereButtonUI();
 
-	
-	/**************************************************************************
-	 *  Install Defaults
-	 *  @param b
-	 */
-	public void installDefaults(AbstractButton b)
-	{
-		super.installDefaults(b);
-		b.setOpaque(false);
-	}   //  installDefaults
-
 	/**
 	 *  Update.
 	 *  This method is invoked by <code>JComponent</code> when the specified
@@ -94,7 +83,7 @@ public class CompiereButtonUI extends MetalButtonUI
 		ButtonModel model = b.getModel();
 		boolean in = model.isPressed() || model.isSelected();
 		//
-		if (b.isBorderPainted())
+		if (b.isOpaque() && b.isBorderPainted())
 			CompiereUtils.paint3Deffect((Graphics2D)g, c, CompiereLookAndFeel.ROUND, !in);
 	}   //  paint
 


### PR DESCRIPTION
# Description

1. Make Compiere button opaque by default, to be consistent with Adempiere theme

2. Only draw 3D effect if Compiere button is opaque

# Screenshots

Before:

![9beb4a1206ff24dea63b7ef9c944d2d](https://user-images.githubusercontent.com/517130/132527727-ad881a41-257c-4281-9c07-52ab0817bded.png)

After:

![445636ff80c93c743124260445aef26](https://user-images.githubusercontent.com/517130/132527755-5396fc14-eef8-4761-b4b4-5420ae64c245.png)

This PR is port from iDempiere: https://idempiere.atlassian.net/browse/IDEMPIERE-4938

