### PR TITLE
Reduce heap usage of Compiere theme

### DIFF
--- a/base/src/org/compiere/plaf/CompiereUtils.java
+++ b/base/src/org/compiere/plaf/CompiereUtils.java
@@ -77,7 +77,7 @@ public class CompiereUtils
 			cc = CompiereColor.getDefaultBackground();
 
 		//  Paint AdempiereColor
-		if (cc != null)
+		if (cc != null && !cc.isFlat())
 		{
 			//  bounds is often not within Panel bouunds
 			cc.paint(g2D, c);


### PR DESCRIPTION
# Description

After merging #3619, heap usage is increased in Compiere theme, which is caused by flat backgrounds drawing using BufferedImage, which use quite a lot of memory.

This commit trying to draw flat background directly without BufferedImage.

# Test

Without this PR, Project window will be failed to open in Compiere theme mode (with default `-Xmx256M` option), i.e.:

1. Login ADempiere as GardenUser using Swing client
2. Open Project Management > Project

With step 2, OutOfMemoryError will be occured.