### PR TITLE
fix: Build project for Trx cannot find.

### DIFF
--- a/serverRoot/src/main/server/org/compiere/server/RequestProcessor.java
+++ b/serverRoot/src/main/server/org/compiere/server/RequestProcessor.java
@@ -36,6 +36,7 @@ import org.compiere.model.MUser;
 import org.compiere.model.Query;
 import org.compiere.util.Msg;
 import org.compiere.util.TimeUtil;
+import org.compiere.util.Trx;
 import org.compiere.util.Util;
 import org.spin.model.MRNoticeTemplate;
 import org.spin.model.MRNoticeTemplateEvent;


### PR DESCRIPTION
In the PR https://github.com/adempiere/adempiere/pull/3730/files#diff-a8e64761dcb728329030ee56a7fd3f583329961cf28013e561f00b9f51524529L38 is removed from the serverRoot/src/main/server/org/compiere/server/RequestProcessor.java class as it was not used however in the PR https://github.com/adempiere/adempiere/pull/3571/files#diff-a8e64761dcb728329030ee56a7fd3f583329961cf28013e561f00b9f51524529R325 the Trx is implemented .

They were mixed in chronological order different from their creation, which generated the error/conflict.