### PR TITLE
fixed error with getLines(String, String) method

### DIFF
--- a/org.eevolution.warehouse/src/main/java/base/org/eevolution/model/MWMInOutBound.java
+++ b/org.eevolution.warehouse/src/main/java/base/org/eevolution/model/MWMInOutBound.java
@@ -58,7 +58,8 @@ import org.compiere.util.Util;
 /**
  * Class Model for In & Out Bound Operation
  * @author victor.perez@e-evoluton.com, e-Evolution
- *
+ * @author Yamel Senih, ysenih@erpya.com, ERPCyA http://www.erpya.com
+ * Fix get line method
  */
 public class MWMInOutBound extends X_WM_InOutBound implements DocAction, DocOptions {
 
@@ -643,7 +644,7 @@ public class MWMInOutBound extends X_WM_InOutBound implements DocAction, DocOpti
 	{
 		StringBuffer whereClause = new StringBuffer(MWMInOutBoundLine.COLUMNNAME_WM_InOutBound_ID+"=?");
 		if (!Util.isEmpty(where, true))
-			whereClause.append(whereClause);
+			whereClause.append(where);
 		if (orderClause.length() == 0)
 			orderClause = MWMInOutBoundLine.COLUMNNAME_Line;
 		//


### PR DESCRIPTION
When is called the method getLines(whereClause, orderBy), exists a error because the custom where clause never is  send to query. Instead is used the internal where clause, see the error line:

```Java
if (!Util.isEmpty(where, true))
			whereClause.append(whereClause);
```