### PR TITLE
fix: The Boolean constructor is deprecated.

### DIFF
--- a/base/src/org/adempiere/pipo/handler/DataElementHandler.java
+++ b/base/src/org/adempiere/pipo/handler/DataElementHandler.java
@@ -213,7 +213,7 @@ public class DataElementHandler extends AbstractElementHandler {
 						else if (((String)(thisValue.get(2))).equals("Integer"))
 							genericPO.set_ValueOfColumn((String)thisValue.get(0), Integer.valueOf((String)thisValue.get(1)));
 						else if (((String)(thisValue.get(2))).equals("Boolean"))
-							genericPO.set_ValueOfColumn((String)thisValue.get(0), new Boolean(((String)thisValue.get(1)).equals("true") ? true : false));
+							genericPO.set_ValueOfColumn((String) thisValue.get(0), Boolean.valueOf((String) thisValue.get(1)));
 					}
 				}
 			}
@@ -274,7 +274,7 @@ public class DataElementHandler extends AbstractElementHandler {
 						genericPO.set_ValueOfColumn(atts.getValue("name").toString(), Integer.valueOf(atts.getValue("value")));
 					}	
 					else if (atts.getValue("class").equals("Boolean")) {
-						genericPO.set_ValueOfColumn(atts.getValue("name"), new Boolean(atts.getValue("value").equals("true") ? true : false));
+						genericPO.set_ValueOfColumn(atts.getValue("name"), Boolean.valueOf(atts.getValue("value")));
 					}
 					else if (atts.getValue("class").equals("Date") || atts.getValue("class").equals("Date+Time")
 							|| atts.getValue("class").equals("Time")) {

--- a/base/src/org/adempiere/util/rpl/EntityWrapper.java
+++ b/base/src/org/adempiere/util/rpl/EntityWrapper.java
@@ -456,7 +456,7 @@ public class EntityWrapper {
      * 	@param active active
      */
     public final void setIsActive (boolean active) {
-        setValue("IsActive", new Boolean(active));
+        setValue("IsActive", Boolean.valueOf(active));
     }	//	setActive
 
     /**

--- a/base/src/org/compiere/model/CalloutOrder.java
+++ b/base/src/org/compiere/model/CalloutOrder.java
@@ -662,7 +662,7 @@ public class CalloutOrder extends CalloutEngine
 			if (rs.next())
 			{
 				//	Tax Included
-				mTab.setValue("IsTaxIncluded", new Boolean("Y".equals(rs.getString(1))));
+				mTab.setValue("IsTaxIncluded", Boolean.valueOf("Y".equals(rs.getString(1))));
 				//	Currency
 				Integer ii = new Integer(rs.getInt(3));
 				mTab.setValue("C_Currency_ID", ii);

--- a/base/src/org/compiere/model/CalloutPaySelection.java
+++ b/base/src/org/compiere/model/CalloutPaySelection.java
@@ -293,7 +293,7 @@ public class CalloutPaySelection extends CalloutEngine
 				AmtSource = rs.getBigDecimal(1);
 				OpenAmt = rs.getBigDecimal(2);
 				DiscountAmt = rs.getBigDecimal(3);
-				IsSOTrx = new Boolean ("Y".equals(rs.getString(4)));
+				IsSOTrx = Boolean.valueOf("Y".equals(rs.getString(4)));
 				C_ConversionType_ID = rs.getInt(5);
 				C_BPartner_ID = rs.getInt(6);
 			}
@@ -371,7 +371,7 @@ public class CalloutPaySelection extends CalloutEngine
 			if (rs.next()) {
 				AmtSource = rs.getBigDecimal(1);
 				OpenAmt = rs.getBigDecimal(2);
-				IsSOTrx = new Boolean ("Y".equals(rs.getString(3)));
+				IsSOTrx = Boolean.valueOf("Y".equals(rs.getString(3)));
 				C_ConversionType_ID = rs.getInt(4);
 				C_BPartner_ID = rs.getInt(5);
 			}

--- a/base/src/org/compiere/model/GridTable.java
+++ b/base/src/org/compiere/model/GridTable.java
@@ -3195,7 +3195,7 @@ public class GridTable extends AbstractTableModel
 					String str = rs.getString(j+1);
 					if (field.isEncryptedColumn())
 						str = (String)decrypt(str);
-					rowData[j] = new Boolean ("Y".equals(str));	//	Boolean
+					rowData[j] = Boolean.valueOf("Y".equals(str));	//	Boolean
 				}
 				//	LOB
 				else if (DisplayType.isLOB(displayType))

--- a/base/src/org/compiere/model/MProductPricing.java
+++ b/base/src/org/compiere/model/MProductPricing.java
@@ -149,7 +149,7 @@ public class MProductPricing
 			calculateDiscount();
 		setPrecision();		//	from Price List
 		//
-		found = new Boolean (calculated);
+		found = Boolean.valueOf(calculated);
 		return calculated;
 	}	//	calculatePrice
 

--- a/base/src/org/compiere/model/MRole.java
+++ b/base/src/org/compiere/model/MRole.java
@@ -1502,7 +1502,7 @@ public final class MRole extends X_AD_Role
 				pstmt.setInt(1, getAD_Role_ID());
 				rs = pstmt.executeQuery();
 				while (rs.next())
-					m_windowAccess.put(new Integer(rs.getInt(1)), new Boolean("Y".equals(rs.getString(2))));
+					m_windowAccess.put(new Integer(rs.getInt(1)), Boolean.valueOf("Y".equals(rs.getString(2))));
 			}
 			catch (Exception e)
 			{
@@ -1601,7 +1601,7 @@ public final class MRole extends X_AD_Role
 				pstmt.setInt(1, getAD_Role_ID());
 				rs = pstmt.executeQuery();
 				while (rs.next())
-					m_processAccess.put(new Integer(rs.getInt(1)), new Boolean("Y".equals(rs.getString(2))));
+					m_processAccess.put(new Integer(rs.getInt(1)), Boolean.valueOf("Y".equals(rs.getString(2))));
 			}
 			catch (Exception e)
 			{
@@ -1754,7 +1754,7 @@ public final class MRole extends X_AD_Role
 				pstmt.setInt(1, getAD_Role_ID());
 				rs = pstmt.executeQuery();
 				while (rs.next())
-					m_formAccess.put(new Integer(rs.getInt(1)), new Boolean("Y".equals(rs.getString(2))));
+					m_formAccess.put(new Integer(rs.getInt(1)), Boolean.valueOf("Y".equals(rs.getString(2))));
 			}
 			catch (Exception e)
 			{
@@ -1843,7 +1843,7 @@ public final class MRole extends X_AD_Role
 				pstmt.setInt(1, getAD_Role_ID());
 				rs = pstmt.executeQuery();
 				while (rs.next())
-					m_browseAccess.put(new Integer(rs.getInt(1)), new Boolean("Y".equals(rs.getString(2))));
+					m_browseAccess.put(new Integer(rs.getInt(1)), Boolean.valueOf("Y".equals(rs.getString(2))));
 			}
 			catch (Exception e)
 			{
@@ -1929,7 +1929,7 @@ public final class MRole extends X_AD_Role
 				pstmt.setInt(1, getAD_Role_ID());
 				rs = pstmt.executeQuery();
 				while (rs.next())
-					m_workflowAccess.put(new Integer(rs.getInt(1)), new Boolean("Y".equals(rs.getString(2))));
+					m_workflowAccess.put(new Integer(rs.getInt(1)), Boolean.valueOf("Y".equals(rs.getString(2))));
 			}
 			catch (Exception e)
 			{

--- a/base/src/org/compiere/model/PO.java
+++ b/base/src/org/compiere/model/PO.java
@@ -821,7 +821,7 @@ public abstract class PO
 			//	Set Boolean
 			else if (p_info.getColumnClass(index) == Boolean.class
 				&& ("Y".equals(value) || "N".equals(value)) )
-				m_newValues[index] = new Boolean("Y".equals(value));
+				m_newValues[index] = Boolean.valueOf("Y".equals(value));
 			// added by vpj-cd
 			// To solve BUG [ 1618423 ] Set Project Type button in Project window throws warning
 			// generated because C_Project.C_Project_Type_ID is defined as button in dictionary
@@ -947,7 +947,7 @@ public abstract class PO
 			//	Set Boolean
 			else if (p_info.getColumnClass(index) == Boolean.class
 				&& ("Y".equals(value) || "N".equals(value)) )
-				m_newValues[index] = new Boolean("Y".equals(value));
+				m_newValues[index] = Boolean.valueOf("Y".equals(value));
 			else if (p_info.getColumnClass(index) == Integer.class
 				&& value.getClass() == String.class)
 			{
@@ -1513,7 +1513,7 @@ public abstract class PO
 				else if (clazz == BigDecimal.class)
 					m_oldValues[index] = decrypt(index, rs.getBigDecimal(columnName));
 				else if (clazz == Boolean.class)
-					m_oldValues[index] = new Boolean ("Y".equals(decrypt(index, rs.getString(columnName))));
+					m_oldValues[index] = Boolean.valueOf("Y".equals(decrypt(index, rs.getString(columnName))));
 				else if (clazz == Timestamp.class)
 					m_oldValues[index] = decrypt(index, rs.getTimestamp(columnName));
 				else if (DisplayType.isLOB(dt) || (DisplayType.isText(dt) && p_info.getFieldLength(index) > 4000))
@@ -1577,7 +1577,7 @@ public abstract class PO
 				else if (clazz == BigDecimal.class)
 					m_oldValues[index] = new BigDecimal(value);
 				else if (clazz == Boolean.class)
-					m_oldValues[index] = new Boolean ("Y".equals(value));
+					m_oldValues[index] = Boolean.valueOf("Y".equals(value));
 				else if (clazz == Timestamp.class)
 					m_oldValues[index] = Timestamp.valueOf(value);
 				else if (DisplayType.isLOB(dt))
@@ -1731,17 +1731,17 @@ public abstract class PO
 			else if (colName.equals(p_info.getTableName() + "_ID"))    //  KeyColumn
 				m_newValues[i] = I_ZERO;
 			else if (colName.equals("IsActive"))
-				m_newValues[i] = new Boolean(true);
+				m_newValues[i] = Boolean.TRUE;
 			else if (colName.equals("AD_Client_ID"))
 				m_newValues[i] = new Integer(Env.getAD_Client_ID(p_ctx));
 			else if (colName.equals("AD_Org_ID"))
 				m_newValues[i] = new Integer(Env.getAD_Org_ID(p_ctx));
 			else if (colName.equals("Processed"))
-				m_newValues[i] = new Boolean(false);
+				m_newValues[i] = Boolean.FALSE;
 			else if (colName.equals("Processing"))
-				m_newValues[i] = new Boolean(false);
+				m_newValues[i] = Boolean.FALSE;
 			else if (colName.equals("Posted"))
-				m_newValues[i] = new Boolean(false);
+				m_newValues[i] = Boolean.FALSE;
 			else
 				m_newValues[i] = getDefaultValue(get_ColumnName(i));
 		}
@@ -1948,7 +1948,7 @@ public abstract class PO
 	 */
 	public final void setIsActive (boolean active)
 	{
-		set_Value("IsActive", new Boolean(active));
+		set_Value("IsActive", Boolean.valueOf(active));
 	}	//	setActive
 
 	/**

--- a/base/src/org/compiere/model/Scriptlet.java
+++ b/base/src/org/compiere/model/Scriptlet.java
@@ -307,12 +307,12 @@ public class Scriptlet
 		//  Boolean
 		if (stringValue.equals("Y"))
 		{
-			m_ctx.put(convertKey(key), new Boolean(true));
+			m_ctx.put(convertKey(key), Boolean.TRUE);
 			return;
 		}
 		if (stringValue.equals("N"))
 		{
-			m_ctx.put(convertKey(key), new Boolean(false));
+			m_ctx.put(convertKey(key), Boolean.FALSE);
 			return;
 		}
 

--- a/base/src/org/compiere/process/ChangeLogProcess.java
+++ b/base/src/org/compiere/process/ChangeLogProcess.java
@@ -91,9 +91,9 @@ public class ChangeLogProcess extends SvrProcess
 			if (para[i].getParameter() == null)
 				;
 			else if (name.equals("CheckNewValue"))
-				p_CheckNewValue = new Boolean("Y".equals(para[i].getParameter()));
+				p_CheckNewValue = Boolean.valueOf("Y".equals(para[i].getParameter()));
 			else if (name.equals("CheckOldValue"))
-				p_CheckOldValue = new Boolean("Y".equals(para[i].getParameter()));
+				p_CheckOldValue = Boolean.valueOf("Y".equals(para[i].getParameter()));
 			else if (name.equals("SetCustomization"))
 				p_SetCustomization = "Y".equals(para[i].getParameter());
 			else

--- a/base/src/org/compiere/wf/MWFActivity.java
+++ b/base/src/org/compiere/wf/MWFActivity.java
@@ -1093,7 +1093,7 @@ public class MWFActivity extends X_AD_WF_Activity implements Runnable
 		if (value == null)
 			;
 		else if (displayType == DisplayType.YesNo)
-			dbValue = new Boolean("Y".equals(value));
+			dbValue = Boolean.valueOf("Y".equals(value));
 		else if (DisplayType.isNumeric(displayType))
 			dbValue = new BigDecimal (value);
 		else if (DisplayType.isID(displayType)) // Fix[3409739]DocValueWorkflow_cannot_set_var_ID_Column

--- a/base/src/org/compiere/wf/MWFNodeNext.java
+++ b/base/src/org/compiere/wf/MWFNodeNext.java
@@ -219,7 +219,7 @@ public class MWFNodeNext extends X_AD_WF_NodeNext
 	 */
 	public void setFromSplitAnd (boolean fromSplitAnd)
 	{
-		m_fromSplitAnd = new Boolean(fromSplitAnd);
+		m_fromSplitAnd = Boolean.valueOf(fromSplitAnd);
 	}	//	setFromSplitAnd
 
 	/**
@@ -244,7 +244,7 @@ public class MWFNodeNext extends X_AD_WF_NodeNext
 	 */
 	private void setToJoinAnd (boolean toJoinAnd)
 	{
-		m_toJoinAnd = new Boolean(toJoinAnd);
+		m_toJoinAnd = Boolean.valueOf(toJoinAnd);
 	}	//	setToJoinAnd
 
 }	//	MWFNodeNext

--- a/base/src/org/eevolution/model/MPPOrderNodeNext.java
+++ b/base/src/org/eevolution/model/MPPOrderNodeNext.java
@@ -132,7 +132,7 @@ public class MPPOrderNodeNext extends X_PP_Order_NodeNext
 	 */
 	public void setFromSplitAnd (boolean fromSplitAnd)
 	{
-		m_fromSplitAnd = new Boolean(fromSplitAnd);
+		m_fromSplitAnd = Boolean.valueOf(fromSplitAnd);
 	}	//	setFromSplitAnd
 
 	/**
@@ -157,7 +157,7 @@ public class MPPOrderNodeNext extends X_PP_Order_NodeNext
 	 */
 	private void setToJoinAnd (boolean toJoinAnd)
 	{
-		m_toJoinAnd = new Boolean(toJoinAnd);
+		m_toJoinAnd = Boolean.valueOf(toJoinAnd);
 	}	//	setToJoinAnd
 
 	public void setPP_Order_Next_ID()

--- a/client/src/org/adempiere/controller/form/BOMDropController.java
+++ b/client/src/org/adempiere/controller/form/BOMDropController.java
@@ -222,7 +222,7 @@ public class BOMDropController implements ValueChangeListener, VetoableChangeLis
 		String explodeBOMDesc = Msg.translate(ctx, MSG_ExplodeBOMTooltip);
 		String isExplodeBOMName = Msg.translate(ctx, MSG_IsExplodeBOMName);
 		explodeBomEditor = form.createSelectionEditor(DisplayType.YesNo, null, isExplodeBOMName, explodeBOMName, explodeBOMDesc, row++, 1);
-		explodeBomEditor.setValue(new Boolean(false)); // Default - don't explode 
+		explodeBomEditor.setValue(Boolean.FALSE); // Default - don't explode 
 		addListener(explodeBomEditor);
 		
 		//  If no PO, create editors for the possible documents

--- a/client/src/org/compiere/apps/OnlineHelp.java
+++ b/client/src/org/compiere/apps/OnlineHelp.java
@@ -271,7 +271,7 @@ class Worker extends Thread
 			InputStream is = conn.getInputStream();
 			HTMLEditorKit kit = new HTMLEditorKit();
 			HTMLDocument doc = (HTMLDocument)kit.createDefaultDocument();
-			doc.putProperty("IgnoreCharsetDirective", new Boolean(true));
+			doc.putProperty("IgnoreCharsetDirective", Boolean.TRUE);
 			kit.read (new InputStreamReader(is), doc, 0);
 
 			//  Get The Links to the Help Pages

--- a/client/src/org/compiere/apps/form/Charge.java
+++ b/client/src/org/compiere/apps/form/Charge.java
@@ -93,7 +93,7 @@ public class Charge
 				line.add(rs.getString(2));          //  1-Value
 				line.add(rs.getString(3));          //  2-Name
 				boolean isExpenseType = rs.getString(4).equals("E");
-				line.add(new Boolean(isExpenseType));   //  3-Expense
+				line.add(Boolean.valueOf(isExpenseType));   //  3-Expense
 				data.add(line);
 			}
 			rs.close();

