### PR TITLE
First testing by cache transaction

### DIFF
--- a/base/src/org/compiere/model/PO.java
+++ b/base/src/org/compiere/model/PO.java
@@ -125,6 +125,24 @@ public abstract class PO
 	private static final String USE_TIMEOUT_FOR_UPDATE = "org.adempiere.po.useTimeoutForUpdate";
 
 	private static final int QUERY_TIME_OUT = 10;
+	private boolean isCachedEntity = false;
+	
+	
+	/**
+	 * Validate if this PO is managed from cache
+	 * @return
+	 */
+	public final boolean isCachedEntity() {
+		return isCachedEntity;
+	}
+
+	/**
+	 * Set value for cache flag
+	 * @param isCachedEntity
+	 */
+	public final void setIsCachedEntity(boolean isCachedEntity) {
+		this.isCachedEntity = isCachedEntity;
+	}
 
 	/**
 	 * get instance based on table id , record id and trxName
@@ -3826,6 +3844,9 @@ public abstract class PO
 	 */
 	public String get_TrxName()
 	{
+		if(isCachedEntity()) {
+			return null;
+		}
 		return m_trxName;
 	}	//	getTrx
 

--- a/base/src/org/compiere/util/CCache.java
+++ b/base/src/org/compiere/util/CCache.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.compiere.model.PO;
 
 /**
  *  Adempiere Cache.
@@ -228,7 +229,12 @@ public class CCache<K,V> extends HashMap<K,V> implements CacheInterface
 	public V get(Object key)
 	{
 		expire();
-		return super.get(key);
+		V value = super.get(key);
+		if(value != null && PO.class.isAssignableFrom(value.getClass())) {
+			PO entity = (PO) value;
+			entity.setIsCachedEntity(true);
+		}
+		return value;
 	}	//	get
 
 	/**
@@ -241,6 +247,13 @@ public class CCache<K,V> extends HashMap<K,V> implements CacheInterface
 	{
 		expire();
 		m_justReset = false;
+		if(value == null) {
+			return super.remove(key);
+		}
+		if(PO.class.isAssignableFrom(value.getClass())) {
+			PO entity = (PO) value;
+			entity.setIsCachedEntity(true);
+		}
 		return super.put (key, value);
 	}	// put
 


### PR DESCRIPTION
This change just inject a flag for validate object managed as cache and return null when a object is cached

The events are:
- For cache:
  - `put(key, value)`
  - `get(key)`
- For PO:
  - `get_TrxName()`