### PR TITLE
This pull request just add support to gradle builder to base source

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -1,0 +1,161 @@
+apply plugin: 'java-library'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
+
+dependencies {
+	implementation fileTree(
+        dir: '../tools/lib', 
+        include: [
+        'Verisign.jar', 
+		'payflow.jar',
+        ]
+    )
+	//api '<library-group>:<library-name>:<library-version>'
+    // https://mvnrepository.com/artifact/org.apache.poi/poi
+	implementation group: 'org.apache.poi', name: 'poi', version: '3.17'
+    // https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml
+	implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '3.17'
+    // https://mvnrepository.com/artifact/com.itextpdf/pdfa
+	implementation group: 'com.itextpdf', name: 'pdfa', version: '7.1.13'
+    // https://mvnrepository.com/artifact/com.itextpdf/itextpdf
+    implementation group: 'com.itextpdf', name: 'itextpdf', version: '5.5.2'
+	// https://mvnrepository.com/artifact/io.konik/itext-carriage
+	implementation group: 'io.konik', name: 'itext-carriage', version: '0.8.0'
+    // https://mvnrepository.com/artifact/io.konik/harness
+    implementation group: 'io.konik', name: 'harness', version: '1.0.0'
+    // https://mvnrepository.com/artifact/com.sun.mail/javax.mail
+	implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.4.7'
+    // https://mvnrepository.com/artifact/com.jgoodies/looks
+	implementation group: 'com.jgoodies', name: 'looks', version: '2.0.4'
+    // https://mvnrepository.com/artifact/javaee/javaee-api
+	implementation group: 'javaee', name: 'javaee-api', version: '5'
+    // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3
+	implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.827'
+    // https://mvnrepository.com/artifact/org.jfree/jfreechart
+	implementation group: 'org.jfree', name: 'jfreechart', version: '1.0.14'
+    // https://mvnrepository.com/artifact/commons-io/commons-io
+	implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
+    // https://mvnrepository.com/artifact/commons-validator/commons-validator
+	implementation group: 'commons-validator', name: 'commons-validator', version: '1.6'
+    // https://mvnrepository.com/artifact/org.apache.activemq/activemq-core
+	implementation group: 'org.apache.activemq', name: 'activemq-core', version: '5.7.0'
+    // https://mvnrepository.com/artifact/org.apache.ant/ant
+	implementation group: 'org.apache.ant', name: 'ant', version: '1.10.5'
+    // https://mvnrepository.com/artifact/com.github.lookfirst/sardine
+	implementation group: 'com.github.lookfirst', name: 'sardine', version: '5.9'
+    // https://mvnrepository.com/artifact/io.vavr/vavr
+    implementation group: 'io.vavr', name: 'vavr', version: '0.10.4'
+    // https://mvnrepository.com/artifact/net.sourceforge.barbecue/barbecue
+	implementation group: 'net.sourceforge.barbecue', name: 'barbecue', version: '1.5-beta1'
+    // https://mvnrepository.com/artifact/log4j/log4j
+	implementation group: 'log4j', name: 'log4j', version: '1.2.17'
+    // https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc6
+	implementation group: 'com.oracle.database.jdbc', name: 'ojdbc6', version: '11.2.0.4'
+    // https://mvnrepository.com/artifact/com.google.zxing/core
+	implementation group: 'com.google.zxing', name: 'core', version: '2.3.0'
+    // https://mvnrepository.com/artifact/it.sauronsoftware.cron4j/cron4j
+	implementation group: 'it.sauronsoftware.cron4j', name: 'cron4j', version: '2.2.5'
+    // https://mvnrepository.com/artifact/com.zaxxer/HikariCP
+    implementation group: 'com.zaxxer', name: 'HikariCP', version: '5.0.1'
+    // https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client
+    implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '3.0.4'
+    // https://mvnrepository.com/artifact/org.postgresql/postgresql
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.3'
+    // https://mvnrepository.com/artifact/mysql/mysql-connector-java
+	implementation group: 'mysql', name: 'mysql-connector-java', version: '5.1.3'
+    // https://mvnrepository.com/artifact/org.beanshell/bsh
+    implementation group: 'org.beanshell', name: 'bsh', version: '2.0b5'
+    //  Local
+    api 'io.github.adempiere:tools:3.9.4-develop-1.0'
+}
+
+sourceSets {
+    main {
+         java {
+            srcDirs = ['src']
+         }
+    }
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+signing {
+    sign configurations.archives
+}
+
+def entityType = 'D'
+version = "3.9.4-develop-1.0"
+
+jar {
+    manifest {
+        attributes("Implementation-Title": "Adempiere Base Module",
+                   "Implementation-Version": version, 
+                   "EntityType": entityType)
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            credentials {
+                username = ossrhUsername ?: System.getenv("OSSRH_USER_NAME")
+                password = ossrhPassword ?: System.getenv("OSSRH_PASSWORD")
+            }
+        }
+    }
+    publications {
+        mavenJava(MavenPublication) {
+        	groupId 'io.github.adempiere'
+            artifactId 'base'
+            version
+           	from components.java
+           	pom {
+                name = 'Base'
+                description = 'ADempiere core library as invoice, order and other core library.'
+                url = 'http://adempiere.io/'
+                licenses {
+                    license {
+                        name = 'GNU General Public License, version 2'
+                        url = 'https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'yamelsenih'
+                        name = 'Yamel Senih'
+                        email = 'ysenih@erpya.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/adempiere/adempiere.git'
+                    developerConnection = 'scm:git:ssh://github.com/adempiere/adempiere.git'
+                    url = 'http://github.com/adempiere/adempiere'
+                }
+            }
+		}
+	}
+}
+
+signing {
+    sign publishing.publications.mavenJava
+}


### PR DESCRIPTION
folder. The gradle structure is the follow:

- adempiereTrunk:
  - base:
    - build.gradle

Now you can run the follow command to base source folder:
```Shell
gradle build
```
The dependence from tools is:
```Java
api 'io.github.adempiere:tools:3.9.4-develop-1.0'
```

Note: now I can't find the follows libraries because are many olds and
exists from other vendor:
- /tools/lib/Verisign.jar
- /tools/lib/payflow.jar

Both libraries are dependences of:
- [org.compiere.model.PP_PayPal.java](https://github.com/adempiere/adempiere/blob/develop/base/src/org/compiere/model/PP_PayPal.java)
- [org.compiere.model.PP_PayFlowPro.java](https://github.com/adempiere/adempiere/blob/develop/base/src/org/compiere/model/PP_PayFlowPro.java)
- [org.compiere.model.PP_PayFlowPro4.java](https://github.com/adempiere/adempiere/blob/develop/base/src/org/compiere/model/PP_PayFlowPro4.java)

I think that these files can be removed and implemented as new
funcionality