### PR TITLE
Fixed error with ConcurrentModificationException

### DIFF
--- a/base/src/org/compiere/model/MTable.java
+++ b/base/src/org/compiere/model/MTable.java
@@ -24,7 +24,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -166,36 +165,12 @@ public class MTable extends X_AD_Table
 	{
 		if (tableName == null)
 			return null;
-		Iterator<MTable> it = s_cache.values().iterator();
-		while (it.hasNext())
-		{
-			MTable retValue = it.next();
-			if (tableName.equalsIgnoreCase(retValue.getTableName()) 
-					&& retValue.getCtx() == ctx 
-				) 
-			{
-				return retValue;
+		int tableId = getTable_ID(tableName);
+		if(tableId <= 0) {
+			return null;
 		}
-		}
-		//
-		MTable retValue = null;
-		String sql = "SELECT * FROM AD_Table WHERE UPPER(TableName)=?";
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-		try {
-			pstmt = DB.prepareStatement (sql, null);
-			pstmt.setString(1, tableName.toUpperCase());
-			rs = pstmt.executeQuery ();
-			if (rs.next ())
-				retValue = new MTable (ctx, rs, null);
-		} catch (Exception e) {
-			s_log.log(Level.SEVERE, sql, e);
-		} finally {
-			DB.close(rs, pstmt);
-		}
-		
-		if (retValue != null)
-		{
+		MTable retValue = MTable.get(ctx, tableId);
+		if (retValue != null) {
 			Integer key = new Integer (retValue.getAD_Table_ID());
 			s_cache.put (key, retValue);
 		}


### PR DESCRIPTION
```Java
Exception in thread "Acme01 - Accounting Processor"
java.util.ConcurrentModificationException
        at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1579)
        at java.base/java.util.HashMap$ValueIterator.next(HashMap.java:1607)
        at org.compiere.model.MTable.get(MTable.java:172)
        at org.compiere.model.Query.<init>(Query.java:131)
        at org.compiere.model.MTable.getColumnsAsList(MTable.java:473)
        at org.compiere.model.MTable.getColumns(MTable.java:451)
        at org.compiere.model.MTable.getKeyColumns(MTable.java:517)
        at org.compiere.model.Query.getIDsAsList(Query.java:804)
        at org.compiere.acct.Doc.streamUnpostedRecordIdsForTableOnDate(Doc.java:301)
        at org.compiere.acct.SessionPoster.postDocumentsOnDate(SessionPoster.java:145)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
        at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
        at org.compiere.acct.SessionPoster.post(SessionPoster.java:116)
        at org.compiere.server.AcctProcessor.doWork(AcctProcessor.java:129)
        at org.compiere.server.AdempiereServer.run(AdempiereServer.java:265)
```