### PR TITLE
fix: Build Warning Could not find file.

### DIFF
--- a/sqlj/build.xml
+++ b/sqlj/build.xml
@@ -24,7 +24,7 @@
 	    <!-- create the build directory structure used by compile -->
 	    <mkdir dir="${build.dir}"/>
             <!--begin vpj-cd e-evolution PostgreSQL-->
-            <copy file="postgresql/sqlj.ddr" tofile="./${build.dir}/deployment/sqlj.ddr" failonerror="no"/>
+            <copy file="PostgreSQL/sqlj.ddr" tofile="./${build.dir}/deployment/sqlj.ddr" failonerror="no"/>
 	    <!--end vpj-cd e-evolution PostgreSQL-->
 	</target>
 	


### PR DESCRIPTION


<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report

#### Steps to reproduce
1. Build adempiere.

See output build log;
```log
sqljInit:
     [echo] =========== Build SQLJ
    [mkdir] Created dir: /home/edwin/workspace/glpa/adempiere/sqlj/build
     [copy] Warning: Could not find file /home/edwin/workspace/glpa/adempiere/sqlj/postgresql/sqlj.ddr to copy.
```

#### Log files

Before this changes:

[output-error.log](https://github.com/adempiere/adempiere/files/8009397/output-error.log)

After this changes:

[output-fix.log](https://github.com/adempiere/adempiere/files/8009398/output-fix.log)



#### Other relevant information
- Your OS: Linux Mint 20.2 Cinnamon x64.
- Java version: 11.0.13.
- ADempiere version: 3.9.3
- Browser: Mozilla Firefox.
- Browser Version: 96.0.3.
- DB Provider: PostgreSQL.
- DB version: 13.5.