--- a/client/src/org/compiere/apps/form/CreateFromRMA.java
+++ b/client/src/org/compiere/apps/form/CreateFromRMA.java
@@ -100,7 +100,7 @@ public class CreateFromRMA extends CreateFromHelper {
             while (rs.next())
             {
                 Vector<Object> line = new Vector<Object>(7);
-                line.add(new Boolean(false));           //  0-Selection
+                line.add(Boolean.FALSE);           //  0-Selection
                 
                 KeyNamePair lineKNPair = new KeyNamePair(rs.getInt(1), rs.getString(2)); // 1-Line
                 line.add(lineKNPair);

--- a/client/src/org/compiere/apps/form/VTreeBOM.java
+++ b/client/src/org/compiere/apps/form/VTreeBOM.java
@@ -545,8 +545,8 @@ public class VTreeBOM extends CPanel implements FormPanel, ActionListener,
 
 		
 		Vector<Object> line = new Vector<Object>(17);
-		line.add( new Boolean(false));  //  0 Select
-		line.add( new Boolean(M_Product.isActive()));   //  1 IsActive
+		line.add(Boolean.FALSE);  //  0 Select
+		line.add(Boolean.valueOf(M_Product.isActive()));   //  1 IsActive
 		line.add( new Integer(0)); // 2 Line
 		KeyNamePair pp = new KeyNamePair(M_Product.getM_Product_ID(),M_Product.getValue().concat("_").concat(M_Product.getName()));
 		line.add(pp); //  3 M_Product_ID
@@ -640,8 +640,8 @@ public class VTreeBOM extends CPanel implements FormPanel, ActionListener,
 
 		
 		Vector<Object> line = new Vector<Object>(17);
-		line.add( new Boolean(false));  //  0 Select
-		line.add( new Boolean(M_Product.isActive()));   //  1 IsActive
+		line.add(Boolean.FALSE);  //  0 Select
+		line.add(Boolean.valueOf(M_Product.isActive()));   //  1 IsActive
 		line.add( new Integer(0)); // 2 Line
 		KeyNamePair pp = new KeyNamePair(M_Product.getM_Product_ID(),M_Product.getValue().concat("_").concat(M_Product.getName()));
 		line.add(pp); //  3 M_Product_ID
@@ -699,8 +699,8 @@ public class VTreeBOM extends CPanel implements FormPanel, ActionListener,
 		MProduct M_Product = MProduct.get(getCtx(), bomline.getM_ProductBOM_ID());
 
 		Vector<Object> line = new Vector<Object>(17);
-		line.add( new Boolean(false));  //  0 Select
-		line.add( new Boolean(bomline.isActive()));   //  1 IsActive
+		line.add(Boolean.FALSE);  //  0 Select
+		line.add(Boolean.valueOf(bomline.isActive()));   //  1 IsActive
 		line.add( new Integer(bomline.getLine())); // 2 Line
 		KeyNamePair pp = new KeyNamePair(M_Product.getM_Product_ID(),M_Product.getValue().concat("_").concat(M_Product.getName()));
 		line.add(pp); //  3 M_Product_ID
@@ -728,8 +728,8 @@ public class VTreeBOM extends CPanel implements FormPanel, ActionListener,
 		MProduct M_Product = MProduct.get(getCtx(), bom.getM_Product_ID());
 
 		Vector<Object> line = new Vector<Object>(17);
-		line.add( new Boolean(false));  //  0 Select
-		line.add( new Boolean(M_Product.isActive()));   //  1 IsActive
+		line.add(Boolean.FALSE);  //  0 Select
+		line.add(Boolean.valueOf(M_Product.isActive()));   //  1 IsActive
 		line.add( new Integer(bom.getLine())); // 2 Line
 		KeyNamePair pp = new KeyNamePair(M_Product.getM_Product_ID(),M_Product.getValue().concat("_").concat(M_Product.getName()));
 		line.add(pp); //  3 M_Product_ID

--- a/client/src/org/compiere/apps/search/Info.java
+++ b/client/src/org/compiere/apps/search/Info.java
@@ -1815,7 +1815,7 @@ public abstract class Info extends CDialog
 							}
 						}
 						else if (c == Boolean.class)
