### PR TITLE
Remove redundant empty rows in CSV export

### DIFF
--- a/base/src/org/spin/util/AbstractExportFormat.java
+++ b/base/src/org/spin/util/AbstractExportFormat.java
@@ -261,8 +261,6 @@ public abstract class AbstractExportFormat {
 			//	for all rows (-1 = header row)
 			for (int row = startAt; row < printData.getRowCount(); row++)
 			{
-				if ( row != startAt )
-					writer.write(Env.NL);
 				StringBuffer sb = new StringBuffer();
 				if (row != -1)
 					printData.setRowIndex(row);


### PR DESCRIPTION
# Description

This commit remove redundant empty rows in CSV export, to make it consistent with XLSX export.

# Test

1. Login ZK-UI with GardenUser
2. Open "System Admin > Organization Rules > Organization"
3. Click "Report" icon
4. Click "Lookup Record" icon and click "Ok"
5. Select "CSV"