### PR TITLE
adempiere 3782  MOrder voidIt terminated

### DIFF
--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -2032,7 +2032,7 @@ public class MOrder extends X_C_Order implements DocAction
 		MOrderTax[] taxes = getTaxes(true);
 		for (MOrderTax tax : taxes )
 		{
-			if(tax.calculateTaxFromLines()) {
+			if(!tax.calculateTaxFromLines()) {
 				return false;
 			}
 			//	Save


### PR DESCRIPTION
Orders cannot be voided, due to erroneous interruption
Class MOrder, line 2035
if(tax.calculateTaxFromLines()) {
				return false;

correct code
**if(!tax.calculateTaxFromLines()) {**
				return false;

https://github.com/adempiere/adempiere/issues/3782