-							data = new Boolean("Y".equals(m_rs.getString(colIndex)));
+							data = Boolean.valueOf("Y".equals(m_rs.getString(colIndex)));
 						else if (c == Timestamp.class)
 							data = m_rs.getTimestamp(colIndex);
 						else if (c == BigDecimal.class)

--- a/client/src/org/compiere/apps/search/InvoiceHistory.java
+++ b/client/src/org/compiere/apps/search/InvoiceHistory.java
@@ -606,7 +606,7 @@ public class InvoiceHistory extends CDialog
 				line.add(rs.getString(1));      		//  Name
 				line.add(new Double(rs.getDouble(2)));  //  Qty
 				line.add(rs.getTimestamp(3));   		//  Date
-				line.add(new Boolean("Y".equals(rs.getString(4))));	//  IsSOTrx
+				line.add(Boolean.valueOf("Y".equals(rs.getString(4))));	//  IsSOTrx
 				line.add(rs.getString(5));				//  DocNo
 				line.add(rs.getString(6));				//  Warehouse
 				data.add(line);

--- a/client/src/org/compiere/grid/ed/VCheckBox.java
+++ b/client/src/org/compiere/grid/ed/VCheckBox.java
@@ -198,7 +198,7 @@ public class VCheckBox extends CCheckBox
 	 */
 	public Object getValue()
 	{
-		return new Boolean (isSelected());
+		return Boolean.valueOf(isSelected());
 	}	//	getValue
 
 	/**

--- a/client/src/org/compiere/grid/ed/VRadioButton.java
+++ b/client/src/org/compiere/grid/ed/VRadioButton.java
@@ -192,7 +192,7 @@ public class VRadioButton extends CRadioButton
 	 */
 	public Object getValue()
 	{
-		return new Boolean (isSelected());
+		return Boolean.valueOf(isSelected());
 	}	//	getValue
 
 	/**

--- a/client/src/org/compiere/grid/ed/VRowIDEditor.java
+++ b/client/src/org/compiere/grid/ed/VRowIDEditor.java
@@ -116,7 +116,7 @@ public class VRowIDEditor extends AbstractCellEditor implements TableCellEditor
 		log.fine("" + m_cb.isSelected());
 		if (m_rid == null)
 			return null;
-		m_rid[1] = new Boolean (m_cb.isSelected());
+		m_rid[1] = Boolean.valueOf(m_cb.isSelected());
 		return m_rid;
 	}	//	getCellEditorValue
 

--- a/client/src/org/compiere/minigrid/MiniTable.java
+++ b/client/src/org/compiere/minigrid/MiniTable.java
@@ -922,7 +922,7 @@ public class MiniTable extends CTable implements IMiniTable
 					if (c == IDColumn.class)
 						data = new IDColumn(rs.getInt(colIndex));
 					else if (c == Boolean.class)
-						data = new Boolean("Y".equals(rs.getString(colIndex)));
+						data = Boolean.valueOf("Y".equals(rs.getString(colIndex)));
 					else if (c == Timestamp.class)
 						data = rs.getTimestamp(colIndex);
 					else if (c == BigDecimal.class)

--- a/client/src/org/compiere/report/core/RModelData.java
+++ b/client/src/org/compiere/report/core/RModelData.java
@@ -155,7 +155,7 @@ class RModelData
 					else if (rc.getColClass() == Timestamp.class)
 						row.add(rs.getTimestamp(index++));
 					else if (rc.getColClass() == Boolean.class)
-						row.add(new Boolean("Y".equals(rs.getString(index++))));
+						row.add(Boolean.valueOf("Y".equals(rs.getString(index++))));
 					else    //  should not happen
 					{
 						row.add(rs.getString(index++));
@@ -364,7 +364,7 @@ class RModelData
 		{
 			m_groupRowsIndicator = new ArrayList<Boolean>(rows.size());
 			for (int r = 0; r < rows.size(); r++)
-				m_groupRowsIndicator.add(new Boolean(m_groupRows.contains(new Integer(r))));
+				m_groupRowsIndicator.add(Boolean.valueOf(m_groupRows.contains(new Integer(r))));
 		}
 		if (row < 0 || row >= m_groupRowsIndicator.size())
 			return false;

--- a/client/src/org/compiere/swing/CCheckBox.java
+++ b/client/src/org/compiere/swing/CCheckBox.java
@@ -270,7 +270,7 @@ public class CCheckBox extends JCheckBox implements CEditor {
 	public Object getValue() {
 		if (m_value instanceof String)
 			return super.isSelected() ? "Y" : "N";
-		return new Boolean(isSelected());
+		return Boolean.valueOf(isSelected());
 	} // getValue
 
 	/**

--- a/client/src/org/compiere/swing/CField.java
+++ b/client/src/org/compiere/swing/CField.java
@@ -181,14 +181,14 @@ public class CField extends JComboBox
 				Constructor<?> constructor = m_popupClass.getConstructor
 					(new Class<?>[] {Dialog.class, String.class, Boolean.class});
 				popup = (CFieldPopup)constructor.newInstance(new Object[]
-					{(Dialog)win, m_title, new Boolean(true)});
+					{(Dialog) win, m_title, Boolean.TRUE });
 			}
 			else if (win instanceof Frame)
 			{
 				Constructor<?> constructor = m_popupClass.getConstructor
 					(new Class[] {Frame.class, String.class, Boolean.class});
 				popup = (CFieldPopup)constructor.newInstance(new Object[]
-					{(Frame)win, m_title, new Boolean(true)});
+					{(Frame) win, m_title, Boolean.TRUE });
 			}
 			if (popup == null)
 				return false;

--- a/client/src/org/compiere/swing/CRadioButton.java
+++ b/client/src/org/compiere/swing/CRadioButton.java
@@ -260,7 +260,7 @@ public class CRadioButton extends JRadioButton implements CEditor {
 	public Object getValue() {
 		if (m_value instanceof String)
 			return super.isSelected() ? "Y" : "N";
-		return new Boolean(isSelected());
+		return Boolean.valueOf(isSelected());
 	} // getValue
 
 	/**

--- a/client/src/org/eevolution/grid/Browser.java
+++ b/client/src/org/eevolution/grid/Browser.java
@@ -1678,8 +1678,7 @@ public abstract class Browser {
 												&& DisplayType.Integer != field.getAD_Reference_ID())))
 							data = new IDColumn(no);
 						else if (DisplayType.YesNo == field.getAD_Reference_ID())
-							data = new Boolean("Y".equals(resultSet
-									.getString(colIndex)));
+							data = Boolean.valueOf("Y".equals(resultSet.getString(colIndex)));
 						else if (DisplayType.isDate(field.getAD_Reference_ID()))
 							data = resultSet.getTimestamp(colIndex);
 						else if(DisplayType.isID(field.getAD_Reference_ID())

--- a/install/src/org/compiere/install/ConfigurationPanel.java
+++ b/install/src/org/compiere/install/ConfigurationPanel.java
@@ -660,7 +660,7 @@ public class ConfigurationPanel extends CPanel implements ActionListener
 					m_success = true;
 				bTest.setEnabled(true);
 				m_testing = false;
-				return new Boolean(m_success);
+				return Boolean.valueOf(m_success);
 			}
 			//	Finish it
 			public void finished()

--- a/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSTable.java
+++ b/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSTable.java
@@ -120,7 +120,7 @@ public class WPOSTable extends WListbox {
 					}	
 					else if (columnClass == Boolean.class)
 					{
-						data = rs.getString(rsColIndex) == null ?  new Boolean(false) : new Boolean(rs.getString(rsColIndex).equals("Y"));
+						data = rs.getString(rsColIndex) == null ? Boolean.FALSE : Boolean.valueOf(rs.getString(rsColIndex).equals("Y"));
 					}
 					else if (columnClass == Timestamp.class)
 					{

--- a/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/ModelADServiceImpl.java
+++ b/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/ModelADServiceImpl.java
@@ -805,9 +805,9 @@ public class ModelADServiceImpl implements ModelADService {
 			value = null;
 		} else if (columnClass == Boolean.class) {
 			if ("Y".equalsIgnoreCase(field.getVal()) || "true".equalsIgnoreCase(field.getVal()))
-				value = new Boolean(true);
+				value = Boolean.TRUE;
 			else if ("N".equalsIgnoreCase(field.getVal()) || "false".equalsIgnoreCase(field.getVal()))
-				value = new Boolean(false);
+				value = Boolean.FALSE;
 			else
 				throw new XFireFault("Web service type "
 						+ m_webservicetype.getValue() + ": input column "

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VMRPDetailed.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VMRPDetailed.java
@@ -144,8 +144,7 @@ public class VMRPDetailed extends MRPDetailed implements FormPanel,
 							data = id;
 							p_table.setColumnReadOnly(0, false);
 						} else if (c == Boolean.class)
-							data = new Boolean("Y".equals(rs
-									.getString(colIndex)));
+							data = Boolean.valueOf("Y".equals(rs.getString(colIndex)));
 						else if (c == Timestamp.class)
 							data = rs.getTimestamp(colIndex);
 						else if (c == BigDecimal.class)

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VOrderPlanning.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VOrderPlanning.java
@@ -644,7 +644,7 @@ implements FormPanel, ActionListener, VetoableChangeListener, ChangeListener, Li
 							p_table.setColumnReadOnly(0, false);
 						}        
 						else if (c == Boolean.class)
-							data = new Boolean("Y".equals(rs.getString(colIndex)));
+							data = Boolean.valueOf("Y".equals(rs.getString(colIndex)));
 						else if (c == Timestamp.class)
 							data = rs.getTimestamp(colIndex);
 						else if (c == BigDecimal.class)

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VTreeBOM.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VTreeBOM.java
@@ -443,8 +443,8 @@ public class VTreeBOM extends TreeBOM implements FormPanel, ActionListener,
 		DefaultMutableTreeNode parent = new DefaultMutableTreeNode(productSummary(M_Product, false));
 
 		Vector<Object> line = new Vector<Object>(17);
-		line.add( new Boolean(false));  //  0 Select
-		line.add( new Boolean(true));   //  1 IsActive
+		line.add(Boolean.FALSE);  //  0 Select
+		line.add(Boolean.TRUE);   //  1 IsActive
 		line.add( new Integer(bomline.getLine())); // 2 Line                
 		line.add( (Timestamp) bomline.getValidFrom()); //  3 ValidDrom
 		line.add( (Timestamp) bomline.getValidTo()); //  4 ValidTo
@@ -452,10 +452,10 @@ public class VTreeBOM extends TreeBOM implements FormPanel, ActionListener,
 		line.add(pp); //  5 M_Product_ID
 		KeyNamePair uom = new KeyNamePair(bomline.getC_UOM_ID(),bomline.getC_UOM().getUOMSymbol());
 		line.add(uom); //  6 C_UOM_ID
-		line.add(new Boolean(bomline.isQtyPercentage())); //  7 IsQtyPorcentage
+		line.add(Boolean.valueOf(bomline.isQtyPercentage())); //  7 IsQtyPorcentage
 		line.add((BigDecimal) bomline.getQtyBatch());  //  8 BatchPercent
 		line.add((BigDecimal) ((bomline.getQtyBOM()!=null) ? bomline.getQtyBOM() : new BigDecimal(0)));  //  9 QtyBOM
-		line.add(new Boolean(bomline.isCritical())); //  10 IsCritical                  
+		line.add(Boolean.valueOf(bomline.isCritical())); //  10 IsCritical                  
 		line.add( (Integer) bomline.getLeadTimeOffset()); // 11 LTOffSet
 		line.add( (BigDecimal) bomline.getAssay()); // 12 Assay
 		line.add( (BigDecimal) (bomline.getScrap())); // 13 Scrap
@@ -492,8 +492,8 @@ public class VTreeBOM extends TreeBOM implements FormPanel, ActionListener,
 			//System.out.println("Componente :" + component.getValue() + "[" + component.getName() + "]");
 			//component(component);
 			Vector<Object> line = new Vector<Object>(17);
-			line.add( new Boolean(false));  //  0 Select
-			line.add( new Boolean(true));   //  1 IsActive
+			line.add(Boolean.FALSE);  //  0 Select
+			line.add(Boolean.TRUE);   //  1 IsActive
 			line.add( new Integer(bomline.getLine())); // 2 Line                
 			line.add( (Timestamp) bomline.getValidFrom()); //  3 ValidDrom
 			line.add( (Timestamp) bomline.getValidTo()); //  4 ValidTo
@@ -501,10 +501,10 @@ public class VTreeBOM extends TreeBOM implements FormPanel, ActionListener,
 			line.add(pp); //  5 M_Product_ID
 			KeyNamePair uom = new KeyNamePair(bomline.getC_UOM_ID(),bomline.getC_UOM().getUOMSymbol());
 			line.add(uom); //  6 C_UOM_ID
-			line.add(new Boolean(bomline.isQtyPercentage())); //  7 IsQtyPercentage
+			line.add(Boolean.valueOf(bomline.isQtyPercentage())); //  7 IsQtyPercentage
 			line.add((BigDecimal) bomline.getQtyBatch());  //  8 BatchPercent
 			line.add((BigDecimal) bomline.getQtyBOM());  //  9 QtyBom
-			line.add(new Boolean(bomline.isCritical())); //  10 IsCritical       
+			line.add(Boolean.valueOf(bomline.isCritical())); //  10 IsCritical       
 			line.add( (Integer) bomline.getLeadTimeOffset()); // 11 LTOffSet
 			line.add( (BigDecimal) bomline.getAssay()); // 12 Assay
 			line.add( (BigDecimal) (bomline.getScrap())); // 13 Scrap

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/RadioButtonTreeCellRenderer.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/RadioButtonTreeCellRenderer.java
@@ -173,8 +173,8 @@ public class RadioButtonTreeCellRenderer implements CheckboxTreeCellRenderer {
 
 
 		Vector<Comparable<?>> line = new Vector<Comparable<?>>(17);
-		line.add( new Boolean(false));  //  0 Select
-		line.add( new Boolean(true));   //  1 IsActive
+		line.add(Boolean.FALSE);  //  0 Select
+		line.add(Boolean.TRUE);   //  1 IsActive
 		line.add( new Integer(bomline.getLine())); // 2 Line                
 		line.add( (Timestamp) bomline.getValidFrom()); //  3 ValidDrom
 		line.add( (Timestamp) bomline.getValidTo()); //  4 ValidTo
@@ -182,10 +182,10 @@ public class RadioButtonTreeCellRenderer implements CheckboxTreeCellRenderer {
 		line.add(pp); //  5 M_Product_ID
 		KeyNamePair uom = new KeyNamePair(bomline.getC_UOM_ID(),"");
 		line.add(uom); //  6 C_UOM_ID
-		line.add(new Boolean(bomline.isQtyPercentage())); //  7 IsQtyPorcentage
+		line.add(Boolean.valueOf(bomline.isQtyPercentage())); //  7 IsQtyPorcentage
 		line.add((BigDecimal) bomline.getQtyBatch());  //  8 BatchPercent
 		line.add((BigDecimal) ((bomline.getQtyBOM()!=null) ? bomline.getQtyBOM() : new BigDecimal(0)));  //  9 QtyBOM
-		line.add(new Boolean(bomline.isCritical())); //  10 IsCritical                  
+		line.add(Boolean.valueOf(bomline.isCritical())); //  10 IsCritical                  
 		line.add( (Integer) bomline.getLeadTimeOffset()); // 11 LTOffSet
 		line.add( (BigDecimal) bomline.getAssay()); // 12 Assay
 		line.add( (BigDecimal) (bomline.getScrap())); // 13 Scrap
@@ -227,8 +227,8 @@ public class RadioButtonTreeCellRenderer implements CheckboxTreeCellRenderer {
 			//System.out.println("Componente :" + component.getValue() + "[" + component.getName() + "]");
 			//component(component);
 			Vector<Comparable<?>> line = new Vector<Comparable<?>>(17);
-			line.add( new Boolean(false));  //  0 Select
-			line.add( new Boolean(true));   //  1 IsActive
+			line.add(Boolean.FALSE);  //  0 Select
+			line.add(Boolean.TRUE);   //  1 IsActive
 			line.add( new Integer(bomline.getLine())); // 2 Line                
 			line.add( (Timestamp) bomline.getValidFrom()); //  3 ValidDrom
 			line.add( (Timestamp) bomline.getValidTo()); //  4 ValidTo
@@ -236,10 +236,10 @@ public class RadioButtonTreeCellRenderer implements CheckboxTreeCellRenderer {
 			line.add(pp); //  5 M_Product_ID
 			KeyNamePair uom = new KeyNamePair(bomline.getC_UOM_ID(),"");
 			line.add(uom); //  6 C_UOM_ID
-			line.add(new Boolean(bomline.isQtyPercentage())); //  7 IsQtyPercentage
+			line.add(Boolean.valueOf(bomline.isQtyPercentage())); //  7 IsQtyPercentage
 			line.add((BigDecimal) bomline.getQtyBatch());  //  8 BatchPercent
 			line.add((BigDecimal) bomline.getQtyBOM());  //  9 QtyBom
-			line.add(new Boolean(bomline.isCritical())); //  10 IsCritical       
+			line.add(Boolean.valueOf(bomline.isCritical())); //  10 IsCritical       
 			line.add( (Integer) bomline.getLeadTimeOffset()); // 11 LTOffSet
 			line.add( (BigDecimal) bomline.getAssay()); // 12 Assay
 			line.add( (BigDecimal) (bomline.getScrap())); // 13 Scrap

--- a/org.eevolution.manufacturing/src/main/java/ui/zk/org/eevolution/form/WTreeBOM.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/zk/org/eevolution/form/WTreeBOM.java
@@ -358,8 +358,8 @@ public class WTreeBOM extends TreeBOM implements IFormController, EventListener,
         SimpleTreeNode parent = new SimpleTreeNode(productSummary(M_Product, false), new ArrayList());
 
 		Vector<Object> line = new Vector<Object>(17);
-		line.add( new Boolean(false));  //  0 Select
-		line.add( new Boolean(true));   //  1 IsActive
+		line.add(Boolean.FALSE);  //  0 Select
+		line.add(Boolean.TRUE);   //  1 IsActive
 		line.add( new Integer(bomline.getLine())); // 2 Line                
 		line.add( (Timestamp) bomline.getValidFrom()); //  3 ValidDrom
 		line.add( (Timestamp) bomline.getValidTo()); //  4 ValidTo
@@ -367,10 +367,10 @@ public class WTreeBOM extends TreeBOM implements IFormController, EventListener,
 		line.add(pp); //  5 M_Product_ID
 		KeyNamePair uom = new KeyNamePair(bomline.getC_UOM_ID(),bomline.getC_UOM().getUOMSymbol());
 		line.add(uom); //  6 C_UOM_ID
-		line.add(new Boolean(bomline.isQtyPercentage())); //  7 IsQtyPorcentage
+		line.add(Boolean.valueOf(bomline.isQtyPercentage())); //  7 IsQtyPorcentage
 		line.add((BigDecimal) bomline.getQtyBatch());  //  8 BatchPercent
 		line.add((BigDecimal) ((bomline.getQtyBOM()!=null) ? bomline.getQtyBOM() : new BigDecimal(0)));  //  9 QtyBOM
-		line.add(new Boolean(bomline.isCritical())); //  10 IsCritical                  
+		line.add(Boolean.valueOf(bomline.isCritical())); //  10 IsCritical                  
 		line.add( (Integer) bomline.getLeadTimeOffset()); // 11 LTOffSet
 		line.add( (BigDecimal) bomline.getAssay()); // 12 Assay
 		line.add( (BigDecimal) (bomline.getScrap())); // 13 Scrap
@@ -395,8 +395,8 @@ public class WTreeBOM extends TreeBOM implements IFormController, EventListener,
 		{
 			MProduct component = MProduct.get(getCtx(), bomline.getM_Product_ID());
 			Vector<Object> line = new Vector<Object>(17);
-			line.add( new Boolean(false));  //  0 Select
-			line.add( new Boolean(true));   //  1 IsActive
+			line.add(Boolean.FALSE);  //  0 Select
+			line.add(Boolean.TRUE);   //  1 IsActive
 			line.add( new Integer(bomline.getLine())); // 2 Line                
 			line.add( (Timestamp) bomline.getValidFrom()); //  3 ValidDrom
 			line.add( (Timestamp) bomline.getValidTo()); //  4 ValidTo
@@ -404,10 +404,10 @@ public class WTreeBOM extends TreeBOM implements IFormController, EventListener,
 			line.add(pp); //  5 M_Product_ID
 			KeyNamePair uom = new KeyNamePair(bomline.getC_UOM_ID(),bomline.getC_UOM().getUOMSymbol());
 			line.add(uom); //  6 C_UOM_ID
-			line.add(new Boolean(bomline.isQtyPercentage())); //  7 IsQtyPercentage
+			line.add(Boolean.valueOf(bomline.isQtyPercentage())); //  7 IsQtyPercentage
 			line.add((BigDecimal) bomline.getQtyBatch());  //  8 BatchPercent
 			line.add((BigDecimal) bomline.getQtyBOM());  //  9 QtyBom
-			line.add(new Boolean(bomline.isCritical())); //  10 IsCritical       
+			line.add(Boolean.valueOf(bomline.isCritical())); //  10 IsCritical       
 			line.add( (Integer) bomline.getLeadTimeOffset()); // 11 LTOffSet
 			line.add( (BigDecimal) bomline.getAssay()); // 12 Assay
 			line.add( (BigDecimal) (bomline.getScrap())); // 13 Scrap

--- a/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
+++ b/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
@@ -326,7 +326,7 @@ public class OutBoundOrder {
 			while (rs.next()) {
 				column = 1;
 				Vector<Object> line = new Vector<Object>();
-				line.add(new Boolean(false));       		//  0-Selection
+				line.add(Boolean.FALSE);       		//  0-Selection
 				line.add(rs.getString(column++));       	//  1-Warehouse
 				KeyNamePair pp = new KeyNamePair(rs.getInt(column++), rs.getString(column++));
 				line.add(pp);				       			//  2-DocumentNo
@@ -677,7 +677,7 @@ public class OutBoundOrder {
 				}
 				//	Fill Row
 				Vector<Object> line = new Vector<Object>();
-				line.add(new Boolean(false));       			//  0-Selection
+				line.add(Boolean.FALSE);       			//  0-Selection
 				line.add(warehouse);       					//  1-Warehouse
 				line.add(documentNo);				       		//  2-DocumentNo
 				line.add(product);				      		//  3-Product

--- a/tools/src/org/apache/ecs/ECSDefaults.java
+++ b/tools/src/org/apache/ecs/ECSDefaults.java
@@ -42,9 +42,9 @@ public class ECSDefaults
 		}
 	}
 
-	private static boolean filter_state = new Boolean(resource.getString("filter_state")).booleanValue();
+	private static boolean filter_state = Boolean.valueOf(resource.getString("filter_state")).booleanValue();
 
-    private static boolean filter_attribute_state = new Boolean(resource.getString("filter_attribute_state")).booleanValue();
+    private static boolean filter_attribute_state = Boolean.valueOf(resource.getString("filter_attribute_state")).booleanValue();
 
     private static char attribute_equality_sign = resource.getString("attribute_equality_sign").charAt(1);
 
@@ -58,9 +58,9 @@ public class ECSDefaults
 
     private static char attribute_quote_char = resource.getString("attribute_quote_char").charAt(0);
 
-    private static boolean attribute_quote = new Boolean(resource.getString("attribute_quote")).booleanValue();
+    private static boolean attribute_quote = Boolean.valueOf(resource.getString("attribute_quote")).booleanValue();
 
-	private static boolean end_element = new Boolean(resource.getString("end_element")).booleanValue();
+	private static boolean end_element = Boolean.valueOf(resource.getString("end_element")).booleanValue();
 
 	private static String codeset = resource.getString("codeset");
 
@@ -72,7 +72,7 @@ public class ECSDefaults
 
 	private static char end_tag = resource.getString("end_tag").charAt(0);
 
-	private static boolean pretty_print = new Boolean(resource.getString("pretty_print")).booleanValue();
+	private static boolean pretty_print = Boolean.valueOf(resource.getString("pretty_print")).booleanValue();
 
 
 	/**

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WCreateFromPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/form/WCreateFromPanel.java
@@ -145,7 +145,7 @@ public class WCreateFromPanel extends Panel implements EventListener, WTableMode
 			ListModelTable model = dataTable.getModel();
 			int rows = model.getSize();
 			for (int i = 0; i < rows; i++) {
-				model.setValueAt(new Boolean(true), i, 0);
+				model.setValueAt(Boolean.TRUE, i, 0);
 			}
 			//refresh
 			dataTable.setModel(model);

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/component/Checkbox.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/component/Checkbox.java
@@ -85,7 +85,7 @@ public class Checkbox extends org.zkoss.zul.Checkbox
 	 */
 	public Object getValue()
 	{
-		return new Boolean (isSelected());
+		return Boolean.valueOf(isSelected());
 	}	//	getValue
 
 	/**

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/component/WListbox.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/component/WListbox.java
@@ -637,7 +637,7 @@ public class WListbox extends Listbox implements IMiniTable, TableValueChangeLis
 					}	
 					else if (columnClass == Boolean.class)
 					{
-						data = rs.getString(rsColIndex) == null ?  new Boolean(false) : new Boolean(rs.getString(rsColIndex).equals("Y"));
+						data = rs.getString(rsColIndex) == null ? Boolean.FALSE : Boolean.valueOf(rs.getString(rsColIndex).equals("Y"));
 					}
 					else if (columnClass == Timestamp.class)
 					{

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WRadioEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WRadioEditor.java
@@ -110,7 +110,7 @@ public class WRadioEditor extends WEditor implements ContextMenuListener
     @Override
     public Object getValue()
     {
-        return new Boolean(getComponent().isChecked());
+        return Boolean.valueOf(getComponent().isChecked());
     }
 
     @Override

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WYesNoEditor.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/editor/WYesNoEditor.java
@@ -114,7 +114,7 @@ public class WYesNoEditor extends WEditor implements ContextMenuListener
     @Override
     public Object getValue()
     {
-        return new Boolean(getComponent().isChecked());
+        return Boolean.valueOf(getComponent().isChecked());
     }
 
     @Override

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
@@ -815,7 +815,7 @@ public abstract class InfoPanel extends Window implements EventListener, WTableM
 						
 			}
 			else if (c == Boolean.class)
-		        value = new Boolean("Y".equals(rs.getString(colIndex)));
+		        value = Boolean.valueOf("Y".equals(rs.getString(colIndex)));
 			else if (c == Timestamp.class)
 		        value = rs.getTimestamp(colIndex);
 			else if (c == BigDecimal.class)

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/panel/InvoiceHistory.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/panel/InvoiceHistory.java
@@ -646,7 +646,7 @@ public class InvoiceHistory extends Window implements EventListener
 				line.add(rs.getString(1));      		//  Name
 				line.add(new Double(rs.getDouble(2)));  //  Qty
 				line.add(rs.getTimestamp(3));   		//  Date
-				line.add(new Boolean("Y".equals(rs.getString(4))));	//  IsSOTrx
+				line.add(Boolean.valueOf("Y".equals(rs.getString(4))));	//  IsSOTrx
 				line.add(rs.getString(5));				//  DocNo
 				line.add(rs.getString(6));				//  Warehouse
 				data.add(line);


### PR DESCRIPTION
Currently there are multiple (102) warning messages concerning the deprecated boolean constructor since java version 9:

`The constructor Boolean(boolean) is deprecated since version 9`
`The constructor Boolean(String) is deprecated since version 9`

![boolean-constructor](https://user-images.githubusercontent.com/20288327/163087223-2ebb4d63-948a-45b6-a833-4c04b835b2e2.png)


That may well work by replacing the constructor `new Boolean(boolean|String)` by `Boolean.valueOf(boolean|String)`.
