### PR TITLE
Fixed error with UOM for OutBound Line

### DIFF
--- a/org.eevolution.warehouse/src/main/java/base/org/eevolution/model/MWMInOutBoundLine.java
+++ b/org.eevolution.warehouse/src/main/java/base/org/eevolution/model/MWMInOutBoundLine.java
@@ -39,6 +39,7 @@ import org.compiere.model.MBPartner;
 import org.compiere.model.MInvoiceLine;
 import org.compiere.model.MOrderLine;
 import org.compiere.model.MProduct;
+import org.compiere.model.MUOMConversion;
 import org.compiere.model.Query;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
@@ -156,7 +157,8 @@ public class MWMInOutBoundLine extends X_WM_InOutBoundLine
 		setWM_InOutBound_ID(inOutBound.get_ID());
 		setC_Order_ID(orderLine.getC_Order_ID());
 		setC_OrderLine_ID(orderLine.getC_OrderLine_ID());
-		setMovementQty(orderLine.getQtyOrdered().subtract(getQtyToDeliver()));
+		
+		setMovementQty(getQtyToDeliver());
 		setM_Product_ID(orderLine.getM_Product_ID());
 		setC_Charge_ID(orderLine.getC_Charge_ID());
 		setC_UOM_ID(orderLine.getC_UOM_ID());
@@ -237,14 +239,16 @@ public class MWMInOutBoundLine extends X_WM_InOutBoundLine
 			Optional<I_C_OrderLine> maybeOrderLine = Optional.ofNullable(getOrderLine());
 			AtomicReference<BigDecimal> quantityToDeliver = new AtomicReference<>(BigDecimal.ZERO);
 			maybeOrderLine.ifPresent( orderLine -> {
-				quantityToDeliver.set(orderLine.getQtyOrdered().subtract(orderLine.getQtyDelivered()));
+				BigDecimal convertedQuantity = MUOMConversion.convertProductFrom(getCtx(), orderLine.getM_Product_ID(), orderLine.getC_UOM_ID(), orderLine.getQtyOrdered().subtract(orderLine.getQtyDelivered()));
+				quantityToDeliver.set(convertedQuantity);
 			});
 			return quantityToDeliver.get();
 		} else if(getDD_OrderLine_ID() != 0) {
 			Optional<I_DD_OrderLine> maybeOrderLine = Optional.ofNullable(getDD_OrderLine());
 			AtomicReference<BigDecimal> quantityToDeliver = new AtomicReference<>(BigDecimal.ZERO);
 			maybeOrderLine.ifPresent( orderLine -> {
-				quantityToDeliver.set(orderLine.getQtyOrdered().subtract(orderLine.getQtyDelivered()));
+				BigDecimal convertedQuantity = MUOMConversion.convertProductFrom(getCtx(), orderLine.getM_Product_ID(), orderLine.getC_UOM_ID(), orderLine.getQtyOrdered().subtract(orderLine.getQtyDelivered()));
+				quantityToDeliver.set(convertedQuantity);
 			});
 			return quantityToDeliver.get();
 		}

