### PR TITLE
This pull request just add support to gradle builder to asset source folder

### DIFF
--- a/org.adempiere.asset/build.gradle
+++ b/org.adempiere.asset/build.gradle
@@ -1,0 +1,109 @@
+apply plugin: 'java-library'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
+
+dependencies {
+    // https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api
+    implementation group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
+    // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
+    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+    // https://mvnrepository.com/artifact/com.sun.mail/javax.mail
+	implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.4.7'
+    api 'io.github.adempiere:base:3.9.4-develop-1.0'
+    api 'io.github.adempiere:project:3.9.4-develop-1.0'
+}
+
+test {
+    exclude 'org/compiere/model/IT_MAsset.class'
+}
+
+sourceSets {
+    main {
+         java {
+            srcDirs = ['src/main/java/base']
+         }
+    }
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+signing {
+    sign configurations.archives
+}
+
+def entityType = 'D'
+version = "3.9.4-develop-1.0"
+
+jar {
+    manifest {
+        attributes("Implementation-Title": "Adempiere Project Management",
+                   "Implementation-Version": version, 
+                   "EntityType": entityType)
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            credentials {
+                username = ossrhUsername ?: System.getenv("OSSRH_USER_NAME")
+                password = ossrhPassword ?: System.getenv("OSSRH_PASSWORD")
+            }
+        }
+    }
+    publications {
+        mavenJava(MavenPublication) {
+        	groupId 'io.github.adempiere'
+            artifactId 'asset'
+            version
+           	from components.java
+           	pom {
+                name = 'Asset'
+                description = 'Fixed Asset Management of ADempiere.'
+                url = 'http://adempiere.io/'
+                licenses {
+                    license {
+                        name = 'GNU General Public License, version 2'
+                        url = 'https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'yamelsenih'
+                        name = 'Yamel Senih'
+                        email = 'ysenih@erpya.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/adempiere/adempiere.git'
+                    developerConnection = 'scm:git:ssh://github.com/adempiere/adempiere.git'
+                    url = 'http://github.com/adempiere/adempiere'
+                }
+            }
+		}
+	}
+}
+
+signing {
+    sign publishing.publications.mavenJava
+}


### PR DESCRIPTION
The gradle structure is the follow:
- adempiereTrunk:
  - org.adempiere.asset:
    - build.gradle

Now you can run the follow command to base source folder:
```Shell
gradle build
```
The dependence from tools is:
```Java
    // https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api
    implementation group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
    // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
    // https://mvnrepository.com/artifact/com.sun.mail/javax.mail
	implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.4.7'
    api 'io.github.adempiere:base:3.9.4-develop-1.0'
    api 'io.github.adempiere:project:3.9.4-develop-1.0'
```