--- a/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
+++ b/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
@@ -156,6 +156,8 @@ public class OutBoundOrder {
 	
 	/**	Load Order			*/
 	protected MWMInOutBound  	outBoundOrder = null;
+	/** Outbound Locator Id */
+	protected Integer locatorId = null;
 	
 	/**
 	 * Get Order data from parameters
@@ -815,7 +817,7 @@ public class OutBoundOrder {
 				BigDecimal qtyOrderLine = (BigDecimal) orderLineTable.getValueAt(row, OL_QTY_IN_TRANSIT);
 				BigDecimal qtyDelivered = (BigDecimal) orderLineTable.getValueAt(row, OL_QTY_DELIVERED);
 				KeyNamePair uom = (KeyNamePair) orderLineTable.getValueAt(row, OL_UOM);
-				KeyNamePair deliveryRule = (KeyNamePair) orderLineTable.getValueAt(row, OL_DELIVERY_RULE);
+				ValueNamePair deliveryRule = (ValueNamePair) orderLineTable.getValueAt(row, OL_DELIVERY_RULE);
 				//	
 				MProduct product = MProduct.get(Env.getCtx(), productId);
 				int precision = MUOM.getPrecision(Env.getCtx(), uom.getKey());
@@ -944,7 +946,10 @@ public class OutBoundOrder {
 					outBoundOrderLine.setC_OrderLine_ID(line.getC_OrderLine_ID());
 					outBoundOrderLine.setM_AttributeSetInstance_ID(line.getM_AttributeSetInstance_ID());
 					outBoundOrderLine.setC_UOM_ID(product.getC_UOM_ID());
-					outBoundOrderLine.setM_Locator_ID(getDefaultLocator(line.getM_Warehouse_ID(), productId, line.getM_AttributeSetInstance_ID(), qty, trxName));
+					if (locatorId == null)
+						locatorId = getDefaultLocator(line.getM_Warehouse_ID(), productId, line.getM_AttributeSetInstance_ID(), qty, trxName);
+
+					outBoundOrderLine.setM_LocatorTo_ID(locatorId);
 				}
 				outBoundOrderLine.setM_Product_ID(productId);
 				outBoundOrderLine.setMovementQty(qty);

--- a/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
+++ b/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
@@ -31,11 +31,14 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.exceptions.DocTypeNotFoundException;
 import org.compiere.minigrid.IMiniTable;
 import org.compiere.model.MDocType;
+import org.compiere.model.MLocator;
 import org.compiere.model.MOrderLine;
 import org.compiere.model.MProduct;
 import org.compiere.model.MRefList;
 import org.compiere.model.MRole;
+import org.compiere.model.MStorage;
 import org.compiere.model.MUOM;
+import org.compiere.model.MWarehouse;
 import org.compiere.model.X_C_Order;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
@@ -809,6 +812,11 @@ public class OutBoundOrder {
 	 * @return
 	 */
 	public String validateQuantity(IMiniTable orderLineTable) {
+		MDocType m_DocType = MDocType.get(Env.getCtx(), docTypeTargetId);
+		validateQuantity = m_DocType.get_ValueAsBoolean("IsValidateQuantity");
+		if(!validateQuantity) {
+			return null;
+		}
 		StringBuffer errorMessage = new StringBuffer();
 		DecimalFormat format = DisplayType.getNumberFormat(DisplayType.Number);
 		for (int row = 0; row < orderLineTable.getRowCount(); row++) {
@@ -834,7 +842,7 @@ public class OutBoundOrder {
 					if(errorMessage.length() > 0) {
 						errorMessage.append(Env.NL);
 					} else {
-						errorMessage.append("@Error@ @Qty@ > @QtyAvailable@");
+						errorMessage.append("@Error@ @Qty@ > @QtyAvailable@ ");
 					}
 					errorMessage.append("@C_Order_ID@ " + order.getName())
 						.append(", @M_Product_ID@ " + product.getValue() + "-" + product.getName())
@@ -859,10 +867,6 @@ public class OutBoundOrder {
 	 * @return String
 	 */
 	public String generateLoadOrder(String trxName, IMiniTable orderLineTable) {
-		String errorMessage = validateQuantity(orderLineTable);
-		if(!Util.isEmpty(errorMessage)) {
-			throw new AdempiereException(errorMessage);
-		}
 		int quantity = 0;
 		int rows = orderLineTable.getRowCount();
 		outBoundOrder = new MWMInOutBound(Env.getCtx(), 0, trxName);
@@ -894,7 +898,13 @@ public class OutBoundOrder {
             } else {
             	outBoundOrder.setC_DocType_ID(defaultDocumentType.get().getC_DocType_ID());
             }
+            docTypeTargetId = defaultDocumentType.get().getC_DocType_ID();
         }
+        //	Validate
+		String errorMessage = validateQuantity(orderLineTable);
+		if(!Util.isEmpty(errorMessage)) {
+			throw new AdempiereException(errorMessage);
+		}
 		//	Set Warehouse
 		if(warehouseId > 0) {
 			outBoundOrder.setM_Warehouse_ID(warehouseId);
@@ -927,22 +937,29 @@ public class OutBoundOrder {
 				outBoundOrderLine = new MWMInOutBoundLine(outBoundOrder);
 				//	Set Values
 				outBoundOrderLine.setAD_Org_ID(orgId);
+				MProduct product = MProduct.get(Env.getCtx(), productId);
 				if (movementType.equals(I_DD_Order.Table_Name)) {
 					outBoundOrderLine.setDD_OrderLine_ID(orderLineId);
 					MDDOrderLine line = new MDDOrderLine(Env.getCtx(), orderLineId, trxName);
 					outBoundOrderLine.setDD_Order_ID(line.getDD_Order_ID());
-					outBoundOrderLine.setDD_Order_ID(line.getDD_Order_ID());
-					outBoundOrderLine.setC_UOM_ID(line.getC_UOM_ID());
+					outBoundOrderLine.setDD_OrderLine_ID(line.getDD_OrderLine_ID());
+					outBoundOrderLine.setM_AttributeSetInstance_ID(line.getM_AttributeSetInstance_ID());
+					outBoundOrderLine.setC_UOM_ID(product.getC_UOM_ID());
+					outBoundOrderLine.setM_Locator_ID(line.getM_Locator_ID());
+					outBoundOrderLine.setM_LocatorTo_ID(line.getM_LocatorTo_ID());
 				} else {
 					outBoundOrderLine.setC_OrderLine_ID(orderLineId);
 					MOrderLine line = new MOrderLine(Env.getCtx(), orderLineId, trxName);
 					outBoundOrderLine.setC_Order_ID(line.getC_Order_ID());
-					outBoundOrderLine.setC_Order_ID(line.getC_Order_ID());
-					outBoundOrderLine.setC_UOM_ID(line.getC_UOM_ID());
+					outBoundOrderLine.setC_OrderLine_ID(line.getC_OrderLine_ID());
+					outBoundOrderLine.setM_AttributeSetInstance_ID(line.getM_AttributeSetInstance_ID());
+					outBoundOrderLine.setC_UOM_ID(product.getC_UOM_ID());
+					outBoundOrderLine.setM_Locator_ID(getDefaultLocator(line.getM_Warehouse_ID(), productId, line.getM_AttributeSetInstance_ID(), qty, trxName));
 				}
 				outBoundOrderLine.setM_Product_ID(productId);
 				outBoundOrderLine.setMovementQty(qty);
 				outBoundOrderLine.setPickedQty(qty);
+				
 				//	Add Weight
 				totalWeight = totalWeight.add(weight);
 				//	Add Volume
@@ -975,6 +992,34 @@ public class OutBoundOrder {
 		//	Message
 		return Msg.parseTranslation(Env.getCtx(), "@Created@ = [" + outBoundOrder.getDocumentNo() 
 				+ "] || @LineNo@" + " = [" + quantity + "]" + (errorMessage != null? "\n@Errors@:" + errorMessage: ""));
+	}
+	
+	/**
+	 * Get Default locator based on stock, else default
+	 * @param warehouseId
+	 * @param productId
+	 * @param attributeSetInstanceId
+	 * @param quantity
+	 * @param transactionName
+	 * @return
+	 * @return int
+	 */
+	private int getDefaultLocator(int warehouseId, int productId, int attributeSetInstanceId, BigDecimal quantity, String transactionName) {
+		int locatorId = MStorage.getM_Locator_ID(warehouseId, 
+				productId, 
+				attributeSetInstanceId, 
+				quantity, 
+				transactionName);
+		if(locatorId > 0) {
+			return locatorId;
+		}
+		MWarehouse warehouse = MWarehouse.get(Env.getCtx(), warehouseId);
+		MLocator locator = MLocator.getDefault(warehouse);
+		if(locator == null) {
+			MProduct product = MProduct.get(Env.getCtx(), productId);
+			throw new AdempiereException("@M_Locator_ID@ @NotFound@ [@M_Product_ID@: " + product.getValue() + " - " + product.getName() + " @M_Warehouse_ID@: " + warehouse.getName() + "]");
+		}
+		return locator.getM_Locator_ID();
 	}
 	
 	/**

--- a/org.eevolution.warehouse/src/main/java/ui/zk/org/spin/form/WOutBoundOrder.java
+++ b/org.eevolution.warehouse/src/main/java/ui/zk/org/spin/form/WOutBoundOrder.java
@@ -38,6 +38,7 @@ import org.adempiere.webui.component.Row;
 import org.adempiere.webui.component.Rows;
 import org.adempiere.webui.component.WListbox;
 import org.adempiere.webui.editor.WTableDirEditor;
+import org.adempiere.webui.editor.WLocatorEditor;
 import org.adempiere.webui.event.WTableModelEvent;
 import org.adempiere.webui.event.WTableModelListener;
 import org.adempiere.webui.panel.ADForm;
@@ -49,6 +50,7 @@ import org.adempiere.webui.window.FDialog;
 import org.compiere.minigrid.IMiniTable;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.MDocType;
+import org.compiere.model.MLocatorLookup;
 import org.compiere.model.MLookup;
 import org.compiere.model.MLookupFactory;
 import org.compiere.model.MProduct;
@@ -151,6 +153,9 @@ public class WOutBoundOrder extends OutBoundOrder
 	private Label 			shipperLabel = new Label();
 	private WTableDirEditor shipperPick = null;
 	private DateFormat 		dateFormat 		 = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+	/** Locator 				*/
+	protected Label locatorLabel = new Label();
+	protected WLocatorEditor locatorField = new WLocatorEditor();
 	
 	/** Panels				*/
 	private Panel 			orderPanel = new Panel();
@@ -333,6 +338,9 @@ public class WOutBoundOrder extends OutBoundOrder
 		row = rows.newRow();
 		row.appendChild(selectAllButton);
 		selectAllButton.setImage("/images/SelectAll24.png");
+
+		row.appendChild(locatorLabel.rightAlign());
+		row.appendChild(locatorField.getComponent());
 		row.appendChild(new Space());
 		row.appendChild(confirmPanel);
 		
@@ -517,6 +525,14 @@ public class WOutBoundOrder extends OutBoundOrder
 		//	Document Action
 		docActionPick = new WTableDirEditor("DocAction", true, false, true,docActionL);
 		docActionPick.setValue(DocAction.ACTION_Complete);
+
+		locatorLabel.setValue(Msg.translate(Env.getCtx(), "M_Locator_ID"));
+		locatorLabel.setMandatory(true);
+		MLocatorLookup locator = new MLocatorLookup(Env.getCtx(), form.getWindowNo());
+		locatorField = new WLocatorEditor ("M_Locator_ID", true, false, true, locator, form.getWindowNo());
+		locatorField.setMandatory(true);
+		locatorField.addValueChangeListener(this);
+
 		//	
 		documentDateField.setValue(Env.getContextAsDate(Env.getCtx(), "#Date"));
 		//	Set Date
@@ -655,8 +671,15 @@ public class WOutBoundOrder extends OutBoundOrder
 	 * @return
 	 */
 	private boolean validateDataForSave() {
-		String error = validateData();
+
 		StringBuffer errorMessage = new StringBuffer();
+
+		if (locatorField.getValue() == null )
+			errorMessage.append(" @WM_InOutBound_ID@ @M_Locator_ID@ @NotFound@");
+		else
+			locatorId = (Integer)locatorField.getValue();
+
+		String error = validateData();
 		if(!Util.isEmpty(error)) {
 			errorMessage.append(error);
 		}


### PR DESCRIPTION
Currently when a outbound order is generated the uom is not used correctly, also the movement quantity is not the real movement based on available for shipment. This pull request just allows define a correct uom for outboundline based on product.

**Features**
- Add correct UOM for OutBound Order Line
- Add correct movement quantity
- Add support to attribute set instance from Generate Outbound Order form
- Add support to default locator from Generate Outbound Order form