### PR TITLE
fix: BigDecimal Round deprecated. 

### DIFF
--- a/base/src/org/adempiere/engine/AbstractCostingMethod.java
+++ b/base/src/org/adempiere/engine/AbstractCostingMethod.java
@@ -4,6 +4,7 @@
 package org.adempiere.engine;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -260,8 +261,8 @@ public abstract class AbstractCostingMethod implements ICostingMethod {
 	
 	protected void setReversalCostDetail()
 	{
-		costDetail.setCurrentCostPrice(getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(),BigDecimal.ROUND_HALF_UP));
-		costDetail.setCurrentCostPriceLL(getNewCurrentCostPriceLowerLevel(lastCostDetail, accountSchema.getCostingPrecision(),BigDecimal.ROUND_HALF_UP));
+		costDetail.setCurrentCostPrice(getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP));
+		costDetail.setCurrentCostPriceLL(getNewCurrentCostPriceLowerLevel(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP));
 		costDetail.setCurrentQty(Env.ZERO);
 		costDetail.setQty(Env.ZERO);
 		costDetail.setAmt(Env.ZERO);
@@ -304,7 +305,7 @@ public abstract class AbstractCostingMethod implements ICostingMethod {
 		accumulatedQuantity = getNewAccumulatedQuantity(costDetail);
 		accumulatedAmount = getNewAccumulatedAmount(costDetail);
 		accumulatedAmountLowerLevel = getNewAccumulatedAmountLowerLevel(costDetail);
-		currentCostPrice = getNewCurrentCostPrice(costDetail, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+		currentCostPrice = getNewCurrentCostPrice(costDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 	}
 	
 	public abstract void updateAmountCost();
@@ -316,8 +317,19 @@ public abstract class AbstractCostingMethod implements ICostingMethod {
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price This Level
+	 * @deprecated
 	 */
 	abstract public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, int roundingMode);
+	/**
+	 * Method to implement the costing method Get the New Current Cost Price
+	 * This Level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price This Level
+	 */
+	abstract public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, RoundingMode roundingMode);
+
 
 	/**
 	 * Method to implement the costing method Get the New Cumulated Amt This Level
@@ -332,8 +344,18 @@ public abstract class AbstractCostingMethod implements ICostingMethod {
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price low level
+	 * @deprecated
 	 */
 	abstract public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, int roundingMode);
+	
+	/**
+	 * Method to implement the costing method Get the New Current Cost Price low level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price low level
+	 */
+	abstract public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, RoundingMode roundingMode);
 
 	/**
 	 * Method to implement the costing method Get the new Cumulated Amt Low Level

--- a/base/src/org/adempiere/engine/AverageInvoiceCostingMethod.java
+++ b/base/src/org/adempiere/engine/AverageInvoiceCostingMethod.java
@@ -210,10 +210,10 @@ public class AverageInvoiceCostingMethod extends AbstractCostingMethod
 								.multiply(movementQuantity));
 			} // Logic to calculate adjustment when inventory is negative
 			else if (quantityOnHand.add(movementQuantity).signum() < 0
-			&& getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(),  BigDecimal.ROUND_HALF_UP).signum() != 0
+			&& getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP).signum() != 0
 			&& costThisLevel.signum() == 0  )
 			{
-				currentCostPrice = getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(),  BigDecimal.ROUND_HALF_UP);
+				currentCostPrice = getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 				adjustCost = currentCostPrice.multiply(movementQuantity).abs();
 			}
             // If period is not open then an adjustment cost is create based on quantity on hand of attribute instance
@@ -273,8 +273,8 @@ public class AverageInvoiceCostingMethod extends AbstractCostingMethod
 			// Use the last current cost price for out transaction			
 			if (quantityOnHand.add(movementQuantity).signum() >= 0)
 			{
-				currentCostPrice = getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
-				currentCostPriceLowerLevel = getNewCurrentCostPriceLowerLevel(lastCostDetail, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+				currentCostPrice = getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
+				currentCostPriceLowerLevel = getNewCurrentCostPriceLowerLevel(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 			} 
 			else
 			{
@@ -439,12 +439,25 @@ public class AverageInvoiceCostingMethod extends AbstractCostingMethod
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price This Level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0)
+		return getNewCurrentCostPrice(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
+	
+	/**
+	 * Average Invoice Get the New Current Cost Price This Level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price This Level
+	 */
+	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0) {
 			return getNewAccumulatedAmount(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+		
+		return BigDecimal.ZERO;
 	}
 
 	/**
@@ -496,12 +509,25 @@ public class AverageInvoiceCostingMethod extends AbstractCostingMethod
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price low level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0)
+		return getNewCurrentCostPriceLowerLevel(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
+
+	/**
+	 * Average Invoice Get the New Current Cost Price low level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price low level
+	 */
+	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0) {
 			return getNewAccumulatedAmountLowerLevel(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+		
+		return BigDecimal.ZERO;
 	}
 
 

--- a/base/src/org/adempiere/engine/AverageInvoiceCostingMethod.java
+++ b/base/src/org/adempiere/engine/AverageInvoiceCostingMethod.java
@@ -167,10 +167,10 @@ public class AverageInvoiceCostingMethod extends AbstractCostingMethod
 			currentCostPrice = accumulatedAmount.divide(
 					accumulatedQuantity.signum() != 0 ? accumulatedQuantity
 							: BigDecimal.ONE, accountSchema.getCostingPrecision(),
-					BigDecimal.ROUND_HALF_UP);
+							RoundingMode.HALF_UP);
 			currentCostPriceLowerLevel = accumulatedAmountLowerLevel.divide(accumulatedQuantity
 					.signum() != 0 ? accumulatedQuantity : BigDecimal.ONE, accountSchema
-					.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+					.getCostingPrecision(), RoundingMode.HALF_UP);
 
 			if(adjustCost.add(adjustCostLowerLevel).signum() == 0)
 				return;
@@ -575,8 +575,8 @@ public class AverageInvoiceCostingMethod extends AbstractCostingMethod
     public void updateInventoryValue() {
         if (accumulatedQuantity.signum() != 0)
         {
-            dimension.setCurrentCostPrice(accumulatedAmount.divide(accumulatedQuantity, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP));
-            dimension.setCurrentCostPriceLL(accumulatedAmountLowerLevel.divide(accumulatedQuantity, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP));
+            dimension.setCurrentCostPrice(accumulatedAmount.divide(accumulatedQuantity, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP));
+            dimension.setCurrentCostPriceLL(accumulatedAmountLowerLevel.divide(accumulatedQuantity, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP));
         }
         if (model.getReversalLine_ID() != 0)
 		{

--- a/base/src/org/adempiere/engine/AveragePOCostingMethod.java
+++ b/base/src/org/adempiere/engine/AveragePOCostingMethod.java
@@ -555,8 +555,8 @@ public class AveragePOCostingMethod extends AbstractCostingMethod
     public void updateInventoryValue() {
         if (accumulatedQuantity.signum() != 0)
         {
-            dimension.setCurrentCostPrice(accumulatedAmount.divide(accumulatedQuantity, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP));
-            dimension.setCurrentCostPriceLL(accumulatedAmountLowerLevel.divide(accumulatedQuantity, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP));
+            dimension.setCurrentCostPrice(accumulatedAmount.divide(accumulatedQuantity, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP));
+            dimension.setCurrentCostPriceLL(accumulatedAmountLowerLevel.divide(accumulatedQuantity, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP));
         }
         dimension.setCumulatedAmt(accumulatedAmount);
         dimension.setCumulatedAmtLL(accumulatedAmountLowerLevel);

--- a/base/src/org/adempiere/engine/AveragePOCostingMethod.java
+++ b/base/src/org/adempiere/engine/AveragePOCostingMethod.java
@@ -154,10 +154,11 @@ public class AveragePOCostingMethod extends AbstractCostingMethod
 			currentCostPrice = accumulatedAmount.divide(
 					accumulatedQuantity.signum() != 0 ? accumulatedQuantity
 							: BigDecimal.ONE, accountSchema.getCostingPrecision(),
-					BigDecimal.ROUND_HALF_UP);
+					RoundingMode.HALF_UP
+			);
 			currentCostPriceLowerLevel = accumulatedAmountLowerLevel.divide(accumulatedQuantity
 					.signum() != 0 ? accumulatedQuantity : BigDecimal.ONE, accountSchema
-					.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+					.getCostingPrecision(), RoundingMode.HALF_UP);
 
 			if(adjustCost.add(adjustCostLowerLevel).signum() == 0)
 				return;
@@ -197,10 +198,10 @@ public class AveragePOCostingMethod extends AbstractCostingMethod
 								.multiply(movementQuantity));
 			} // Logic to calculate adjustment when inventory is negative
 			else if (quantityOnHand.add(movementQuantity).signum() < 0
-			&& getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(),  BigDecimal.ROUND_HALF_UP).signum() != 0
+			&& getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP).signum() != 0
 			&& costThisLevel.signum() == 0  )
 			{
-				currentCostPrice = getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(),  BigDecimal.ROUND_HALF_UP);
+				currentCostPrice = getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 				adjustCost = currentCostPrice.multiply(movementQuantity).abs();
 			}
             // If period is not open then an adjustment cost is create based on quantity on hand of attribute instance
@@ -256,8 +257,8 @@ public class AveragePOCostingMethod extends AbstractCostingMethod
 			// Use the last current cost price for out transaction			
 			if (quantityOnHand.add(movementQuantity).signum() >= 0)
 			{
-				currentCostPrice = getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
-				currentCostPriceLowerLevel = getNewCurrentCostPriceLowerLevel(lastCostDetail, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+				currentCostPrice = getNewCurrentCostPrice(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
+				currentCostPriceLowerLevel = getNewCurrentCostPriceLowerLevel(lastCostDetail, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 			} 
 			else
 			{
@@ -432,12 +433,25 @@ public class AveragePOCostingMethod extends AbstractCostingMethod
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price This Level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0)
+		return getNewCurrentCostPrice(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
+	
+	/**
+	 * Average Invoice Get the New Current Cost Price This Level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price This Level
+	 */
+	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0) {
 			return getNewAccumulatedAmount(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+		
+		return BigDecimal.ZERO;
 	}
 
 	/**
@@ -489,12 +503,25 @@ public class AveragePOCostingMethod extends AbstractCostingMethod
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price low level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0)
+		return getNewCurrentCostPriceLowerLevel(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
+	
+	/**
+	 * Average Invoice Get the New Current Cost Price low level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price low level
+	 */
+	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0) {
 			return getNewAccumulatedAmountLowerLevel(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+		
+		return BigDecimal.ZERO;
 	}
 
 

--- a/base/src/org/adempiere/engine/CostEngine.java
+++ b/base/src/org/adempiere/engine/CostEngine.java
@@ -178,7 +178,7 @@ public class CostEngine {
 
 		if (qtyDelivered.signum() != 0)
 			actualCost = actualCost.divide(qtyDelivered,
-					accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_DOWN);
+					accountSchema.getCostingPrecision(), RoundingMode.HALF_DOWN);
 
 		BigDecimal rate = MConversionRate.getRate(
 				costCollector.getC_Currency_ID(), costCollector.getC_Currency_ID(),
@@ -187,7 +187,7 @@ public class CostEngine {
 		if (rate != null) {
 			actualCost = actualCost.multiply(rate);
 			if (actualCost.scale() > accountSchema.getCostingPrecision())
-				actualCost = actualCost.setScale(accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+				actualCost = actualCost.setScale(accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 		}
 
 		return actualCost;
@@ -227,7 +227,7 @@ public class CostEngine {
 
 		BigDecimal unitCost = Env.ZERO;
 		if (production.getProductionQty().signum() != 0 && totalCost.signum() != 0)
-			unitCost = totalCost.divide(production.getProductionQty() , accountSchema.getCostingPrecision() , BigDecimal.ROUND_HALF_UP);
+			unitCost = totalCost.divide(production.getProductionQty(), accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 
 		return unitCost;
 	}
@@ -607,8 +607,8 @@ public class CostEngine {
 				{
 					costThisLevel =  lastCostDetail.getCostAmt().add(
 							lastCostDetail.getCostAdjustment())
-							.divide(lastCostDetail.getQty(), accountSchema.getCostingPrecision(),
-									BigDecimal.ROUND_HALF_UP).abs();
+							.divide(lastCostDetail.getQty(), accountSchema.getCostingPrecision(), RoundingMode.HALF_UP)
+							.abs();
 				}
 				// return unit cost from last transaction
 				// transaction quantity is zero
@@ -619,9 +619,12 @@ public class CostEngine {
 					costThisLevel =  lastCostDetail.getCostAmt().add(
 									 lastCostDetail.getCostAdjustment()).add(
 									 lastCostDetail.getCumulatedAmt())
-							.divide(lastCostDetail.getCumulatedQty().add( lastCostDetail.getQty()),
+							.divide(
+									lastCostDetail.getCumulatedQty().add( lastCostDetail.getQty()),
 									accountSchema.getCostingPrecision(),
-							BigDecimal.ROUND_HALF_UP).abs();
+									RoundingMode.HALF_UP
+							)
+							.abs();
 					
 					return costThisLevel;
 				}	
@@ -632,9 +635,12 @@ public class CostEngine {
 				else if (lastCostDetail.getCumulatedQty().signum() != 0)
 				{
 					costThisLevel = lastCostDetail.getCumulatedAmt()
-							.divide(lastCostDetail.getCumulatedQty(),
+							.divide(
+									lastCostDetail.getCumulatedQty(),
 									accountSchema.getCostingPrecision(),
-							BigDecimal.ROUND_HALF_UP).abs();
+									RoundingMode.HALF_UP
+							)
+							.abs();
 
 					return costThisLevel;
 				}	
@@ -670,7 +676,8 @@ public class CostEngine {
 			if (lastCostDetail.getQty().signum() != 0)
 			{
 				costLowLevel =  lastCostDetail.getCostAmtLL().add(lastCostDetail.getCostAdjustmentLL())
-						.divide(lastCostDetail.getQty(), accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP).abs();
+						.divide(lastCostDetail.getQty(), accountSchema.getCostingPrecision(), RoundingMode.HALF_UP)
+						.abs();
 			}
 			// return unit cost from last transaction
 			// transaction quantity is zero
@@ -679,9 +686,12 @@ public class CostEngine {
 			else if (lastCostDetail.getCumulatedQty().add( lastCostDetail.getQty()).signum() != 0)
 			{
 				costLowLevel =  lastCostDetail.getCostAmtLL().add(lastCostDetail.getCostAdjustmentLL()).add(lastCostDetail.getCumulatedAmtLL())
-						.divide(lastCostDetail.getCumulatedQty().add( lastCostDetail.getQty()),
-								accountSchema.getCostingPrecision(),
-								BigDecimal.ROUND_HALF_UP).abs();
+						.divide(
+							lastCostDetail.getCumulatedQty().add(lastCostDetail.getQty()),
+							accountSchema.getCostingPrecision(),
+							RoundingMode.HALF_UP
+						)
+						.abs();
 
 				return costLowLevel;
 			}
@@ -692,7 +702,8 @@ public class CostEngine {
 			else if (lastCostDetail.getCumulatedQty().signum() != 0)
 			{
 				costLowLevel = lastCostDetail.getCumulatedAmtLL()
-						.divide(lastCostDetail.getCumulatedQty(), accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP).abs();
+						.divide(lastCostDetail.getCumulatedQty(), accountSchema.getCostingPrecision(), RoundingMode.HALF_UP)
+						.abs();
 				return costLowLevel;
 			}
 

--- a/base/src/org/adempiere/engine/FifoLifoCostingMethod.java
+++ b/base/src/org/adempiere/engine/FifoLifoCostingMethod.java
@@ -375,16 +375,23 @@ public class FifoLifoCostingMethod extends AbstractCostingMethod
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price This Level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPrice(MCostDetail cd, int scale,
 			int roundingMode) 
-	{		
-		if(getNewAccumulatedQuantity(cd).signum() != 0 && getNewAccumulatedAmount(cd).signum() != 0)
-			return getNewAccumulatedAmount(cd).divide(getNewAccumulatedQuantity(cd), scale , roundingMode);
-		else return BigDecimal.ZERO;
+	{
+		return getNewCurrentCostPrice(cd, scale, RoundingMode.valueOf(roundingMode));
 	}
 
+	public BigDecimal getNewCurrentCostPrice(MCostDetail cd, int scale, RoundingMode roundingMode) 
+	{
+		if (getNewAccumulatedQuantity(cd).signum() != 0 && getNewAccumulatedAmount(cd).signum() != 0) {
+			return getNewAccumulatedAmount(cd).divide(getNewAccumulatedQuantity(cd), scale , roundingMode);
+		}
 
+		return BigDecimal.ZERO;
+	}
+	
 	/**
 	 * Get the New Cumulated Amt This Level
 	 * @param cd Cost Detail
@@ -408,12 +415,26 @@ public class FifoLifoCostingMethod extends AbstractCostingMethod
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price low level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cd, int scale,
                                                        int roundingMode) {
-		if(getNewAccumulatedQuantity(cd).signum() != 0 && getNewAccumulatedAmountLowerLevel(cd).signum() != 0)
+		return getNewCurrentCostPriceLowerLevel(cd, scale , RoundingMode.valueOf(roundingMode));
+	}
+	
+	/**
+	 * Get the New Current Cost Price low level
+	 * @param cd Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price low level
+	 */
+	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cd, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cd).signum() != 0 && getNewAccumulatedAmountLowerLevel(cd).signum() != 0) {
 			return getNewAccumulatedAmountLowerLevel(cd).divide(getNewAccumulatedQuantity(cd), scale , roundingMode);
-		else return BigDecimal.ZERO;
+		}
+
+		return BigDecimal.ZERO;
 	}
 
 

--- a/base/src/org/adempiere/engine/FifoLifoCostingMethod.java
+++ b/base/src/org/adempiere/engine/FifoLifoCostingMethod.java
@@ -4,6 +4,7 @@
 package org.adempiere.engine;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -162,11 +163,11 @@ public class FifoLifoCostingMethod extends AbstractCostingMethod
 			accumulatedAmount = costDetail.getCumulatedAmt().add(amount).add(adjustCost);
 			accumulatedAmountLowerLevel = getNewAccumulatedAmountLowerLevel(lastCostDetail).add(amountLowerLevel);
 			if(accumulatedAmount.signum() != 0)
-				currentCostPrice = accumulatedAmount.divide(accumulatedQuantity.signum() != 0 ? accumulatedQuantity : BigDecimal.ONE, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+				currentCostPrice = accumulatedAmount.divide(accumulatedQuantity.signum() != 0 ? accumulatedQuantity : BigDecimal.ONE, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 			else
 				currentCostPrice = Env.ZERO;
 			if(accumulatedAmountLowerLevel.signum() != 0)
-				currentCostPriceLowerLevel = accumulatedAmountLowerLevel.divide(accumulatedQuantity.signum() != 0 ? accumulatedQuantity : BigDecimal.ONE, accountSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+				currentCostPriceLowerLevel = accumulatedAmountLowerLevel.divide(accumulatedQuantity.signum() != 0 ? accumulatedQuantity : BigDecimal.ONE, accountSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 			else
 				currentCostPriceLowerLevel = Env.ZERO;
 
@@ -199,7 +200,7 @@ public class FifoLifoCostingMethod extends AbstractCostingMethod
 		BigDecimal price = costDetail.getAmt();
 
 		if (costDetail.getQty().signum() != 0)
-			price = costDetail.getAmt().divide(costDetail.getQty(), precision, BigDecimal.ROUND_HALF_UP);
+			price = costDetail.getAmt().divide(costDetail.getQty(), precision, RoundingMode.HALF_UP);
 
 		int AD_Org_ID = costDetail.getAD_Org_ID();
 		int M_ASI_ID = costDetail.getM_AttributeSetInstance_ID();
@@ -233,7 +234,7 @@ public class FifoLifoCostingMethod extends AbstractCostingMethod
 				{
 					BigDecimal priceQueue = Env.ZERO;
 					if (costDetail.getQty().signum() != 0)
-						priceQueue = amtQueue.divide(costDetail.getQty(), precision, BigDecimal.ROUND_HALF_UP);
+						priceQueue = amtQueue.divide(costDetail.getQty(), precision, RoundingMode.HALF_UP);
 					log.warning("Amt not match "+this+": price="+price+", priceQueue="+priceQueue+" [ADJUSTED]");
 					// FIXME: teo_sarca: should not happen
 					if ("Y".equals(Env.getContext(costDetail.getCtx(), "#M_CostDetail_CorrectAmt")))

--- a/base/src/org/adempiere/engine/LastInvoiceCostingMethod.java
+++ b/base/src/org/adempiere/engine/LastInvoiceCostingMethod.java
@@ -4,6 +4,7 @@
 package org.adempiere.engine;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 import org.compiere.model.MAcctSchema;
@@ -54,7 +55,7 @@ public class LastInvoiceCostingMethod extends AbstractCostingMethod implements I
 		BigDecimal price = costDetail.getAmt();
 
 		if (costDetail.getQty().signum() != 0)
-			price = costDetail.getAmt().divide(costDetail.getQty(), precision, BigDecimal.ROUND_HALF_UP);
+			price = costDetail.getAmt().divide(costDetail.getQty(), precision, RoundingMode.HALF_UP);
 		if (costDetail.getC_OrderLine_ID() != 0) {
 			if (!isReturnTrx) {
 				if (costDetail.getQty().signum() != 0)

--- a/base/src/org/adempiere/engine/LastInvoiceCostingMethod.java
+++ b/base/src/org/adempiere/engine/LastInvoiceCostingMethod.java
@@ -98,12 +98,25 @@ public class LastInvoiceCostingMethod extends AbstractCostingMethod implements I
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price This Level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0)
+			return getNewCurrentCostPrice(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
+	
+	/**
+	 * Average Invoice Get the New Current Cost Price This Level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price This Level
+	 */
+	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0) {
 			return getNewAccumulatedAmount(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+		
+		return BigDecimal.ZERO;
 	}
 
 	/**
@@ -155,12 +168,25 @@ public class LastInvoiceCostingMethod extends AbstractCostingMethod implements I
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price low level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0)
+		return getNewCurrentCostPriceLowerLevel(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
+	
+	/**
+	 * Average Invoice Get the New Current Cost Price low level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price low level
+	 */
+	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0) {
 			return getNewAccumulatedAmountLowerLevel(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+
+		return BigDecimal.ZERO;
 	}
 
 

--- a/base/src/org/adempiere/engine/LastPOPriceCostingMethod.java
+++ b/base/src/org/adempiere/engine/LastPOPriceCostingMethod.java
@@ -101,12 +101,24 @@ public class LastPOPriceCostingMethod extends AbstractCostingMethod implements I
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price This Level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0)
+		return getNewCurrentCostPrice(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
+	
+	/**
+	 * Average Invoice Get the New Current Cost Price This Level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price This Level
+	 */
+	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0) {
 			return getNewAccumulatedAmount(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+		return BigDecimal.ZERO;
 	}
 
 	/**
@@ -158,12 +170,25 @@ public class LastPOPriceCostingMethod extends AbstractCostingMethod implements I
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price low level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0)
+		return getNewCurrentCostPriceLowerLevel(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
+	
+	/**
+	 * Average Invoice Get the New Current Cost Price low level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price low level
+	 */
+	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0) {
 			return getNewAccumulatedAmountLowerLevel(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+
+		return BigDecimal.ZERO;
 	}
 
 

--- a/base/src/org/adempiere/engine/LastPOPriceCostingMethod.java
+++ b/base/src/org/adempiere/engine/LastPOPriceCostingMethod.java
@@ -4,6 +4,7 @@
 package org.adempiere.engine;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 import org.compiere.model.MAcctSchema;
@@ -55,7 +56,7 @@ public class LastPOPriceCostingMethod extends AbstractCostingMethod implements I
 		BigDecimal price = costDetail.getAmt();
 
 		if ( costDetail.getQty().signum() != 0)
-			price =  costDetail.getAmt().divide(costDetail.getQty(), precision, BigDecimal.ROUND_HALF_UP);
+			price =  costDetail.getAmt().divide(costDetail.getQty(), precision, RoundingMode.HALF_UP);
 
 		if ( costDetail.getC_OrderLine_ID() != 0) {
 			if (!isReturnTrx) {

--- a/base/src/org/adempiere/engine/StandardCostingMethod.java
+++ b/base/src/org/adempiere/engine/StandardCostingMethod.java
@@ -218,12 +218,25 @@ public class StandardCostingMethod extends AbstractCostingMethod implements
 	 * @param scale Scale
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price This Level
+	 * @deprecated
 	 */
 	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0)
+		return getNewCurrentCostPrice(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
+	
+	/**
+	 * Average Invoice Get the New Current Cost Price This Level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price This Level
+	 */
+	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmount(cost).signum() != 0) {
 			return getNewAccumulatedAmount(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+
+		return BigDecimal.ZERO;
 	}
 
 	/**
@@ -268,6 +281,17 @@ public class StandardCostingMethod extends AbstractCostingMethod implements
 		return accumulatedAmountLowerLevel;
 	}
 
+	/**
+	 * Average Invoice Get the New Current Cost Price low level
+	 * @param cost Cost Detail
+	 * @param scale Scale
+	 * @param roundingMode Rounding Mode
+	 * @return New Current Cost Price low level
+	 * @deprecated
+	 */
+	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, int roundingMode) {
+		return getNewCurrentCostPriceLowerLevel(cost, scale, RoundingMode.valueOf(roundingMode));
+	}
 
 	/**
 	 * Average Invoice Get the New Current Cost Price low level
@@ -276,11 +300,12 @@ public class StandardCostingMethod extends AbstractCostingMethod implements
 	 * @param roundingMode Rounding Mode
 	 * @return New Current Cost Price low level
 	 */
-	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, int roundingMode) {
-		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0)
+	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		if (getNewAccumulatedQuantity(cost).signum() != 0 && getNewAccumulatedAmountLowerLevel(cost).signum() != 0) {
 			return getNewAccumulatedAmountLowerLevel(cost).divide(getNewAccumulatedQuantity(cost), scale, roundingMode);
-		else
-			return BigDecimal.ZERO;
+		}
+		
+		return BigDecimal.ZERO;
 	}
 
 	/**

--- a/base/src/org/adempiere/model/PromotionRule.java
+++ b/base/src/org/adempiere/model/PromotionRule.java
@@ -271,7 +271,7 @@ public class PromotionRule {
 									}
 									else {  // : Gift line
 										BigDecimal qtyreward = pr.getM_PromotionDistribution().getQty();
-										BigDecimal qtymodulo = ol.getQtyOrdered().divide(qtyreward,0);
+										BigDecimal qtymodulo = ol.getQtyOrdered().divide(qtyreward, RoundingMode.UP);
 										addGiftLine(order, ol, pr.getAmount(), pr.getQty().multiply(qtymodulo), pr.getC_Charge_ID(), pr.getM_Promotion());
 									} 
 								}

--- a/base/src/org/adempiere/model/PromotionRule.java
+++ b/base/src/org/adempiere/model/PromotionRule.java
@@ -14,6 +14,7 @@
 package org.adempiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -297,7 +298,7 @@ public class PromotionRule {
 		
 		MOrderLine nol;
 		if (discount.scale() > 2)
-			discount = discount.setScale(2, BigDecimal.ROUND_HALF_UP);
+			discount = discount.setScale(2, RoundingMode.HALF_UP);
 		String description = promotion.getName();
 		if (ol != null)
 			description += (", " + ol.getName());
@@ -659,11 +660,11 @@ public class PromotionRule {
 			BigDecimal qty, int C_Charge_ID, I_M_Promotion promotion) throws Exception {
 		MOrderLine nol;
 		if (discount.scale() > 2)
-			discount = discount.setScale(2, BigDecimal.ROUND_HALF_UP);
+			discount = discount.setScale(2, RoundingMode.HALF_UP);
 		
 		// Calculate discount
 		BigDecimal actualPrice = ol.getPriceActual();
-		actualPrice = actualPrice.setScale(2, BigDecimal.ROUND_HALF_UP);
+		actualPrice = actualPrice.setScale(2, RoundingMode.HALF_UP);
 		BigDecimal multiplicator = Env.ONEHUNDRED.subtract(discount).divide(Env.ONEHUNDRED);
 		actualPrice = actualPrice.multiply(multiplicator);
 		

--- a/base/src/org/adempiere/pdf/SmjPdfReport.java
+++ b/base/src/org/adempiere/pdf/SmjPdfReport.java
@@ -8,6 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.Date;
 import java.util.Iterator;
@@ -573,7 +574,7 @@ public class SmjPdfReport extends PdfPageEventHelper {
 			return "";
 		else{
 			DecimalFormat frm = new DecimalFormat("###,###,###,##0.00");
-			return frm.format(data.setScale(2, BigDecimal.ROUND_HALF_UP));	// Goodwill BF Rounding is necessary
+			return frm.format(data.setScale(2, RoundingMode.HALF_UP));	// Goodwill BF Rounding is necessary
 		}
 	}// formatValue
 

--- a/base/src/org/adempiere/process/SB_InOutGenerateFromOrderLine.java
+++ b/base/src/org/adempiere/process/SB_InOutGenerateFromOrderLine.java
@@ -17,6 +17,7 @@
 package org.adempiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -329,7 +330,7 @@ public class SB_InOutGenerateFromOrderLine extends SB_InOutGenerateFromOrderLine
 			if (orderLine.getQtyEntered().compareTo(orderLine.getQtyOrdered()) != 0)
 				line.setQtyEntered(qty
 					.multiply(orderLine.getQtyEntered())
-					.divide(orderLine.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP));
+					.divide(orderLine.getQtyOrdered(), 12, RoundingMode.HALF_UP));
 			line.setLine(m_line + orderLine.getLine());
 			line.saveEx();
 			log.fine(line.toString());
@@ -388,7 +389,7 @@ public class SB_InOutGenerateFromOrderLine extends SB_InOutGenerateFromOrderLine
 				line.setQty(line.getMovementQty().add(deliver));
 			if (orderLine.getQtyEntered().compareTo(orderLine.getQtyOrdered()) != 0)
 				line.setQtyEntered(line.getMovementQty().multiply(orderLine.getQtyEntered())
-					.divide(orderLine.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP));
+					.divide(orderLine.getQtyOrdered(), 12, RoundingMode.HALF_UP));
 			line.setLine(m_line + orderLine.getLine());
 			line.saveEx();
 			log.fine("ToDeliver=" + qty + "/" + deliver + " - " + line);

--- a/base/src/org/adempiere/process/SB_InvoiceGenerateFromOrderLine.java
+++ b/base/src/org/adempiere/process/SB_InvoiceGenerateFromOrderLine.java
@@ -17,6 +17,7 @@
 package org.adempiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -231,7 +232,7 @@ public class SB_InvoiceGenerateFromOrderLine extends SB_InvoiceGenerateFromOrder
 						if (oLine.getQtyEntered().compareTo(oLine.getQtyOrdered()) != 0)
 							qtyEntered = toInvoice
 								.multiply(oLine.getQtyEntered())
-								.divide(oLine.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP);
+								.divide(oLine.getQtyOrdered(), 12, RoundingMode.HALF_UP);
 						createLine (order, oLine, toInvoice, qtyEntered);
 					}
 					else

--- a/base/src/org/adempiere/process/rpl/imp/ImportHelper.java
+++ b/base/src/org/adempiere/process/rpl/imp/ImportHelper.java
@@ -29,6 +29,7 @@
 package org.adempiere.process.rpl.imp;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.text.ParseException;
@@ -695,7 +696,7 @@ public class ImportHelper {
 			else if( DisplayType.isNumeric(column.getAD_Reference_ID()))
 			{
 				valuecol="Round("+valuecol+",2)";
-				params[col] = new BigDecimal((String)cols[col]).setScale(2, BigDecimal.ROUND_HALF_UP);
+				params[col] = new BigDecimal((String) cols[col]).setScale(2, RoundingMode.HALF_UP);
 			}
 			else
 			{	

--- a/base/src/org/compiere/acct/Doc_AllocationHdr.java
+++ b/base/src/org/compiere/acct/Doc_AllocationHdr.java
@@ -17,6 +17,7 @@
 package org.compiere.acct;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
@@ -796,7 +797,7 @@ public class Doc_AllocationHdr extends Doc
 			//	Round
 			int precision = acctSchema.getStdPrecision();
 			if (acctDifference.scale() > precision)
-				acctDifference = acctDifference.setScale(precision, BigDecimal.ROUND_HALF_UP);
+				acctDifference = acctDifference.setScale(precision, RoundingMode.HALF_UP);
 			String d2 = "(partial) = " + acctDifference + " - Multiplier=" + multiplier;
 			log.fine(d2);
 			description += " - " + d2;
@@ -1104,10 +1105,10 @@ class Doc_AllocationTax
 			|| amt.signum() == 0)
 			return Env.ZERO;
 		//
-		BigDecimal multiplier = tax.divide(total, 10, BigDecimal.ROUND_HALF_UP); 
+		BigDecimal multiplier = tax.divide(total, 10, RoundingMode.HALF_UP); 
 		BigDecimal retValue = multiplier.multiply(amt);
 		if (retValue.scale() > precision)
-			retValue = retValue.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			retValue = retValue.setScale(precision, RoundingMode.HALF_UP);
 		log.fine(retValue + " (Mult=" + multiplier + "(Prec=" + precision + ")");
 		return retValue;
 	}	//	calcAmount

--- a/base/src/org/compiere/acct/Doc_Invoice.java
+++ b/base/src/org/compiere/acct/Doc_Invoice.java
@@ -17,6 +17,7 @@
 package org.compiere.acct;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -835,7 +836,7 @@ public class Doc_Invoice extends Doc
 		Arrays.stream(landedCostAllocations)
 				.filter(landedCostAllocation -> landedCostAllocation.getBase().signum() != 0) // only cost allocation with base > 0
 				.forEach(landedCostAllocation -> {
-			BigDecimal percent = landedCostAllocation.getBase().divide(totalBase, BigDecimal.ROUND_HALF_UP);
+			BigDecimal percent = landedCostAllocation.getBase().divide(totalBase, RoundingMode.HALF_UP);
 			String desc = invoiceLine.getDescription();
 			if (desc == null)
 				desc = percent + "%";

--- a/base/src/org/compiere/acct/Doc_MatchInv.java
+++ b/base/src/org/compiere/acct/Doc_MatchInv.java
@@ -17,6 +17,7 @@
 package org.compiere.acct;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 
@@ -159,7 +160,7 @@ public class Doc_MatchInv extends Doc
 		//  NotInvoicedReceipt      DR
 		//  From Receipt
 		BigDecimal multiplier = getQty()
-			.divide(m_receiptLine.getMovementQty(), 12, BigDecimal.ROUND_HALF_UP)
+			.divide(m_receiptLine.getMovementQty(), 12, RoundingMode.HALF_UP)
 			.abs();
 		FactLine dr = fact.createLine (null,
 			getAccount(Doc.ACCTTYPE_NotInvoicedReceipts, as),
@@ -203,7 +204,7 @@ public class Doc_MatchInv extends Doc
 			expense = m_pc.getAccount(ProductCost.ACCTTYPE_P_Expense, as);
 		BigDecimal LineNetAmt = m_invoiceLine.getLineNetAmt();
 		multiplier = getQty()
-			.divide(m_invoiceLine.getQtyInvoiced(), 12, BigDecimal.ROUND_HALF_UP)
+			.divide(m_invoiceLine.getQtyInvoiced(), 12, RoundingMode.HALF_UP)
 			.abs();
 		if (multiplier.compareTo(Env.ONE) != 0)
 			LineNetAmt = LineNetAmt.multiply(multiplier);

--- a/base/src/org/compiere/acct/Doc_MatchPO.java
+++ b/base/src/org/compiere/acct/Doc_MatchPO.java
@@ -17,6 +17,7 @@
 package org.compiere.acct;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -169,7 +170,7 @@ public class Doc_MatchPO extends Doc
 			}
 			poCost = poCost.multiply(rate);
 			if (poCost.scale() > as.getCostingPrecision())
-				poCost = poCost.setScale(as.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+				poCost = poCost.setScale(as.getCostingPrecision(), RoundingMode.HALF_UP);
 		}
 
 		//	Calculate PPV for standard costing
@@ -202,7 +203,7 @@ public class Doc_MatchPO extends Doc
             }
 	
 			//	Difference
-			BigDecimal difference = poCost.subtract(costs.setScale(as.getCostingPrecision(), BigDecimal.ROUND_HALF_UP));
+			BigDecimal difference = poCost.subtract(costs.setScale(as.getCostingPrecision(), RoundingMode.HALF_UP));
 			//	Nothing to post
 			if (difference.signum() == 0)
 			{

--- a/base/src/org/compiere/acct/FactLine.java
+++ b/base/src/org/compiere/acct/FactLine.java
@@ -17,6 +17,7 @@
 package org.compiere.acct;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -226,14 +227,14 @@ public final class FactLine extends X_Fact_Acct
 		int precision = MCurrency.getStdPrecision(getCtx(), C_Currency_ID);
 		if (AmtSourceDr != null && AmtSourceDr.scale() > precision)
 		{
-			BigDecimal AmtSourceDr1 = AmtSourceDr.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal AmtSourceDr1 = AmtSourceDr.setScale(precision, RoundingMode.HALF_UP);
 			if (AmtSourceDr1.compareTo(AmtSourceDr) != 0)
 				log.warning("Source DR Precision " + AmtSourceDr + " -> " + AmtSourceDr1);
 			setAmtSourceDr(AmtSourceDr1);
 		}
 		if (AmtSourceCr != null && AmtSourceCr.scale() > precision)
 		{
-			BigDecimal AmtSourceCr1 = AmtSourceCr.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal AmtSourceCr1 = AmtSourceCr.setScale(precision, RoundingMode.HALF_UP);
 			if (AmtSourceCr1.compareTo(AmtSourceCr) != 0)
 				log.warning("Source CR Precision " + AmtSourceCr + " -> " + AmtSourceCr1);
 			setAmtSourceCr(AmtSourceCr1);
@@ -269,14 +270,14 @@ public final class FactLine extends X_Fact_Acct
 		int precision = MCurrency.getStdPrecision(getCtx(), C_Currency_ID);
 		if (AmtAcctDr != null && AmtAcctDr.scale() > precision)
 		{
-			BigDecimal AmtAcctDr1 = AmtAcctDr.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal AmtAcctDr1 = AmtAcctDr.setScale(precision, RoundingMode.HALF_UP);
 			if (AmtAcctDr1.compareTo(AmtAcctDr) != 0)
 				log.warning("Accounted DR Precision " + AmtAcctDr + " -> " + AmtAcctDr1);
 			setAmtAcctDr(AmtAcctDr1);
 		}
 		if (AmtAcctCr != null && AmtAcctCr.scale() > precision)
 		{
-			BigDecimal AmtAcctCr1 = AmtAcctCr.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal AmtAcctCr1 = AmtAcctCr.setScale(precision, RoundingMode.HALF_UP);
 			if (AmtAcctCr1.compareTo(AmtAcctCr) != 0)
 				log.warning("Accounted CR Precision " + AmtAcctCr + " -> " + AmtAcctCr1);
 			setAmtAcctCr(AmtAcctCr1);

--- a/base/src/org/compiere/db/DB_MariaDB.java
+++ b/base/src/org/compiere/db/DB_MariaDB.java
@@ -16,6 +16,7 @@
 package org.compiere.db;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -405,7 +406,7 @@ public class DB_MariaDB implements AdempiereDatabase {
 		int scale = DisplayType.getDefaultPrecision(displayType);
 		if (scale > number.scale()) {
 			try {
-				result = number.setScale(scale, BigDecimal.ROUND_HALF_UP);
+				result = number.setScale(scale, RoundingMode.HALF_UP);
 			} catch (Exception e) {
 				// log.severe("Number=" + number + ", Scale=" + " - " +
 				// e.getMessage());

--- a/base/src/org/compiere/db/DB_MySQL.java
+++ b/base/src/org/compiere/db/DB_MySQL.java
@@ -27,6 +27,7 @@
 package org.compiere.db;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -440,7 +441,7 @@ public class DB_MySQL implements AdempiereDatabase {
 		int scale = DisplayType.getDefaultPrecision(displayType);
 		if (scale > number.scale()) {
 			try {
-				result = number.setScale(scale, BigDecimal.ROUND_HALF_UP);
+				result = number.setScale(scale, RoundingMode.HALF_UP);
 			} catch (Exception e) {
 				// log.severe("Number=" + number + ", Scale=" + " - " +
 				// e.getMessage());

--- a/base/src/org/compiere/db/DB_Oracle.java
+++ b/base/src/org/compiere/db/DB_Oracle.java
@@ -17,6 +17,7 @@
 package org.compiere.db;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.Driver;
@@ -513,7 +514,7 @@ public class DB_Oracle implements AdempiereDatabase
         {
             try
             {
-                result = number.setScale(scale, BigDecimal.ROUND_HALF_UP);
+                result = number.setScale(scale, RoundingMode.HALF_UP);
             }
             catch (Exception e)
             {

--- a/base/src/org/compiere/db/DB_PostgreSQL.java
+++ b/base/src/org/compiere/db/DB_PostgreSQL.java
@@ -37,6 +37,7 @@ import javax.sql.ConnectionPoolDataSource;
 import javax.sql.DataSource;
 import javax.sql.RowSet;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -460,7 +461,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 		{
 			try
 			{
-				result = number.setScale(scale, BigDecimal.ROUND_HALF_UP);
+				result = number.setScale(scale, RoundingMode.HALF_UP);
 			}
 			catch (Exception e)
 			{

--- a/base/src/org/compiere/impexp/ImpFormatRow.java
+++ b/base/src/org/compiere/impexp/ImpFormatRow.java
@@ -18,6 +18,7 @@
 package org.compiere.impexp;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -500,7 +501,7 @@ public final class ImpFormatRow
 			return "0";
 		BigDecimal bd = new BigDecimal(sb.toString());
 		if (m_divideBy100)					//	assumed two decimal scale
-			bd = bd.divide(new BigDecimal(100.0), 2, BigDecimal.ROUND_HALF_UP);
+			bd = bd.divide(new BigDecimal(100.0), 2, RoundingMode.HALF_UP);
 		return bd.toString();
 	}	//	parseNumber
 

--- a/base/src/org/compiere/model/CalloutEngine.java
+++ b/base/src/org/compiere/model/CalloutEngine.java
@@ -18,6 +18,7 @@ package org.compiere.model;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -253,7 +254,7 @@ public class CalloutEngine implements Callout
 		BigDecimal one = new BigDecimal(1.0);
 
 		if (rate1.doubleValue() != 0.0)	//	no divide by zero
-			rate2 = one.divide(rate1, 12, BigDecimal.ROUND_HALF_UP);
+			rate2 = one.divide(rate1, 12, RoundingMode.HALF_UP);
 		//
 		if (mField.getColumnName().equals("MultiplyRate"))
 			mTab.setValue("DivideRate", rate2);

--- a/base/src/org/compiere/model/CalloutGLJournal.java
+++ b/base/src/org/compiere/model/CalloutGLJournal.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -224,10 +225,10 @@ public class CalloutGLJournal extends CalloutEngine
 			AmtSourceCr = Env.ZERO;
 
 		BigDecimal AmtAcctDr = AmtSourceDr.multiply(CurrencyRate);
-		AmtAcctDr = AmtAcctDr.setScale(Precision, BigDecimal.ROUND_HALF_UP);
+		AmtAcctDr = AmtAcctDr.setScale(Precision, RoundingMode.HALF_UP);
 		mTab.setValue("AmtAcctDr", AmtAcctDr);
 		BigDecimal AmtAcctCr = AmtSourceCr.multiply(CurrencyRate);
-		AmtAcctCr = AmtAcctCr.setScale(Precision, BigDecimal.ROUND_HALF_UP);
+		AmtAcctCr = AmtAcctCr.setScale(Precision, RoundingMode.HALF_UP);
 		mTab.setValue("AmtAcctCr", AmtAcctCr);
 
 		return "";

--- a/base/src/org/compiere/model/CalloutInOut.java
+++ b/base/src/org/compiere/model/CalloutInOut.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -412,7 +413,7 @@ public class CalloutInOut extends CalloutEngine
 			BigDecimal QtyEntered = MovementQty;
 			if (ol.getQtyEntered().compareTo(ol.getQtyOrdered()) != 0)
 				QtyEntered = QtyEntered.multiply(ol.getQtyEntered())
-					.divide(ol.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP);
+					.divide(ol.getQtyOrdered(), 12, RoundingMode.HALF_UP);
 			mTab.setValue("QtyEntered", QtyEntered);
 			//
 			mTab.setValue("C_Activity_ID", new Integer(ol.getC_Activity_ID()));
@@ -565,7 +566,7 @@ public class CalloutInOut extends CalloutEngine
 		{
 			int C_UOM_To_ID = ((Integer)value).intValue();
 			QtyEntered = (BigDecimal)mTab.getValue("QtyEntered");
-			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
 			if (QtyEntered.compareTo(QtyEntered1) != 0)
 			{
 				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID
@@ -596,7 +597,7 @@ public class CalloutInOut extends CalloutEngine
 		{
 			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
 			QtyEntered = (BigDecimal)value;
-			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
 			if (QtyEntered.compareTo(QtyEntered1) != 0)
 			{
 				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID
@@ -622,7 +623,7 @@ public class CalloutInOut extends CalloutEngine
 			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
 			MovementQty = (BigDecimal)value;
 			int precision = MProduct.get(ctx, M_Product_ID).getUOMPrecision();
-			BigDecimal MovementQty1 = MovementQty.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal MovementQty1 = MovementQty.setScale(precision, RoundingMode.HALF_UP);
 			if (MovementQty.compareTo(MovementQty1) != 0)
 			{
 				log.fine("Corrected MovementQty "

--- a/base/src/org/compiere/model/CalloutInvoice.java
+++ b/base/src/org/compiere/model/CalloutInvoice.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -638,7 +639,7 @@ public class CalloutInvoice extends CalloutEngine
 			{
 				discount = new BigDecimal ((priceList.doubleValue () - priceActual.doubleValue ()) / priceList.doubleValue () * 100.0);
 				if (discount.scale () > 2)
-					discount = discount.setScale (2, BigDecimal.ROUND_HALF_UP);
+					discount = discount.setScale(2, RoundingMode.HALF_UP);
 			//	mTab.setValue ("Discount", Discount);
 			}
 		}
@@ -658,7 +659,7 @@ public class CalloutInvoice extends CalloutEngine
 			lineNetAmount = quantityInvoiced.multiply(priceActual);
 		}
 		if (lineNetAmount.scale() > standardPrecision)
-			lineNetAmount = lineNetAmount.setScale(standardPrecision, BigDecimal.ROUND_HALF_UP);
+			lineNetAmount = lineNetAmount.setScale(standardPrecision, RoundingMode.HALF_UP);
 		log.info("amt = LineNetAmt=" + lineNetAmount);
 		mTab.setValue("LineNetAmt", lineNetAmount);
 
@@ -744,7 +745,7 @@ public class CalloutInvoice extends CalloutEngine
 		{
 			int C_UOM_To_ID = ((Integer)value).intValue();
 			QtyEntered = (BigDecimal)mTab.getValue("QtyEntered");
-			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
 			if (QtyEntered.compareTo(QtyEntered1) != 0)
 			{
 				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID 
@@ -775,7 +776,7 @@ public class CalloutInvoice extends CalloutEngine
 		{
 			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
 			QtyEntered = (BigDecimal)value;
-			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
 			if (QtyEntered.compareTo(QtyEntered1) != 0)
 			{
 				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID 
@@ -801,7 +802,7 @@ public class CalloutInvoice extends CalloutEngine
 			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
 			QtyInvoiced = (BigDecimal)value;
 			int precision = MProduct.get(ctx, M_Product_ID).getUOMPrecision(); 
-			BigDecimal QtyInvoiced1 = QtyInvoiced.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyInvoiced1 = QtyInvoiced.setScale(precision, RoundingMode.HALF_UP);
 			if (QtyInvoiced.compareTo(QtyInvoiced1) != 0)
 			{
 				log.fine("Corrected QtyInvoiced Scale "

--- a/base/src/org/compiere/model/CalloutInvoiceBatch.java
+++ b/base/src/org/compiere/model/CalloutInvoiceBatch.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -365,7 +366,7 @@ public class CalloutInvoiceBatch extends CalloutEngine
 		//	Line Net Amt
 		BigDecimal LineNetAmt = QtyEntered.multiply(PriceEntered);
 		if (LineNetAmt.scale() > StdPrecision)
-			LineNetAmt = LineNetAmt.setScale(StdPrecision, BigDecimal.ROUND_HALF_UP);
+			LineNetAmt = LineNetAmt.setScale(StdPrecision, RoundingMode.HALF_UP);
 
 		//	Calculate Tax Amount
 		boolean IsSOTrx = "Y".equals(Env.getContext(Env.getCtx(), WindowNo, "IsSOTrx"));

--- a/base/src/org/compiere/model/CalloutOrder.java
+++ b/base/src/org/compiere/model/CalloutOrder.java
@@ -24,6 +24,7 @@ import org.compiere.util.Ini;
 import org.compiere.util.Msg;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -1079,7 +1080,7 @@ public class CalloutOrder extends CalloutEngine
 			if ( priceList.doubleValue() != 0 )
 				priceActual = new BigDecimal ((100.0 - discount.doubleValue()) / 100.0 * priceList.doubleValue());
 			if (priceActual.scale() > standardPrecision)
-				priceActual = priceActual.setScale(standardPrecision, BigDecimal.ROUND_HALF_UP);
+				priceActual = priceActual.setScale(standardPrecision, RoundingMode.HALF_UP);
 			priceEntered = MUOMConversion.convertProductFrom (ctx, productId, 
 				uOMToId, priceActual);
 			if (priceEntered == null)
@@ -1095,7 +1096,7 @@ public class CalloutOrder extends CalloutEngine
 			else
 				discount = new BigDecimal ((priceList.doubleValue() - priceActual.doubleValue()) / priceList.doubleValue() * 100.0);
 			if (discount.scale() > 2)
-				discount = discount.setScale(2, BigDecimal.ROUND_HALF_UP);
+				discount = discount.setScale(2, RoundingMode.HALF_UP);
 			mTab.setValue("Discount", discount);
 		}
 		log.fine("PriceEntered=" + priceEntered + ", Actual=" + priceActual + ", Discount=" + discount);
@@ -1118,7 +1119,7 @@ public class CalloutOrder extends CalloutEngine
 			{
 				discount = new BigDecimal ((priceList.doubleValue () - priceActual.doubleValue ()) / priceList.doubleValue () * 100.0);
 				if (discount.scale () > 2)
-					discount = discount.setScale (2, BigDecimal.ROUND_HALF_UP);
+					discount = discount.setScale (2, RoundingMode.HALF_UP);
 				mTab.setValue ("Discount", discount);
 			}
 		}
@@ -1138,7 +1139,7 @@ public class CalloutOrder extends CalloutEngine
 			lineNetAmount = quantityOrdered.multiply(priceActual);
 		}
 		if (lineNetAmount.scale() > standardPrecision)
-			lineNetAmount = lineNetAmount.setScale(standardPrecision, BigDecimal.ROUND_HALF_UP);
+			lineNetAmount = lineNetAmount.setScale(standardPrecision, RoundingMode.HALF_UP);
 		log.info("LineNetAmt=" + lineNetAmount);
 		mTab.setValue("LineNetAmt", lineNetAmount);
 		//
@@ -1177,7 +1178,7 @@ public class CalloutOrder extends CalloutEngine
 		{
 			int C_UOM_To_ID = ((Integer)value).intValue();
 			QtyEntered = (BigDecimal)mTab.getValue("QtyEntered");
-			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
 			if (QtyEntered.compareTo(QtyEntered1) != 0)
 			{
 				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID 
@@ -1208,7 +1209,7 @@ public class CalloutOrder extends CalloutEngine
 		{
 			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
 			QtyEntered = (BigDecimal)value;
-			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
 			if (QtyEntered.compareTo(QtyEntered1) != 0)
 			{
 				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID 
@@ -1234,7 +1235,7 @@ public class CalloutOrder extends CalloutEngine
 			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
 			QtyOrdered = (BigDecimal)value;
 			int precision = MProduct.get(ctx, M_Product_ID).getUOMPrecision(); 
-			BigDecimal QtyOrdered1 = QtyOrdered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyOrdered1 = QtyOrdered.setScale(precision, RoundingMode.HALF_UP);
 			if (QtyOrdered.compareTo(QtyOrdered1) != 0)
 			{
 				log.fine("Corrected QtyOrdered Scale " 

--- a/base/src/org/compiere/model/CalloutPaySelection.java
+++ b/base/src/org/compiere/model/CalloutPaySelection.java
@@ -19,6 +19,7 @@ package org.compiere.model;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -191,10 +192,8 @@ public class CalloutPaySelection extends CalloutEngine
 		if(OpenAmt.doubleValue() != 0) {
 			CurrentCurrencyRate = AmtSource.divide(OpenAmt, MathContext.DECIMAL128);
 			//	
-			DiscountAmt = DiscountAmt.multiply(CurrentCurrencyRate).setScale(
-					currency.getStdPrecision(), BigDecimal.ROUND_HALF_UP);
-			PayAmt = PayAmt.multiply(CurrentCurrencyRate).setScale(
-					currency.getStdPrecision(), BigDecimal.ROUND_HALF_UP);
+			DiscountAmt = DiscountAmt.multiply(CurrentCurrencyRate).setScale(currency.getStdPrecision(), RoundingMode.HALF_UP);
+			PayAmt = PayAmt.multiply(CurrentCurrencyRate).setScale(currency.getStdPrecision(), RoundingMode.HALF_UP);
 		}
 		//	For Conversion Rate
 		if(C_Conversion_Rate_ID != 0) {
@@ -218,13 +217,10 @@ public class CalloutPaySelection extends CalloutEngine
 		log.fine ("Rate=" + CurrencyRate + ", InvoiceOpenAmt="
 			+ AmtSource);
 		//	Set Open Amount
-		OpenAmt = AmtSource.multiply(CurrencyRate).setScale(
-				currency.getStdPrecision(), BigDecimal.ROUND_HALF_UP);
+		OpenAmt = AmtSource.multiply(CurrencyRate).setScale(currency.getStdPrecision(), RoundingMode.HALF_UP);
 		// Currency Changed - convert all
-		PayAmt = PayAmt.multiply(CurrencyRate).setScale(
-				currency.getStdPrecision(), BigDecimal.ROUND_HALF_UP);
-		DiscountAmt = DiscountAmt.multiply (CurrencyRate).setScale(
-				currency.getStdPrecision (), BigDecimal.ROUND_HALF_UP);
+		PayAmt = PayAmt.multiply(CurrencyRate).setScale(currency.getStdPrecision(), RoundingMode.HALF_UP);
+		DiscountAmt = DiscountAmt.multiply(CurrencyRate).setScale(currency.getStdPrecision (), RoundingMode.HALF_UP);
 		//	Set difference
 		DifferenceAmt = OpenAmt.subtract(PayAmt).subtract(DiscountAmt);
 		//	Set values

--- a/base/src/org/compiere/model/CalloutPayment.java
+++ b/base/src/org/compiere/model/CalloutPayment.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -401,8 +402,7 @@ public class CalloutPayment extends CalloutEngine
 				return "NoCurrencyConversion";
 			}
 			//
-			InvoiceOpenAmt = InvoiceOpenAmt.multiply (CurrencyRate).setScale (
-				currency.getStdPrecision (), BigDecimal.ROUND_HALF_UP);
+			InvoiceOpenAmt = InvoiceOpenAmt.multiply(CurrencyRate).setScale(currency.getStdPrecision(), RoundingMode.HALF_UP);
 			log.fine ("Rate=" + CurrencyRate + ", InvoiceOpenAmt="
 				+ InvoiceOpenAmt);
 		}
@@ -410,17 +410,13 @@ public class CalloutPayment extends CalloutEngine
 		if (colName.equals ("C_Currency_ID")
 			|| colName.equals ("C_ConversionType_ID"))
 		{
-			PayAmt = PayAmt.multiply (CurrencyRate).setScale (
-				currency.getStdPrecision (), BigDecimal.ROUND_HALF_UP);
+			PayAmt = PayAmt.multiply(CurrencyRate).setScale(currency.getStdPrecision(), RoundingMode.HALF_UP);
 			mTab.setValue ("PayAmt", PayAmt);
-			DiscountAmt = DiscountAmt.multiply (CurrencyRate).setScale (
-				currency.getStdPrecision (), BigDecimal.ROUND_HALF_UP);
+			DiscountAmt = DiscountAmt.multiply(CurrencyRate).setScale(currency.getStdPrecision(), RoundingMode.HALF_UP);
 			mTab.setValue ("DiscountAmt", DiscountAmt);
-			WriteOffAmt = WriteOffAmt.multiply (CurrencyRate).setScale (
-				currency.getStdPrecision (), BigDecimal.ROUND_HALF_UP);
+			WriteOffAmt = WriteOffAmt.multiply(CurrencyRate).setScale(currency.getStdPrecision(), RoundingMode.HALF_UP);
 			mTab.setValue ("WriteOffAmt", WriteOffAmt);
-			OverUnderAmt = OverUnderAmt.multiply (CurrencyRate).setScale (
-				currency.getStdPrecision (), BigDecimal.ROUND_HALF_UP);
+			OverUnderAmt = OverUnderAmt.multiply(CurrencyRate).setScale(currency.getStdPrecision(), RoundingMode.HALF_UP);
 			mTab.setValue ("OverUnderAmt", OverUnderAmt);
 		}
 		// No Invoice - Set Discount, Witeoff, Under/Over to 0

--- a/base/src/org/compiere/model/CalloutRequisition.java
+++ b/base/src/org/compiere/model/CalloutRequisition.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.Properties;
 
@@ -90,7 +91,7 @@ public class CalloutRequisition extends CalloutEngine
 		//	Multiply
 		BigDecimal LineNetAmt = Qty.multiply(PriceActual);
 		if (LineNetAmt.scale() > StdPrecision)
-			LineNetAmt = LineNetAmt.setScale(StdPrecision, BigDecimal.ROUND_HALF_UP);
+			LineNetAmt = LineNetAmt.setScale(StdPrecision, RoundingMode.HALF_UP);
 		line.setLineNetAmt(LineNetAmt);
 		log.info("amt - LineNetAmt=" + LineNetAmt);
 		//

--- a/base/src/org/compiere/model/MAllocationHdr.java
+++ b/base/src/org/compiere/model/MAllocationHdr.java
@@ -28,6 +28,7 @@ import org.compiere.util.Msg;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -1099,7 +1100,7 @@ public final class MAllocationHdr extends X_C_AllocationHdr implements DocAction
 						} else {
 								//	allocation as a percentage of the invoice
 								BigDecimal multiplier = invoice.getOpenAmt().signum() == 0 ? BigDecimal.ONE :
-									allocationAmount.divide(invoice.getOpenAmt(), 8, BigDecimal.ROUND_HALF_UP);
+									allocationAmount.divide(invoice.getOpenAmt(), 8, RoundingMode.HALF_UP);
 								//	Reduce Orig Invoice Accounted
 								invoiceAmountAccounted = invoiceAmountAccounted.multiply(multiplier);
 								//	Difference based on percentage of Orig Invoice
@@ -1110,7 +1111,7 @@ public final class MAllocationHdr extends X_C_AllocationHdr implements DocAction
 								//	Round
 								int precision = MCurrency.getStdPrecision(getCtx(), client.getC_Currency_ID());
 								if (openBalanceDifference.scale() > precision)
-									openBalanceDifference = openBalanceDifference.setScale(precision, BigDecimal.ROUND_HALF_UP);
+									openBalanceDifference = openBalanceDifference.setScale(precision, RoundingMode.HALF_UP);
 						}
 					}
 
@@ -1152,7 +1153,7 @@ public final class MAllocationHdr extends X_C_AllocationHdr implements DocAction
 						}
 						int precision = MCurrency.getStdPrecision(getCtx(), client.getC_Currency_ID());
 						if (newCreditAmount.scale() > precision)
-							newCreditAmount = newCreditAmount.setScale(precision, BigDecimal.ROUND_HALF_UP);
+							newCreditAmount = newCreditAmount.setScale(precision, RoundingMode.HALF_UP);
 
 						partner.setSO_CreditUsed(newCreditAmount);
 					}

--- a/base/src/org/compiere/model/MBPGroup.java
+++ b/base/src/org/compiere/model/MBPGroup.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.Properties;
@@ -226,7 +227,7 @@ public class MBPGroup extends X_C_BP_Group
 	{
 		BigDecimal bd = super.getCreditWatchPercent();
 		if (bd != Env.ZERO)
-			return bd.divide(Env.ONEHUNDRED, 2, BigDecimal.ROUND_HALF_UP);
+			return bd.divide(Env.ONEHUNDRED, 2, RoundingMode.HALF_UP);
 		return new BigDecimal(0.90);
 	}	//	getCreditWatchRatio
 

--- a/base/src/org/compiere/model/MBankStatementLine.java
+++ b/base/src/org/compiere/model/MBankStatementLine.java
@@ -18,6 +18,7 @@
 package org.compiere.model;
  
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.Optional;
@@ -205,7 +206,7 @@ import org.compiere.util.Msg;
                     payment.getAD_Org_ID()))
             		.orElseThrow(() -> new AdempiereException(errorMassage.toString()));
             //	Set convert amount
-			paymentAmount.updateAndGet(payAmount -> payAmount.multiply(currencyRate).setScale(currencyTo.getStdPrecision(), BigDecimal.ROUND_HALF_UP));
+			paymentAmount.updateAndGet(payAmount -> payAmount.multiply(currencyRate).setScale(currencyTo.getStdPrecision(), RoundingMode.HALF_UP));
         }
         setC_Payment_ID (payment.getC_Payment_ID());
         setC_Currency_ID (bankAccount.getC_Currency_ID());

--- a/base/src/org/compiere/model/MColorSchema.java
+++ b/base/src/org/compiere/model/MColorSchema.java
@@ -18,6 +18,7 @@ package org.compiere.model;
 
 import java.awt.Color;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.util.Properties;
 
@@ -54,7 +55,7 @@ public class MColorSchema extends X_PA_ColorSchema
 			&& target != null && target.signum() != 0)
 		{
 			BigDecimal pp = actual.multiply(Env.ONEHUNDRED)
-				.divide(target, 0, BigDecimal.ROUND_HALF_UP);
+				.divide(target, 0, RoundingMode.HALF_UP);
 			percent = pp.intValue();
 		}
 		return getColor(ctx, PA_ColorSchema_ID, percent);

--- a/base/src/org/compiere/model/MCommissionDetail.java
+++ b/base/src/org/compiere/model/MCommissionDetail.java
@@ -18,6 +18,7 @@ package org.compiere.model;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -167,7 +168,7 @@ public class MCommissionDetail extends X_C_CommissionDetail
 		commissionAmt = commissionAmt.multiply(commissionLine.getAmtMultiplier());
 		//	Scale
 		if (commissionAmt.scale() > stdPrecision) {
-			commissionAmt = commissionAmt.setScale(stdPrecision, BigDecimal.ROUND_HALF_UP);
+			commissionAmt = commissionAmt.setScale(stdPrecision, RoundingMode.HALF_UP);
 		}
 		//	Set Commission
 		setCommissionAmt(commissionAmt);
@@ -313,13 +314,13 @@ public class MCommissionDetail extends X_C_CommissionDetail
 		// Proportional overall commission reduction: there is no distinction among the different commissions paid (too complex)
 		BigDecimal percentage = Env.ONE;
 		if (getActualQty().compareTo(qtyReturned)==1) {
-			percentage = qtyReturned.divide(getActualQty(), 4, BigDecimal.ROUND_HALF_UP);
+			percentage = qtyReturned.divide(getActualQty(), 4, RoundingMode.HALF_UP);
 		}
 		
 		// all negated
-		setActualAmt(getActualAmt().multiply(percentage).setScale(2, BigDecimal.ROUND_HALF_UP).negate());	
-		setActualQty(getActualQty().multiply(percentage).setScale(2, BigDecimal.ROUND_HALF_UP).negate());
-		setConvertedAmt(getConvertedAmt().multiply(percentage).setScale(2, BigDecimal.ROUND_HALF_UP).negate());
+		setActualAmt(getActualAmt().multiply(percentage).setScale(2, RoundingMode.HALF_UP).negate());	
+		setActualQty(getActualQty().multiply(percentage).setScale(2, RoundingMode.HALF_UP).negate());
+		setConvertedAmt(getConvertedAmt().multiply(percentage).setScale(2, RoundingMode.HALF_UP).negate());
 		return;		
 	}  // correctForRMA
 }	//	MCommissionDetail

--- a/base/src/org/compiere/model/MConversionRate.java
+++ b/base/src/org/compiere/model/MConversionRate.java
@@ -18,6 +18,7 @@ package org.compiere.model;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
@@ -129,7 +130,7 @@ public class MConversionRate extends X_C_Conversion_Rate
 		retValue = retValue.multiply(Amt);
 		int stdPrecision = MCurrency.getStdPrecision(ctx, CurTo_ID);
 		if (retValue.scale() > stdPrecision)
-			retValue = retValue.setScale(stdPrecision, BigDecimal.ROUND_HALF_UP);
+			retValue = retValue.setScale(stdPrecision, RoundingMode.HALF_UP);
 			
 		return retValue;
 	}	//	convert

--- a/base/src/org/compiere/model/MCost.java
+++ b/base/src/org/compiere/model/MCost.java
@@ -18,6 +18,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -1278,8 +1279,8 @@ public class MCost extends X_M_Cost
 				BigDecimal averageCurrent = oldStockQty.multiply(oldAverageAmt);
 				BigDecimal averageIncrease = matchQty.multiply(cost);
 				BigDecimal newAmt = averageCurrent.add(averageIncrease);
-				newAmt = newAmt.setScale(as.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
-				newAverageAmt = newAmt.divide(newStockQty, as.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+				newAmt = newAmt.setScale(as.getCostingPrecision(), RoundingMode.HALF_UP);
+				newAverageAmt = newAmt.divide(newStockQty, as.getCostingPrecision(), RoundingMode.HALF_UP);
 				s_log.finer("Movement=" + movementQty + ", StockQty=" + newStockQty
 					+ ", Match=" + matchQty + ", Cost=" + cost + ", NewAvg=" + newAverageAmt);
 			}
@@ -1374,8 +1375,8 @@ public class MCost extends X_M_Cost
 				BigDecimal averageCurrent = oldStockQty.multiply(oldAverageAmt);
 				BigDecimal averageIncrease = matchQty.multiply(cost);
 				BigDecimal newAmt = averageCurrent.add(averageIncrease);
-				newAmt = newAmt.setScale(as.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
-				newAverageAmt = newAmt.divide(newStockQty, as.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+				newAmt = newAmt.setScale(as.getCostingPrecision(), RoundingMode.HALF_UP);
+				newAverageAmt = newAmt.divide(newStockQty, as.getCostingPrecision(), RoundingMode.HALF_UP);
 				s_log.finer("Movement=" + movementQty + ", StockQty=" + newStockQty
 					+ ", Match=" + matchQty + ", Cost=" + cost + ", NewAvg=" + newAverageAmt);
 			}
@@ -1852,7 +1853,7 @@ public class MCost extends X_M_Cost
 		BigDecimal sumQty = getCurrentQty().add(qty);
 		if (sumQty.signum() != 0)
 		{
-			BigDecimal cost = sumAmt.divide(sumQty, getPrecision(), BigDecimal.ROUND_HALF_UP);
+			BigDecimal cost = sumAmt.divide(sumQty, getPrecision(), RoundingMode.HALF_UP);
 			setCurrentCostPrice(cost);
 		}
 		//
@@ -1895,7 +1896,7 @@ public class MCost extends X_M_Cost
 		if (getCumulatedQty().signum() != 0
 			&& getCumulatedAmt().signum() != 0)
 			retValue = getCumulatedAmt()
-				.divide(getCumulatedQty(), getPrecision(), BigDecimal.ROUND_HALF_UP);
+				.divide(getCumulatedQty(), getPrecision(), RoundingMode.HALF_UP);
 		return retValue;
 	}	//	getHistoryAverage
 

--- a/base/src/org/compiere/model/MCostDetail.java
+++ b/base/src/org/compiere/model/MCostDetail.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -174,7 +175,7 @@ public class MCostDetail extends X_M_CostDetail
 				.add(costDetail.getCostAdjustment())
 				.add(costDetail.getCostAmtLL())
 				.add(costDetail.getCostAdjustmentLL())
-				.setScale(acctSchema.getCostingPrecision(), BigDecimal.ROUND_HALF_UP);
+				.setScale(acctSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 	}
 	
 	public static List<MCostDetail> getByCollectorCost(MPPCostCollector costCollector)

--- a/base/src/org/compiere/model/MCostQueue.java
+++ b/base/src/org/compiere/model/MCostQueue.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -617,7 +618,7 @@ public class MCostQueue extends X_M_CostQueue
 		BigDecimal sumQty = getCurrentQty().add(qty);
 		if (sumQty.signum() != 0)
 		{
-			BigDecimal cost = sumAmt.divide(sumQty, precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal cost = sumAmt.divide(sumQty, precision, RoundingMode.HALF_UP);
 			setCurrentCostPrice(cost);
 		}
 		//

--- a/base/src/org/compiere/model/MDiscountSchema.java
+++ b/base/src/org/compiere/model/MDiscountSchema.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
@@ -220,7 +221,7 @@ public class MDiscountSchema extends X_M_DiscountSchema
 		//
 		BigDecimal onehundred = new BigDecimal(100);
 		BigDecimal multiplier = (onehundred).subtract(discount);
-		multiplier = multiplier.divide(onehundred, 6, BigDecimal.ROUND_HALF_UP);
+		multiplier = multiplier.divide(onehundred, 6, RoundingMode.HALF_UP);
 		BigDecimal newPrice = Price.multiply(multiplier);
 		log.fine("=>" + newPrice);
 		return newPrice;

--- a/base/src/org/compiere/model/MDistributionLine.java
+++ b/base/src/org/compiere/model/MDistributionLine.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.util.Properties;
 
@@ -193,7 +194,7 @@ public class MDistributionLine extends X_GL_DistributionLine
 	public void calculateAmt (BigDecimal amt, int precision)
 	{
 		amount = amt.multiply(getPercent());
-		amount = amount.divide(Env.ONEHUNDRED, precision, BigDecimal.ROUND_HALF_UP);
+		amount = amount.divide(Env.ONEHUNDRED, precision, RoundingMode.HALF_UP);
 	}	//	setAmt
 
 	/**
@@ -203,7 +204,7 @@ public class MDistributionLine extends X_GL_DistributionLine
 	public void calculateQty (BigDecimal qty)
 	{
 		quantity = qty.multiply(getPercent());
-		quantity = quantity.divide(Env.ONEHUNDRED, BigDecimal.ROUND_HALF_UP);
+		quantity = quantity.divide(Env.ONEHUNDRED, RoundingMode.HALF_UP);
 	}	//	setAmt
 
 	

--- a/base/src/org/compiere/model/MDistributionRunDetail.java
+++ b/base/src/org/compiere/model/MDistributionRunDetail.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
@@ -127,13 +128,13 @@ public class MDistributionRunDetail extends X_T_DistributionRunDetail
 		BigDecimal min = getMinQty();
 		if (min.scale() > m_precision)
 		{
-			setMinQty(min.setScale(m_precision, BigDecimal.ROUND_HALF_UP));
+			setMinQty(min.setScale(m_precision, RoundingMode.HALF_UP));
 			dirty = true;
 		}
 		BigDecimal qty = getQty();
 		if (qty.scale() > m_precision)
 		{
-			setQty(qty.setScale(m_precision, BigDecimal.ROUND_HALF_UP));
+			setQty(qty.setScale(m_precision, RoundingMode.HALF_UP));
 			dirty = true;
 		}
 		if (dirty)
@@ -168,7 +169,7 @@ public class MDistributionRunDetail extends X_T_DistributionRunDetail
 	 */
 	public BigDecimal adjustQty (BigDecimal difference)
 	{
-		BigDecimal diff = difference.setScale(m_precision, BigDecimal.ROUND_HALF_UP);
+		BigDecimal diff = difference.setScale(m_precision, RoundingMode.HALF_UP);
 		BigDecimal qty = getQty();
 		BigDecimal max = getMinQty().subtract(qty);
 		BigDecimal remaining = Env.ZERO;

--- a/base/src/org/compiere/model/MGoal.java
+++ b/base/src/org/compiere/model/MGoal.java
@@ -18,6 +18,7 @@ package org.compiere.model;
 
 import java.awt.Color;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -407,7 +408,7 @@ public class MGoal extends X_PA_Goal
 		BigDecimal MeasureActual = getMeasureActual();
 		BigDecimal GoalPerformance = Env.ZERO;
 		if (MeasureTarget.signum() != 0)
-			GoalPerformance = MeasureActual.divide(MeasureTarget, 6, BigDecimal.ROUND_HALF_UP);
+			GoalPerformance = MeasureActual.divide(MeasureTarget, 6, RoundingMode.HALF_UP);
 		super.setGoalPerformance (GoalPerformance);
 		m_color = null;
 	}	//	setGoalPerformance

--- a/base/src/org/compiere/model/MInOut.java
+++ b/base/src/org/compiere/model/MInOut.java
@@ -18,6 +18,7 @@ package org.compiere.model;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -155,7 +156,7 @@ public class MInOut extends X_M_InOut implements DocAction , DocumentReversalEna
 				if (oLines[i].getQtyEntered().compareTo(oLines[i].getQtyOrdered()) != 0)
 					inOutLine.setQtyEntered(lineQty
 						.multiply(oLines[i].getQtyEntered())
-						.divide(oLines[i].getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP));
+						.divide(oLines[i].getQtyOrdered(), 12, RoundingMode.HALF_UP));
 				inOutLine.setC_Project_ID(oLines[i].getC_Project_ID());
 				inOutLine.save(trxName);
 				//	Delivered everything ?

--- a/base/src/org/compiere/model/MInOutLine.java
+++ b/base/src/org/compiere/model/MInOutLine.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.List;
@@ -370,7 +371,7 @@ implements IDocumentLine , DocumentReversalLineEnable
 		if (QtyEntered != null && getC_UOM_ID() != 0)
 		{
 			int precision = MUOM.getPrecision(getCtx(), getC_UOM_ID());
-			QtyEntered = QtyEntered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			QtyEntered = QtyEntered.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setQtyEntered (QtyEntered);
 	}	//	setQtyEntered
@@ -385,7 +386,7 @@ implements IDocumentLine , DocumentReversalLineEnable
 		if (MovementQty != null && product != null)
 		{
 			int precision = product.getUOMPrecision();
-			MovementQty = MovementQty.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			MovementQty = MovementQty.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setMovementQty(MovementQty);
 	}	//	setMovementQty

--- a/base/src/org/compiere/model/MInventoryLine.java
+++ b/base/src/org/compiere/model/MInventoryLine.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.Properties;
@@ -164,7 +165,7 @@ public class MInventoryLine extends X_M_InventoryLine implements IDocumentLine ,
 			if (product != null)
 			{
 				int precision = product.getUOMPrecision(); 
-				QtyCount = QtyCount.setScale(precision, BigDecimal.ROUND_HALF_UP);
+				QtyCount = QtyCount.setScale(precision, RoundingMode.HALF_UP);
 			}
 		}
 		super.setQtyCount(QtyCount);

--- a/base/src/org/compiere/model/MInventoryLine.java
+++ b/base/src/org/compiere/model/MInventoryLine.java
@@ -184,7 +184,7 @@ public class MInventoryLine extends X_M_InventoryLine implements IDocumentLine ,
 			if (product != null)
 			{
 				int precision = product.getUOMPrecision(); 
-				QtyInternalUse = QtyInternalUse.setScale(precision, BigDecimal.ROUND_HALF_UP);
+				QtyInternalUse = QtyInternalUse.setScale(precision, RoundingMode.HALF_UP);
 			}
 		}
 		super.setQtyInternalUse(QtyInternalUse);

--- a/base/src/org/compiere/model/MInvoiceLine.java
+++ b/base/src/org/compiere/model/MInvoiceLine.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -512,7 +513,7 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 		}
 		
 		if (lineNetAmount.scale() > getPrecision())
-			lineNetAmount = lineNetAmount.setScale(getPrecision(), BigDecimal.ROUND_HALF_UP);
+			lineNetAmount = lineNetAmount.setScale(getPrecision(), RoundingMode.HALF_UP);
 		super.setLineNetAmt (lineNetAmount);
 	}	//	setLineNetAmt
 	/**
@@ -564,7 +565,7 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 		if (QtyEntered != null && getC_UOM_ID() != 0)
 		{
 			int precision = MUOM.getPrecision(getCtx(), getC_UOM_ID());
-			QtyEntered = QtyEntered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			QtyEntered = QtyEntered.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setQtyEntered (QtyEntered);
 	}	//	setQtyEntered
@@ -579,7 +580,7 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 		if (QtyInvoiced != null && product != null)
 		{
 			int precision = product.getUOMPrecision();
-			QtyInvoiced = QtyInvoiced.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			QtyInvoiced = QtyInvoiced.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setQtyInvoiced(QtyInvoiced);
 	}	//	setQtyInvoiced

--- a/base/src/org/compiere/model/MInvoiceLine.java
+++ b/base/src/org/compiere/model/MInvoiceLine.java
@@ -370,7 +370,7 @@ public class MInvoiceLine extends X_C_InvoiceLine implements DocumentReversalLin
 			setPriceEntered(getPriceActual());
 		else
 			setPriceEntered(getPriceActual().multiply(getQtyInvoiced()
-				.divide(getQtyEntered(), 6, BigDecimal.ROUND_HALF_UP)));	//	precision
+				.divide(getQtyEntered(), 6, RoundingMode.HALF_UP)));	//	precision
 		//
 		if (getC_UOM_ID() == 0)
 			setC_UOM_ID(m_productPricing.getC_UOM_ID());

--- a/base/src/org/compiere/model/MInvoicePaySchedule.java
+++ b/base/src/org/compiere/model/MInvoicePaySchedule.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -163,10 +164,10 @@ public class MInvoicePaySchedule extends X_C_InvoicePaySchedule
 		else
 		{
 			due = due.multiply(paySchedule.getPercentage())
-				.divide(HUNDRED, scale, BigDecimal.ROUND_HALF_UP);
+				.divide(HUNDRED, scale, RoundingMode.HALF_UP);
 			setDueAmt (due);
 			BigDecimal discount = due.multiply(paySchedule.getDiscount())
-				.divide(HUNDRED, scale, BigDecimal.ROUND_HALF_UP);
+				.divide(HUNDRED, scale, RoundingMode.HALF_UP);
 			setDiscountAmt (discount);
 			setIsValid(true);
 		}

--- a/base/src/org/compiere/model/MJournalLine.java
+++ b/base/src/org/compiere/model/MJournalLine.java
@@ -311,7 +311,7 @@ public class MJournalLine extends X_GL_JournalLine implements DocumentReversalLi
 		BigDecimal currencyRate = getCurrencyRate();
 		BigDecimal amountDebit = currencyRate.multiply(getAmtSourceDr());
 		if (amountDebit.scale() > getPrecision())
-			amountDebit = amountDebit.setScale(getPrecision(), BigDecimal.ROUND_HALF_UP);
+			amountDebit = amountDebit.setScale(getPrecision(), RoundingMode.HALF_UP);
 		setAmtAcctDr(amountDebit);
 		amountDebit = currencyRate.multiply(getAmtSourceCr());
 		if (amountDebit.scale() > getPrecision())

--- a/base/src/org/compiere/model/MJournalLine.java
+++ b/base/src/org/compiere/model/MJournalLine.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.Properties;
@@ -314,7 +315,7 @@ public class MJournalLine extends X_GL_JournalLine implements DocumentReversalLi
 		setAmtAcctDr(amountDebit);
 		amountDebit = currencyRate.multiply(getAmtSourceCr());
 		if (amountDebit.scale() > getPrecision())
-			amountDebit = amountDebit.setScale(getPrecision(), BigDecimal.ROUND_HALF_UP);
+			amountDebit = amountDebit.setScale(getPrecision(), RoundingMode.HALF_UP);
 		setAmtAcctCr(amountDebit);
 		//	Set Line Org to Acct Org
 	/*	if (newRecord 

--- a/base/src/org/compiere/model/MLandedCostAllocation.java
+++ b/base/src/org/compiere/model/MLandedCostAllocation.java
@@ -22,6 +22,7 @@ import org.compiere.util.DB;
 import org.compiere.util.Env;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -161,7 +162,7 @@ public class MLandedCostAllocation extends X_C_LandedCostAllocation implements I
 	{
 		BigDecimal bd = new BigDecimal(Amt);
 		if (bd.scale() > precision)
-			bd = bd.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			bd = bd.setScale(precision, RoundingMode.HALF_UP);
 		super.setAmt(bd);
 	}	//	setAmt
 
@@ -204,7 +205,7 @@ public class MLandedCostAllocation extends X_C_LandedCostAllocation implements I
 				, getC_ConversionType_ID()
 				, getAD_Client_ID()
 				, getAD_Org_ID())
-				.divide( getQty(),invoiceLine.getParent().getM_PriceList().getPricePrecision() , BigDecimal.ROUND_HALF_UP);
+				.divide( getQty(),invoiceLine.getParent().getM_PriceList().getPricePrecision() , RoundingMode.HALF_UP);
 		if (MDocType.DOCBASETYPE_APCreditMemo.equals(invoiceLine.getParent().getC_DocType().getDocBaseType()))
 			return amount.negate();
 
@@ -256,7 +257,7 @@ public class MLandedCostAllocation extends X_C_LandedCostAllocation implements I
 
 	public BigDecimal getPriceActualCurrency() {
 		MInvoiceLine invoiceLine = getInvoiceLine();
-		BigDecimal amount = getAmt().divide(getQty() ,invoiceLine.getParent().getM_PriceList().getPricePrecision() , BigDecimal.ROUND_HALF_UP);
+		BigDecimal amount = getAmt().divide(getQty() ,invoiceLine.getParent().getM_PriceList().getPricePrecision(), RoundingMode.HALF_UP);
 		if (MDocType.DOCBASETYPE_APCreditMemo.equals(invoiceLine.getParent().getC_DocType().getDocBaseType()))
 			amount = amount.negate();
 		return  amount;

--- a/base/src/org/compiere/model/MMatchPO.java
+++ b/base/src/org/compiere/model/MMatchPO.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -551,7 +552,7 @@ public class MMatchPO extends X_M_MatchPO implements IDocumentLine
 					BigDecimal purchaseOrderAmount = purchaseOrderPrice.multiply(getQty());
 					BigDecimal maxTolerance = purchaseOrderAmount.multiply(priceMatchTolerance);
 					maxTolerance = maxTolerance.abs()
-						.divide(Env.ONEHUNDRED, 2, BigDecimal.ROUND_HALF_UP);
+						.divide(Env.ONEHUNDRED, 2, RoundingMode.HALF_UP);
 					difference = difference.abs();
 					boolean ok = difference.compareTo(maxTolerance) <= 0;
 					log.config("Difference=" + getPriceMatchDifference() 

--- a/base/src/org/compiere/model/MMovementLine.java
+++ b/base/src/org/compiere/model/MMovementLine.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.List;
@@ -140,7 +141,7 @@ public class MMovementLine extends X_M_MovementLine implements IDocumentLine , D
 			if (product != null)
 			{
 				int precision = product.getUOMPrecision(); 
-				MovementQty = MovementQty.setScale(precision, BigDecimal.ROUND_HALF_UP);
+				MovementQty = MovementQty.setScale(precision, RoundingMode.HALF_UP);
 			}
 		}
 		super.setMovementQty(MovementQty);

--- a/base/src/org/compiere/model/MOrder.java
+++ b/base/src/org/compiere/model/MOrder.java
@@ -18,6 +18,7 @@ package org.compiere.model;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -1810,7 +1811,7 @@ public class MOrder extends X_C_Order implements DocAction
 			if (oLine.getQtyEntered().compareTo(oLine.getQtyOrdered()) != 0) {
 				ioLine.setQtyEntered(MovementQty
 						.multiply(oLine.getQtyEntered())
-						.divide(oLine.getQtyOrdered(), 6, BigDecimal.ROUND_HALF_UP));
+						.divide(oLine.getQtyOrdered(), 6, RoundingMode.HALF_UP));
 			}
 			ioLine.saveEx(get_TrxName());
 		}
@@ -1880,7 +1881,7 @@ public class MOrder extends X_C_Order implements DocAction
 				if (oLine.getQtyOrdered().compareTo(oLine.getQtyEntered()) == 0) {
 					iLine.setQtyEntered(iLine.getQtyInvoiced());
 				} else {
-					iLine.setQtyEntered(iLine.getQtyInvoiced().multiply(oLine.getQtyEntered()).divide(oLine.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP));
+					iLine.setQtyEntered(iLine.getQtyInvoiced().multiply(oLine.getQtyEntered()).divide(oLine.getQtyOrdered(), 12, RoundingMode.HALF_UP));
 				}
 				iLine.saveEx(get_TrxName());
 			}

--- a/base/src/org/compiere/model/MOrderLine.java
+++ b/base/src/org/compiere/model/MOrderLine.java
@@ -316,7 +316,7 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 			setPriceEntered(getPriceActual());
 		else
 			setPriceEntered(getPriceActual().multiply(getQtyOrdered()
-				.divide(getQtyEntered(), 12, BigDecimal.ROUND_HALF_UP)));	//	recision
+				.divide(getQtyEntered(), 12, RoundingMode.HALF_UP)));	//	recision
 		
 		//	Calculate Discount
 		setDiscount(m_productPrice.getDiscount());
@@ -679,7 +679,7 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 			return;
 		BigDecimal discount = list.subtract(getPriceActual())
 			.multiply(new BigDecimal(100))
-			.divide(list, getPrecision(), BigDecimal.ROUND_HALF_UP);
+			.divide(list, getPrecision(), RoundingMode.HALF_UP);
 		setDiscount(discount);
 	}	//	setDiscount
 

--- a/base/src/org/compiere/model/MOrderLine.java
+++ b/base/src/org/compiere/model/MOrderLine.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -423,7 +424,7 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 		}
 		
 		if (lineNetAmount.scale() > getPrecision())
-			lineNetAmount = lineNetAmount.setScale(getPrecision(), BigDecimal.ROUND_HALF_UP);
+			lineNetAmount = lineNetAmount.setScale(getPrecision(), RoundingMode.HALF_UP);
 		super.setLineNetAmt (lineNetAmount);
 	}	//	setLineNetAmt
 	
@@ -719,7 +720,7 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 		if (QtyEntered != null && getC_UOM_ID() != 0)
 		{
 			int precision = MUOM.getPrecision(getCtx(), getC_UOM_ID());
-			QtyEntered = QtyEntered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			QtyEntered = QtyEntered.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setQtyEntered (QtyEntered);
 	}	//	setQtyEntered
@@ -734,7 +735,7 @@ public class MOrderLine extends X_C_OrderLine implements IDocumentLine
 		if (QtyOrdered != null && product != null)
 		{
 			int precision = product.getUOMPrecision();
-			QtyOrdered = QtyOrdered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			QtyOrdered = QtyOrdered.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setQtyOrdered(QtyOrdered);
 	}	//	setQtyOrdered

--- a/base/src/org/compiere/model/MProductPrice.java
+++ b/base/src/org/compiere/model/MProductPrice.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.util.Properties;
 
@@ -141,9 +142,9 @@ public class MProductPrice extends X_M_ProductPrice
 	 */
 	public void setPrices (BigDecimal PriceList, BigDecimal PriceStd, BigDecimal PriceLimit)
 	{
-		setPriceLimit (PriceLimit.setScale(this.getM_PriceList_Version().getM_PriceList().getPricePrecision(), BigDecimal.ROUND_HALF_UP)); 
-		setPriceList (PriceList.setScale(this.getM_PriceList_Version().getM_PriceList().getPricePrecision(), BigDecimal.ROUND_HALF_UP)); 
-		setPriceStd (PriceStd.setScale(this.getM_PriceList_Version().getM_PriceList().getPricePrecision(), BigDecimal.ROUND_HALF_UP));
+		setPriceLimit (PriceLimit.setScale(this.getM_PriceList_Version().getM_PriceList().getPricePrecision(), RoundingMode.HALF_UP)); 
+		setPriceList (PriceList.setScale(this.getM_PriceList_Version().getM_PriceList().getPricePrecision(), RoundingMode.HALF_UP)); 
+		setPriceStd (PriceStd.setScale(this.getM_PriceList_Version().getM_PriceList().getPricePrecision(), RoundingMode.HALF_UP));
 	}	//	setPrice
 
 	/**

--- a/base/src/org/compiere/model/MProductPricing.java
+++ b/base/src/org/compiere/model/MProductPricing.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -744,7 +745,7 @@ public class MProductPricing
 			discount = new BigDecimal ((priceList.doubleValue() - priceStd.doubleValue())
 				/ priceList.doubleValue() * 100.0);
 		if (discount.scale() > 2)
-			discount = discount.setScale(2, BigDecimal.ROUND_HALF_UP);
+			discount = discount.setScale(2, RoundingMode.HALF_UP);
 		return discount;
 	}	//	getDiscount
 
@@ -844,7 +845,7 @@ public class MProductPricing
 	{
 		if (precision >= 0	//	-1 = no rounding
 			&& price.scale() > precision)
-			return price.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			return price.setScale(precision, RoundingMode.HALF_UP);
 		return price;
 	}	//	round
 	

--- a/base/src/org/compiere/model/MProduction.java
+++ b/base/src/org/compiere/model/MProduction.java
@@ -1267,8 +1267,8 @@ public class MProduction extends X_M_Production implements DocAction , DocumentR
 		//
 		if (includeScrapQty)
 		{
-			BigDecimal scrapDec = bLine.getScrap().divide(Env.ONEHUNDRED, 12, BigDecimal.ROUND_UP);
-			qty = qty.divide(Env.ONE.subtract(scrapDec), precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal scrapDec = bLine.getScrap().divide(Env.ONEHUNDRED, 12, RoundingMode.UP);
+			qty = qty.divide(Env.ONE.subtract(scrapDec), precision, RoundingMode.HALF_UP);
 		}
 		return qty;
 	}

--- a/base/src/org/compiere/model/MRequisition.java
+++ b/base/src/org/compiere/model/MRequisition.java
@@ -18,6 +18,7 @@ package org.compiere.model;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -280,7 +281,7 @@ public class MRequisition extends X_M_Requisition implements DocAction
 		{
 			MRequisitionLine line = lines[i];
 			BigDecimal lineNet = line.getQty().multiply(line.getPriceActual());
-			lineNet = lineNet.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			lineNet = lineNet.setScale(precision, RoundingMode.HALF_UP);
 			if (lineNet.compareTo(line.getLineNetAmt()) != 0)
 			{
 				line.setLineNetAmt(lineNet);

--- a/base/src/org/compiere/model/MRfQResponseLineQty.java
+++ b/base/src/org/compiere/model/MRfQResponseLineQty.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.util.Comparator;
 import java.util.Properties;
@@ -148,9 +149,9 @@ public class MRfQResponseLineQty extends X_C_RfQResponseLineQty implements Compa
 		if (discount == null || Env.ZERO.compareTo(discount) == 0)
 			return price;
 		//	Calculate
-	//	double result = price.doubleValue() * (100.0 - discount.doubleValue()) / 100.0;
+		//	double result = price.doubleValue() * (100.0 - discount.doubleValue()) / 100.0;
 		BigDecimal factor = ONEHUNDRED.subtract(discount);
-		return price.multiply(factor).divide(ONEHUNDRED, 2, BigDecimal.ROUND_HALF_UP);  
+		return price.multiply(factor).divide(ONEHUNDRED, 2, RoundingMode.HALF_UP);  
 	}	//	getNetAmt
 
 	

--- a/base/src/org/compiere/model/MTax.java
+++ b/base/src/org/compiere/model/MTax.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.util.List;
 import java.util.Properties;
@@ -261,7 +262,7 @@ public class MTax extends X_C_Tax
 		if (isZeroTax())
 			return Env.ZERO;
 		
-		BigDecimal multiplier = getRate().divide(ONEHUNDRED, 12, BigDecimal.ROUND_HALF_UP);		
+		BigDecimal multiplier = getRate().divide(ONEHUNDRED, 12, RoundingMode.HALF_UP);		
 
 		BigDecimal tax = null;		
 		if (!taxIncluded)	//	$100 * 6 / 100 == $6 == $100 * 0.06
@@ -271,10 +272,10 @@ public class MTax extends X_C_Tax
 		else			//	$106 - ($106 / (100+6)/100) == $6 == $106 - ($106/1.06)
 		{
 			multiplier = multiplier.add(Env.ONE);
-			BigDecimal base = amount.divide(multiplier, 12, BigDecimal.ROUND_HALF_UP); 
+			BigDecimal base = amount.divide(multiplier, 12, RoundingMode.HALF_UP); 
 			tax = amount.subtract(base);
 		}
-		BigDecimal finalTax = tax.setScale(scale, BigDecimal.ROUND_HALF_UP);
+		BigDecimal finalTax = tax.setScale(scale, RoundingMode.HALF_UP);
 		log.fine("calculateTax " + amount 
 			+ " (incl=" + taxIncluded + ",mult=" + multiplier + ",scale=" + scale 
 			+ ") = " + finalTax + " [" + tax + "]");

--- a/base/src/org/compiere/model/MTest.java
+++ b/base/src/org/compiere/model/MTest.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.Properties;
@@ -77,7 +78,7 @@ public class MTest extends X_Test
 		setT_DateTime(new Timestamp (System.currentTimeMillis()));
 		setT_Integer(testNo);
 		setT_Amount(new BigDecimal(testNo));
-		setT_Number(Env.ONE.divide(new BigDecimal(testNo), BigDecimal.ROUND_HALF_UP));
+		setT_Number(Env.ONE.divide(new BigDecimal(testNo), RoundingMode.HALF_UP));
 		//
 		setC_Currency_ID(100);		//	USD
 		setC_Location_ID(109);		//	Monroe

--- a/base/src/org/compiere/model/MUOM.java
+++ b/base/src/org/compiere/model/MUOM.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.util.Iterator;
 import java.util.List;
@@ -216,7 +217,7 @@ public class MUOM extends X_C_UOM
 		if (!stdPrecision)
 			precision = getCostingPrecision();
 		if (qty.scale() > precision)
-			return qty.setScale(getStdPrecision(), BigDecimal.ROUND_HALF_UP);
+			return qty.setScale(getStdPrecision(), RoundingMode.HALF_UP);
 		return qty;
 	}	//	round
 

--- a/base/src/org/compiere/model/MUOMConversion.java
+++ b/base/src/org/compiere/model/MUOMConversion.java
@@ -18,6 +18,7 @@ package org.compiere.model;
 
 import java.awt.Point;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -191,7 +192,7 @@ public class MUOMConversion extends X_C_UOM_Conversion
 					s_conversions.put(p, mr);
 				//	reverse
 				if (dr == null && mr != null)
-					dr = Env.ONE.divide(mr, BigDecimal.ROUND_HALF_UP);
+					dr = Env.ONE.divide(mr, RoundingMode.HALF_UP);
 				if (dr != null)
 					s_conversions.put(new Point(p.y,p.x), dr);
 			}

--- a/base/src/org/compiere/model/MUOMConversion.java
+++ b/base/src/org/compiere/model/MUOMConversion.java
@@ -446,7 +446,7 @@ public class MUOMConversion extends X_C_UOM_Conversion
 		//	Calculate & Scale
 		retValue = retValue.multiply(qty);
 		if (retValue.scale() > precision)
-			retValue = retValue.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			retValue = retValue.setScale(precision, RoundingMode.HALF_UP);
 		return retValue;
 	}   //  convert
 

--- a/base/src/org/compiere/model/PaymentProcessor.java
+++ b/base/src/org/compiere/model/PaymentProcessor.java
@@ -21,6 +21,7 @@ import java.io.DataOutputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -210,7 +211,7 @@ public abstract class PaymentProcessor
 		else
 		{
 			if (value.scale() < 2)
-				value = value.setScale(2, BigDecimal.ROUND_HALF_UP);
+				value = value.setScale(2, RoundingMode.HALF_UP);
 			return createPair (name, String.valueOf(value), maxLength);
 		}
 	}	//	createPair

--- a/base/src/org/compiere/print/PrintDataFunction.java
+++ b/base/src/org/compiere/print/PrintDataFunction.java
@@ -17,6 +17,7 @@
 package org.compiere.print;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
@@ -132,25 +133,25 @@ public class PrintDataFunction
 		//	Mean = sum/count - round to 4 digits
 		if (function == F_MEAN)
 		{
-			BigDecimal mean = m_sum.divide(count, 4, BigDecimal.ROUND_HALF_UP);
+			BigDecimal mean = m_sum.divide(count, 4, RoundingMode.HALF_UP);
 			if (mean.scale() > 4)
-				mean = mean.setScale(4, BigDecimal.ROUND_HALF_UP);
+				mean = mean.setScale(4, RoundingMode.HALF_UP);
 			return mean;
 		}
 		//	Variance = sum of squares - (square of sum / count)
 		BigDecimal ss = m_sum.multiply(m_sum);
-		ss = ss.divide(count, 4, BigDecimal.ROUND_HALF_UP);
+		ss = ss.divide(count, 4, RoundingMode.HALF_UP);
 		BigDecimal variance = m_sumSquare.subtract(ss);
 		if (function == F_VARIANCE)
 		{
 			if (variance.scale() > 4)
-				variance = variance.setScale(4, BigDecimal.ROUND_HALF_UP);
+				variance = variance.setScale(4, RoundingMode.HALF_UP);
 			return variance;
 		}
 		//	Standard Deviation
 		BigDecimal deviation = new BigDecimal(Math.sqrt(variance.doubleValue()));
 		if (deviation.scale() > 4)
-			deviation = deviation.setScale(4, BigDecimal.ROUND_HALF_UP);
+			deviation = deviation.setScale(4, RoundingMode.HALF_UP);
 		return deviation;
 	}	//	getValue
 

--- a/base/src/org/compiere/process/DistributionCreate.java
+++ b/base/src/org/compiere/process/DistributionCreate.java
@@ -17,6 +17,7 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.logging.Level;
 
 import org.compiere.model.MBPartner;
@@ -189,7 +190,7 @@ public class DistributionCreate extends SvrProcess
 		BigDecimal ratio = dll.getRatio();
 		BigDecimal qty = p_Qty.multiply(ratio);
 		if (qty.compareTo(Env.ZERO) != 0)
-			qty = qty.divide(m_dl.getRatioTotal(), m_product.getUOMPrecision(), BigDecimal.ROUND_HALF_UP);
+			qty = qty.divide(m_dl.getRatioTotal(), m_product.getUOMPrecision(), RoundingMode.HALF_UP);
 		BigDecimal minQty = dll.getMinQty();
 		if (qty.compareTo(minQty) < 0)
 			qty = minQty;

--- a/base/src/org/compiere/process/DistributionRun.java
+++ b/base/src/org/compiere/process/DistributionRun.java
@@ -638,7 +638,7 @@ public class DistributionRun extends SvrProcess
 					log.info("Qty Target:" + record.getMinQty());
 					log.info("Qty Total Available:" + drl.getTotalQty());
 					log.info("Qty Total Demand:" +  totalration);			
-					BigDecimal factor = ration.divide(totalration, 12 , BigDecimal.ROUND_HALF_UP);
+					BigDecimal factor = ration.divide(totalration, 12, RoundingMode.HALF_UP);
 					record.setQty(drl.getTotalQty().multiply(factor));
 					record.saveEx();
 			}			
@@ -738,7 +738,7 @@ public class DistributionRun extends SvrProcess
 					, p_M_DistributionRun_ID, record.getM_Product_ID());
 					MDistributionRunLine drl = (MDistributionRunLine) MTable.get(getCtx(), MDistributionRunLine.Table_ID).getPO(record.getM_DistributionRunLine_ID(), get_TrxName());
 					BigDecimal ration = record.getRatio();
-					BigDecimal factor = ration.divide(total_ration,BigDecimal.ROUND_HALF_UP);
+					BigDecimal factor = ration.divide(total_ration, RoundingMode.HALF_UP);
 					record.setQty(factor.multiply(drl.getTotalQty()));
 					record.saveEx();
 			}			

--- a/base/src/org/compiere/process/DistributionRun.java
+++ b/base/src/org/compiere/process/DistributionRun.java
@@ -17,6 +17,7 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -406,7 +407,7 @@ public class DistributionRun extends SvrProcess
 					if (detail.isCanAdjust())
 					{
 						BigDecimal diffRatio = detail.getRatio().multiply(difference)
-							.divide(ratioTotal, BigDecimal.ROUND_HALF_UP);	// precision from total
+							.divide(ratioTotal, RoundingMode.HALF_UP);	// precision from total
 						log.fine("Detail=" + detail.toString()
 							+ ", Allocation=" + detail.getActualAllocation()
 							+ ", DiffRatio=" + diffRatio);

--- a/base/src/org/compiere/process/InOutCreateFrom.java
+++ b/base/src/org/compiere/process/InOutCreateFrom.java
@@ -17,6 +17,7 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -120,7 +121,7 @@ public class InOutCreateFrom extends InOutCreateFromAbstract {
 				MProduct product = MProduct.get(getCtx(), productId);
 				precision = product.getUOMPrecision();
 			}
-			qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+			qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 			//
 			log.fine("Line QtyEntered=" + qtyEntered
 					+ ", Product=" + productId
@@ -140,7 +141,7 @@ public class InOutCreateFrom extends InOutCreateFromAbstract {
 				if (orderLine.getQtyEntered().compareTo(orderLine.getQtyOrdered()) != 0) {
 					inOutLine.setMovementQty(qtyEntered
 							.multiply(orderLine.getQtyOrdered())
-							.divide(orderLine.getQtyEntered(), 12, BigDecimal.ROUND_HALF_UP));
+							.divide(orderLine.getQtyEntered(), 12, RoundingMode.HALF_UP));
 					inOutLine.setC_UOM_ID(orderLine.getC_UOM_ID());
 				}
 				inOutLine.setM_AttributeSetInstance_ID(orderLine.getM_AttributeSetInstance_ID());
@@ -169,7 +170,7 @@ public class InOutCreateFrom extends InOutCreateFromAbstract {
 				if (invoiceLine.getQtyEntered().compareTo(invoiceLine.getQtyInvoiced()) != 0) {
 					inOutLine.setMovementQty(qtyEntered
 							.multiply(invoiceLine.getQtyInvoiced())
-							.divide(invoiceLine.getQtyEntered(), 12, BigDecimal.ROUND_HALF_UP));
+							.divide(invoiceLine.getQtyEntered(), 12, RoundingMode.HALF_UP));
 					inOutLine.setC_UOM_ID(invoiceLine.getC_UOM_ID());
 				}
 				inOutLine.setC_OrderLine_ID(invoiceLine.getC_OrderLine_ID());

--- a/base/src/org/compiere/process/InOutGenerate.java
+++ b/base/src/org/compiere/process/InOutGenerate.java
@@ -17,6 +17,7 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -365,7 +366,7 @@ public class InOutGenerate extends InOutGenerateAbstract {
 			if (orderLine.getQtyEntered().compareTo(orderLine.getQtyOrdered()) != 0)
 				line.setQtyEntered(qty
 					.multiply(orderLine.getQtyEntered())
-					.divide(orderLine.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP));
+					.divide(orderLine.getQtyOrdered(), 12, RoundingMode.HALF_UP));
 			line.setLine(m_line + orderLine.getLine());
 			line.saveEx();
 			log.fine(line.toString());
@@ -420,7 +421,7 @@ public class InOutGenerate extends InOutGenerateAbstract {
 				line.setQty(line.getMovementQty().add(deliver));
 			if (orderLine.getQtyEntered().compareTo(orderLine.getQtyOrdered()) != 0)
 				line.setQtyEntered(line.getMovementQty().multiply(orderLine.getQtyEntered())
-					.divide(orderLine.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP));
+					.divide(orderLine.getQtyOrdered(), 12, RoundingMode.HALF_UP));
 			line.setLine(m_line + orderLine.getLine());
 			line.saveEx();
 			log.fine("ToDeliver=" + qty + "/" + deliver + " - " + line);

--- a/base/src/org/compiere/process/InvoiceCreateFrom.java
+++ b/base/src/org/compiere/process/InvoiceCreateFrom.java
@@ -17,6 +17,7 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -93,7 +94,7 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 					invoiceLine.setM_Product_ID(product.getM_Product_ID(), uomId);
 					precision = product.getUOMPrecision();
 					if (product.getC_UOM_ID() != uomId) {
-						qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+						qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 						qtyInvoiced = MUOMConversion.convertProductFrom(Env.getCtx(), productId, uomId, qtyEntered);
 					}
 				}
@@ -101,7 +102,7 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 				invoiceLine.setC_Charge_ID(chargeId);
 			}
 
-			qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+			qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 			if (qtyInvoiced == null)
 				qtyInvoiced = qtyEntered;
 

--- a/base/src/org/compiere/process/InvoiceGenerate.java
+++ b/base/src/org/compiere/process/InvoiceGenerate.java
@@ -17,6 +17,7 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -205,7 +206,7 @@ public class InvoiceGenerate extends InvoiceGenerateAbstract {
 							if (orderLine.getQtyEntered().compareTo(orderLine.getQtyOrdered()) != 0)
 								quantityEntered = toInvoice
 									.multiply(orderLine.getQtyEntered())
-									.divide(orderLine.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP);
+									.divide(orderLine.getQtyOrdered(), 12, RoundingMode.HALF_UP);
 							createLine (order, orderLine, toInvoice, quantityEntered);
 						} else {
 							log.fine("Failed: " + order.getInvoiceRule() 

--- a/base/src/org/compiere/process/ProductUOMConvert.java
+++ b/base/src/org/compiere/process/ProductUOMConvert.java
@@ -17,6 +17,7 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.logging.Level;
 
 import org.compiere.model.MProduct;
@@ -95,8 +96,8 @@ public class ProductUOMConvert extends SvrProcess
 			throw new AdempiereUserError("@NotFound@: @C_UOM_Conversion_ID@");
 		
 		MUOM uomTo = MUOM.get(getCtx(), productTo.getC_UOM_ID());
-		BigDecimal qtyTo = p_Qty.divide(conversion.getDivideRate(), uomTo.getStdPrecision(), BigDecimal.ROUND_HALF_UP);
-		BigDecimal qtyTo6 = p_Qty.divide(conversion.getDivideRate(), 6, BigDecimal.ROUND_HALF_UP);
+		BigDecimal qtyTo = p_Qty.divide(conversion.getDivideRate(), uomTo.getStdPrecision(), RoundingMode.HALF_UP);
+		BigDecimal qtyTo6 = p_Qty.divide(conversion.getDivideRate(), 6, RoundingMode.HALF_UP);
 		if (qtyTo.compareTo(qtyTo6) != 0)
 			throw new AdempiereUserError("@StdPrecision@: " + qtyTo + " <> " + qtyTo6 
 				+ " (" + p_Qty + "/" + conversion.getDivideRate() + ")");

--- a/base/src/org/compiere/process/RfQCreateSO.java
+++ b/base/src/org/compiere/process/RfQCreateSO.java
@@ -17,6 +17,7 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.logging.Level;
 
 import org.compiere.model.MBPartner;
@@ -132,7 +133,7 @@ public class RfQCreateSO extends SvrProcess
 							{
 								margin = margin.add(ONEHUNDRED);
 								price = price.multiply(margin)
-									.divide(ONEHUNDRED, 2, BigDecimal.ROUND_HALF_UP);
+									.divide(ONEHUNDRED, 2, RoundingMode.HALF_UP);
 							}
 						}
 					}	//	price

--- a/base/src/org/compiere/report/FinReport.java
+++ b/base/src/org/compiere/report/FinReport.java
@@ -17,6 +17,7 @@
 package org.compiere.report;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -642,7 +643,7 @@ public class FinReport extends FinReportAbstract {
 		}
 		if (col>0) {
 			BigDecimal bd = new BigDecimal(Float.toString(col*percentage));
-			bd = bd.setScale(2, BigDecimal.ROUND_HALF_UP);
+			bd = bd.setScale(2, RoundingMode.HALF_UP);
         	return bd.floatValue();
 		}
 		else

--- a/base/src/org/compiere/sla/DeliveryAccuracy.java
+++ b/base/src/org/compiere/sla/DeliveryAccuracy.java
@@ -17,6 +17,7 @@
 package org.compiere.sla;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -146,7 +147,7 @@ public class DeliveryAccuracy extends SLACriteria
 			
 		//	Calculate with 2 digits precision
 		if (count != 0)
-			retValue = total.divide(new BigDecimal(count), 2, BigDecimal.ROUND_HALF_UP);
+			retValue = total.divide(new BigDecimal(count), 2, RoundingMode.HALF_UP);
 		return retValue;
 	}	//	calculateMeasure
 

--- a/base/src/org/compiere/util/AmtInWords_HR.java
+++ b/base/src/org/compiere/util/AmtInWords_HR.java
@@ -2,6 +2,8 @@ package org.compiere.util;
 
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 import static java.math.BigDecimal.valueOf;
 import java.util.HashMap;
 import java.util.Map;
@@ -74,10 +76,10 @@ između
     StringBuilder rezultat = new StringBuilder();
 
     // zaokruži na dvije decimale
-    broj = broj.setScale(2, BigDecimal.ROUND_HALF_EVEN);
+    broj = broj.setScale(2, RoundingMode.HALF_EVEN);
 
     // kune (dio bez decimala)
-    BigDecimal kune = broj.setScale(0, BigDecimal.ROUND_DOWN);
+    BigDecimal kune = broj.setScale(0, RoundingMode.DOWN);
     rezultat.append(slovima(kune, "kuna", false, false));
 
     rezultat.append(RAZMAK + "i" + RAZMAK);

--- a/base/src/org/compiere/wf/MWFNode.java
+++ b/base/src/org/compiere/wf/MWFNode.java
@@ -18,6 +18,7 @@ package org.compiere.wf;
 
 import java.awt.Point;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -432,7 +433,7 @@ public class MWFNode extends X_AD_WF_Node
 			return 0;
 		//
 		BigDecimal change = new BigDecimal (seconds)
-			.divide(divide, BigDecimal.ROUND_DOWN)
+			.divide(divide, RoundingMode.DOWN)
 			.multiply(getDynPriorityChange());
 		return change.intValue();
 	}	//	calculateDynamicPriority

--- a/base/src/org/eevolution/model/MDDOrderLine.java
+++ b/base/src/org/eevolution/model/MDDOrderLine.java
@@ -17,6 +17,7 @@
 package org.eevolution.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
@@ -424,7 +425,7 @@ public class MDDOrderLine extends X_DD_OrderLine
 		if (QtyEntered != null && getC_UOM_ID() != 0)
 		{
 			int precision = MUOM.getPrecision(getCtx(), getC_UOM_ID());
-			QtyEntered = QtyEntered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			QtyEntered = QtyEntered.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setQtyEntered (QtyEntered);
 	}	//	setQtyEntered
@@ -439,7 +440,7 @@ public class MDDOrderLine extends X_DD_OrderLine
 		if (QtyOrdered != null && product != null)
 		{
 			int precision = product.getUOMPrecision();
-			QtyOrdered = QtyOrdered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			QtyOrdered = QtyOrdered.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setQtyOrdered(QtyOrdered);
 	}	//	setQtyOrdered

--- a/base/src/org/eevolution/model/MPPCostCollector.java
+++ b/base/src/org/eevolution/model/MPPCostCollector.java
@@ -19,6 +19,7 @@ package org.eevolution.model;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -950,7 +951,7 @@ public class MPPCostCollector extends X_PP_Cost_Collector implements DocAction ,
 			// Check Order Pack
 			if (product_po.getOrder_Pack().signum() > 0 && QtyOrdered.signum() > 0)
 			{
-				QtyOrdered = product_po.getOrder_Pack().multiply(QtyOrdered.divide(product_po.getOrder_Pack(), 0 , BigDecimal.ROUND_UP));
+				QtyOrdered = product_po.getOrder_Pack().multiply(QtyOrdered.divide(product_po.getOrder_Pack(), 0, RoundingMode.UP));
 			}
 			MOrderLine oline = new MOrderLine(order);
 			oline.setM_Product_ID(product.getM_Product_ID());

--- a/base/src/org/eevolution/model/MPPOrder.java
+++ b/base/src/org/eevolution/model/MPPOrder.java
@@ -115,7 +115,7 @@ public class MPPOrder extends X_PP_Order implements DocAction
 		if (qtyBatchSize.signum() == 0)
 			QtyBatchs = Env.ONE;
 		else
-			QtyBatchs = order.getQtyOrdered().divide(qtyBatchSize , 0, BigDecimal.ROUND_UP); 
+			QtyBatchs = order.getQtyOrdered().divide(qtyBatchSize , 0, RoundingMode.UP); 
 		order.setQtyBatchs(QtyBatchs);
 	}
 	
@@ -186,7 +186,7 @@ public class MPPOrder extends X_PP_Order implements DocAction
 				else
 				{
 					BigDecimal qtydelivered = qtyToDeliver;
-					qtydelivered.setScale(4, BigDecimal.ROUND_HALF_UP);
+					qtydelivered.setScale(4, RoundingMode.HALF_UP);
 					qtydelivered = Env.ZERO;
 				}
 		
@@ -998,7 +998,7 @@ public class MPPOrder extends X_PP_Order implements DocAction
 		if (QtyEntered != null && getC_UOM_ID() != 0)
 		{
 			int precision = MUOM.getPrecision(getCtx(), getC_UOM_ID());
-			QtyEntered = QtyEntered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			QtyEntered = QtyEntered.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setQtyEntered (QtyEntered);
 	}	//	setQtyEntered
@@ -1012,7 +1012,7 @@ public class MPPOrder extends X_PP_Order implements DocAction
 		if (QtyOrdered != null)
 		{
 			int precision = getM_Product().getUOMPrecision();
-			QtyOrdered = QtyOrdered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			QtyOrdered = QtyOrdered.setScale(precision, RoundingMode.HALF_UP);
 		}
 		super.setQtyOrdered(QtyOrdered);
 	}	//	setQtyOrdered

--- a/base/src/org/eevolution/model/MPPOrderBOMLine.java
+++ b/base/src/org/eevolution/model/MPPOrderBOMLine.java
@@ -353,9 +353,9 @@ public class MPPOrderBOMLine extends X_PP_Order_BOMLine
 		BigDecimal qtyScrap = getScrap();
 		if (qtyScrap.signum() != 0)
 		{
-			qtyScrap = qtyScrap.divide(Env.ONEHUNDRED, 8, BigDecimal.ROUND_UP);
-			setQtyRequired(getQtyRequired().divide(Env.ONE.subtract(qtyScrap), 8, BigDecimal.ROUND_HALF_UP));
-			setQtyEntered(getQtyEntered().divide(Env.ONE.subtract(qtyScrap), 8, BigDecimal.ROUND_HALF_UP));
+			qtyScrap = qtyScrap.divide(Env.ONEHUNDRED, 8, RoundingMode.UP);
+			setQtyRequired(getQtyRequired().divide(Env.ONE.subtract(qtyScrap), 8, RoundingMode.HALF_UP));
+			setQtyEntered(getQtyEntered().divide(Env.ONE.subtract(qtyScrap), 8, RoundingMode.HALF_UP));
 		}
 	}
 	

--- a/base/src/org/eevolution/model/MPPProductBOMLine.java
+++ b/base/src/org/eevolution/model/MPPProductBOMLine.java
@@ -250,8 +250,8 @@ public class MPPProductBOMLine extends X_PP_Product_BOMLine
 		//
 		if (includeScrapQty)
 		{
-			BigDecimal scrapDec = getScrap().divide(Env.ONEHUNDRED, 12, BigDecimal.ROUND_UP);
-			qty = qty.divide(Env.ONE.subtract(scrapDec), precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal scrapDec = getScrap().divide(Env.ONEHUNDRED, 12, RoundingMode.UP);
+			qty = qty.divide(Env.ONE.subtract(scrapDec), precision, RoundingMode.UP);
 		}
 		//
 		if (qty.scale() > precision)

--- a/base/src/org/eevolution/process/MovementGenerate.java
+++ b/base/src/org/eevolution/process/MovementGenerate.java
@@ -16,6 +16,7 @@
 package org.eevolution.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -388,7 +389,7 @@ public class MovementGenerate extends MovementGenerateAbstract
 			if (orderLine.getQtyEntered().compareTo(orderLine.getQtyOrdered()) != 0)
 				line.setMovementQty(qty
 						.multiply(orderLine.getQtyEntered())
-						.divide(orderLine.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP));
+						.divide(orderLine.getQtyOrdered(), 12, RoundingMode.HALF_UP));
 			line.setLine(lineNo + orderLine.getLine());
 			if (!line.save())
 				throw new IllegalStateException("Could not create Shipment Line");
@@ -448,7 +449,7 @@ public class MovementGenerate extends MovementGenerateAbstract
 				line.setMovementQty(line.getMovementQty().add(deliver));
 			if (orderLine.getQtyEntered().compareTo(orderLine.getQtyOrdered()) != 0)
 				line.setMovementQty(line.getMovementQty().multiply(orderLine.getQtyEntered())
-					.divide(orderLine.getQtyOrdered(), 12, BigDecimal.ROUND_HALF_UP));
+					.divide(orderLine.getQtyOrdered(), 12, RoundingMode.HALF_UP));
 			line.setLine(lineNo + orderLine.getLine());
 			if (linePerASI)
 				line.setM_AttributeSetInstance_ID(storage.getM_AttributeSetInstance_ID());

--- a/base/src/org/spin/process/CreateOrderFromReturnOrder.java
+++ b/base/src/org/spin/process/CreateOrderFromReturnOrder.java
@@ -18,6 +18,7 @@
 package org.spin.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Hashtable;
 import java.util.List;
 
@@ -86,7 +87,7 @@ public class CreateOrderFromReturnOrder extends CreateOrderFromReturnOrderAbstra
 				orderLine.setM_Product_ID(product.getM_Product_ID(), uomId);
 				precision = product.getUOMPrecision();
 				if (product.getC_UOM_ID() != uomId) {
-					qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+					qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 					qtyOrdered = MUOMConversion.convertProductFrom(Env.getCtx(), returnOrderLine.getM_Product_ID(), uomId, qtyEntered);
 				}
 			}
@@ -94,7 +95,7 @@ public class CreateOrderFromReturnOrder extends CreateOrderFromReturnOrderAbstra
 			orderLine.setC_Charge_ID(returnOrderLine.getC_Charge_ID());
 		}
 		//	
-		qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+		qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 		if (qtyOrdered == null) {
 			qtyOrdered = qtyEntered;
 		}

--- a/base/src/org/spin/process/InOutRMACreateFrom.java
+++ b/base/src/org/spin/process/InOutRMACreateFrom.java
@@ -18,6 +18,7 @@
 package org.spin.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -100,7 +101,7 @@ public class InOutRMACreateFrom extends InOutRMACreateFromAbstract {
 				MProduct product = MProduct.get(getCtx(), productId);
 				precision = product.getUOMPrecision();
 			}
-			qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+			qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 			//
 			log.fine("Line QtyEntered=" + qtyEntered
 					+ ", Product=" + productId
@@ -119,7 +120,7 @@ public class InOutRMACreateFrom extends InOutRMACreateFromAbstract {
 			if (orderLine.getQtyEntered().compareTo(orderLine.getQtyOrdered()) != 0) {
 				inOutLine.setMovementQty(qtyEntered
 						.multiply(orderLine.getQtyOrdered())
-						.divide(orderLine.getQtyEntered(), 12, BigDecimal.ROUND_HALF_UP));
+						.divide(orderLine.getQtyEntered(), 12, RoundingMode.HALF_UP));
 				inOutLine.setC_UOM_ID(orderLine.getC_UOM_ID());
 			}
 			inOutLine.setM_AttributeSetInstance_ID(orderLine.getM_AttributeSetInstance_ID());

--- a/base/src/org/spin/process/OrderRMACreateFrom.java
+++ b/base/src/org/spin/process/OrderRMACreateFrom.java
@@ -18,6 +18,7 @@
 package org.spin.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,7 +73,7 @@ public class OrderRMACreateFrom extends OrderRMACreateFromAbstract {
 					orderLine.setM_Product_ID(product.getM_Product_ID(), uomId);
 					precision = product.getUOMPrecision();
 					if (product.getC_UOM_ID() != uomId) {
-						qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+						qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 						qtyOrdered = MUOMConversion.convertProductFrom(Env.getCtx(), productId, uomId, qtyEntered);
 					}
 				}
@@ -80,7 +81,7 @@ public class OrderRMACreateFrom extends OrderRMACreateFromAbstract {
 				orderLine.setC_Charge_ID(chargeId);
 			}
 			//	
-			qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+			qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 			if (qtyOrdered == null) {
 				qtyOrdered = qtyEntered;
 			}

--- a/base/src/org/spin/process/OrderRMACreateFromInvoice.java
+++ b/base/src/org/spin/process/OrderRMACreateFromInvoice.java
@@ -18,6 +18,7 @@
 package org.spin.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -71,7 +72,7 @@ public class OrderRMACreateFromInvoice extends OrderRMACreateFromInvoiceAbstract
 					orderLine.setM_Product_ID(product.getM_Product_ID(), uomId);
 					precision = product.getUOMPrecision();
 					if (product.getC_UOM_ID() != uomId) {
-						qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+						qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 						qtyOrdered = MUOMConversion.convertProductFrom(Env.getCtx(), productId, uomId, qtyEntered);
 					}
 				}
@@ -79,7 +80,7 @@ public class OrderRMACreateFromInvoice extends OrderRMACreateFromInvoiceAbstract
 				orderLine.setC_Charge_ID(chargeId);
 			}
 			//	
-			qtyEntered = qtyEntered.setScale(precision, BigDecimal.ROUND_HALF_DOWN);
+			qtyEntered = qtyEntered.setScale(precision, RoundingMode.HALF_DOWN);
 			if (qtyOrdered == null) {
 				qtyOrdered = qtyEntered;
 			}

--- a/base/src/org/spin/process/PaymentIdentify.java
+++ b/base/src/org/spin/process/PaymentIdentify.java
@@ -17,7 +17,7 @@
 
 package org.spin.process;
 
-import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 
 import org.adempiere.exceptions.AdempiereException;
@@ -94,8 +94,8 @@ public class PaymentIdentify extends PaymentIdentifyAbstract {
 			}
 			int precision = MCurrency.get(getCtx(), identifiedPayment.getC_Currency_ID()).getStdPrecision();
 			//	Amount
-			if(!identifiedPayment.getPayAmt().setScale(precision, BigDecimal.ROUND_HALF_DOWN)
-					.equals(unidentifiedPayment.getPayAmt().setScale(precision, BigDecimal.ROUND_HALF_DOWN))) {
+			if(!identifiedPayment.getPayAmt().setScale(precision, RoundingMode.HALF_DOWN)
+					.equals(unidentifiedPayment.getPayAmt().setScale(precision, RoundingMode.HALF_DOWN))) {
 				throw new AdempiereException("@PayAmt@ @Mismatched@");
 			}
 			//	Document Status

--- a/base/test/src/org/compiere/model/IT_MStorage.java
+++ b/base/test/src/org/compiere/model/IT_MStorage.java
@@ -19,6 +19,7 @@ package org.compiere.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.adempiere.test.CommonGWSetup;
 import org.compiere.util.Env;
@@ -41,8 +42,7 @@ class IT_MStorage extends CommonGWSetup {
         loc.setXYZ("X" + locatorValue, "Y" + locatorValue, "Z" + locatorValue);
         loc.saveEx();
         //
-        BigDecimal targetQty = BigDecimal.valueOf(qtyOnHand).setScale(12,
-                BigDecimal.ROUND_HALF_UP);
+        BigDecimal targetQty = BigDecimal.valueOf(qtyOnHand).setScale(12, RoundingMode.HALF_UP);
         MStorage s1 = MStorage.getCreate(getCtx(), loc.get_ID(), product_id, 0,
                 getTrxName());
         s1.setQtyOnHand(targetQty);
@@ -50,7 +50,7 @@ class IT_MStorage extends CommonGWSetup {
         //
         BigDecimal qty =
                 MStorage.getQtyAvailable(wh.get_ID(), loc.get_ID(), product_id,
-                        0, getTrxName()).setScale(12, BigDecimal.ROUND_HALF_UP);
+                        0, getTrxName()).setScale(12, RoundingMode.HALF_UP);
         assertEquals(targetQty, qty, "Error on locator " + locatorValue);
         //
         return loc;
@@ -72,8 +72,8 @@ class IT_MStorage extends CommonGWSetup {
 
         BigDecimal qty = MStorage.getQtyAvailable(wh.get_ID(), 0, product_id, 0,
                 getTrxName());
-        qty = qty.setScale(12, BigDecimal.ROUND_HALF_UP);
-        targetQty = targetQty.setScale(12, BigDecimal.ROUND_HALF_UP);
+        qty = qty.setScale(12, RoundingMode.HALF_UP);
+        targetQty = targetQty.setScale(12, RoundingMode.HALF_UP);
         assertEquals(targetQty, qty);
 
     }

--- a/client/src/org/adempiere/controller/form/BOMDropController.java
+++ b/client/src/org/adempiere/controller/form/BOMDropController.java
@@ -21,6 +21,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Properties;
@@ -656,7 +657,7 @@ public class BOMDropController implements ValueChangeListener, VetoableChangeLis
 						return;						
 					}
 					// Update the qty editor
-					newQty = newQty.setScale(MUOM.getPrecision(ctx, selectionList.get(index).c_uom_id), BigDecimal.ROUND_HALF_UP);
+					newQty = newQty.setScale(MUOM.getPrecision(ctx, selectionList.get(index).c_uom_id), RoundingMode.HALF_UP);
 					selectionList.get(index).c_uom_id = new_id;
 					selectionList.get(index).uomEditor.setValue(new_id);
 					selectionList.get(index).qtyEditor.setValue(newQty);
@@ -910,7 +911,7 @@ public class BOMDropController implements ValueChangeListener, VetoableChangeLis
 				selection.feature = line.getFeature();
 				selection.name = product.getName();
 				selection.baseQty = line.getQty().multiply(baseQty);
-				BigDecimal displayedQty = line.getQty().multiply(qty).setScale(MUOM.getPrecision(ctx, line.getC_UOM_ID()), BigDecimal.ROUND_HALF_UP);
+				BigDecimal displayedQty = line.getQty().multiply(qty).setScale(MUOM.getPrecision(ctx, line.getC_UOM_ID()), RoundingMode.HALF_UP);
 				selection.qty = displayedQty;
 				
 				selectionList.add(selection);

--- a/client/src/org/compiere/grid/ed/Calculator.java
+++ b/client/src/org/compiere/grid/ed/Calculator.java
@@ -28,6 +28,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -484,7 +485,7 @@ public final class Calculator extends CDialog
 		char op = token.charAt(0);
 
 		if (op == '%') {
-			firstNo = firstNo.divide(new BigDecimal(100.0), m_format.getMaximumFractionDigits(), BigDecimal.ROUND_HALF_UP);
+			firstNo = firstNo.divide(new BigDecimal(100.0), m_format.getMaximumFractionDigits(), RoundingMode.HALF_UP);
 			m_number = firstNo;
 		}
 		
@@ -522,13 +523,13 @@ public final class Calculator extends CDialog
 
 		//	Percent operation
 		if (op2 == '%')
-			secondNo = secondNo.divide(new BigDecimal(100.0), m_format.getMaximumFractionDigits(), BigDecimal.ROUND_HALF_UP);
+			secondNo = secondNo.divide(new BigDecimal(100.0), m_format.getMaximumFractionDigits(), RoundingMode.HALF_UP);
 
 		switch (op)
 		{
 			case '/':
 				m_number = firstNo
-					.divide(secondNo, m_format.getMaximumFractionDigits(), BigDecimal.ROUND_HALF_UP);
+					.divide(secondNo, m_format.getMaximumFractionDigits(), RoundingMode.HALF_UP);
 				break;
 			case '*':
 				m_number = firstNo.multiply(secondNo);
@@ -542,7 +543,7 @@ public final class Calculator extends CDialog
 			default:
 				break;
 		}
-		return m_number.setScale(m_format.getMaximumFractionDigits(), BigDecimal.ROUND_HALF_UP);
+		return m_number.setScale(m_format.getMaximumFractionDigits(), RoundingMode.HALF_UP);
 	}	//	evaluate
 
 

--- a/client/src/org/compiere/grid/ed/MDocNumber.java
+++ b/client/src/org/compiere/grid/ed/MDocNumber.java
@@ -17,6 +17,7 @@
 package org.compiere.grid.ed;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
@@ -226,7 +227,7 @@ public final class MDocNumber extends PlainDocument
 							{
 								Number number = m_format.parse(value);
 								percentValue = new BigDecimal (number.toString());
-								percentValue = percentValue.divide(new BigDecimal(100.0), m_format.getMaximumFractionDigits(), BigDecimal.ROUND_HALF_UP);
+								percentValue = percentValue.divide(new BigDecimal(100.0), m_format.getMaximumFractionDigits(), RoundingMode.HALF_UP);
 								m_tc.setText(m_format.format(percentValue));
 							}
 						}

--- a/client/src/org/compiere/grid/ed/VNumber.java
+++ b/client/src/org/compiere/grid/ed/VNumber.java
@@ -37,6 +37,7 @@ import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyVetoException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.util.logging.Level;
@@ -454,7 +455,7 @@ public final class VNumber extends JComponent
 				return new Integer(bd.intValue());
 			if (bd.signum() == 0)
 				return bd;
-			return bd.setScale(m_format.getMaximumFractionDigits(), BigDecimal.ROUND_HALF_UP);
+			return bd.setScale(m_format.getMaximumFractionDigits(), RoundingMode.HALF_UP);
 		}
 		catch (Exception e)
 		{

--- a/client/src/org/compiere/grid/ed/VPAttributeDialog.java
+++ b/client/src/org/compiere/grid/ed/VPAttributeDialog.java
@@ -26,6 +26,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -823,7 +824,7 @@ public class VPAttributeDialog extends CDialog
 						mandatory += " - " + attributes[i].getName();
 					//setMAttributeInstance doesn't work without decimal point
 					if (value != null && value.scale() == 0)
-						value = value.setScale(1, BigDecimal.ROUND_HALF_UP);
+						value = value.setScale(1, RoundingMode.HALF_UP);
 					attributes[i].setMAttributeInstance(m_M_AttributeSetInstance_ID, value);
 				}
 				else

--- a/extend/src/compiere/model/MyValidator.java
+++ b/extend/src/compiere/model/MyValidator.java
@@ -17,6 +17,7 @@
 package compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.compiere.model.MClient;
 import org.compiere.model.MOrder;
@@ -168,7 +169,7 @@ public class MyValidator implements ModelValidator
 		//	Calculate Discount
 		BigDecimal discountPercent = new BigDecimal(3);	//	3% example
 		BigDecimal discountAmt = totalLines.multiply(discountPercent);
-		discountAmt = discountAmt.divide(Env.ONEHUNDRED, order.getPrecision(), BigDecimal.ROUND_HALF_UP);
+		discountAmt = discountAmt.divide(Env.ONEHUNDRED, order.getPrecision(), RoundingMode.HALF_UP);
 		discountLine.setPrice(discountAmt.negate());
 		if (!discountLine.save())
 			return "Could not save discount line";

--- a/org.adempiere.asset/src/main/java/base/org/compiere/model/MAssetSplit.java
+++ b/org.adempiere.asset/src/main/java/base/org/compiere/model/MAssetSplit.java
@@ -24,6 +24,7 @@ import org.compiere.util.DB;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -420,9 +421,9 @@ public class MAssetSplit extends X_A_Asset_Split implements DocAction {
                     if (getA_QTY_Split().signum() <= 0)
                         throw new AdempiereException("@A_QTY_Split@ @NotFound@");
 
-                    acquisitionCost = assetBalance.getA_Asset_Cost().divide(getA_QTY_Split(),7 , BigDecimal.ROUND_HALF_UP);
-                    accumulatedCost = assetBalance.getA_Accumulated_Depr().divide(getA_QTY_Split(),7 , BigDecimal.ROUND_HALF_UP);
-                    remainingCost = assetBalance.getA_Asset_Remaining().divide(getA_QTY_Split(),7 , BigDecimal.ROUND_HALF_UP);
+                    acquisitionCost = assetBalance.getA_Asset_Cost().divide(getA_QTY_Split(), 7, RoundingMode.HALF_UP);
+                    accumulatedCost = assetBalance.getA_Accumulated_Depr().divide(getA_QTY_Split(), 7, RoundingMode.HALF_UP);
+                    remainingCost = assetBalance.getA_Asset_Remaining().divide(getA_QTY_Split(), 7, RoundingMode.HALF_UP);
                     for (int sequence = 1; sequence < getA_QTY_Split().intValue() + 1; sequence++) {
                         MAsset fixedAssetSplit = createAssetSplit(
                                 fixedAssetToBeSplit,
@@ -435,7 +436,7 @@ public class MAssetSplit extends X_A_Asset_Split implements DocAction {
                 }
 
                 if (MAssetSplit.A_SPLIT_TYPE_Amount.equals(getA_Split_Type())) {
-                    BigDecimal percentage = getA_Amount_Split().divide(getA_Asset_Cost() , 7 , BigDecimal.ROUND_HALF_UP);
+                    BigDecimal percentage = getA_Amount_Split().divide(getA_Asset_Cost(), 7, RoundingMode.HALF_UP);
                     acquisitionCost = assetBalance.getA_Asset_Cost().subtract(getA_Amount_Split());
                     accumulatedCost = assetBalance.getA_Accumulated_Depr().multiply(percentage);
                     remainingCost = assetBalance.getA_Asset_Remaining().multiply(percentage);
@@ -605,19 +606,19 @@ public class MAssetSplit extends X_A_Asset_Split implements DocAction {
 
                     if (MAssetSplit.A_SPLIT_TYPE_Quantity.equals(getA_Split_Type())) {
 
-                        accumulated = depreciation.getA_Accumulated_Depr().divide(getA_QTY_Split(), 7 , BigDecimal.ROUND_HALF_UP);
-                        accumulatedDelta = depreciation.getA_Accumulated_Depr_Delta().divide(getA_QTY_Split(), 7 , BigDecimal.ROUND_HALF_UP);
-                        remaining = depreciation.getA_Asset_Remaining().divide(getA_QTY_Split(),  7 , BigDecimal.ROUND_HALF_UP);
-                        expense = depreciation.getExpense().divide(getA_QTY_Split(), 7 , BigDecimal.ROUND_HALF_UP);
+                        accumulated = depreciation.getA_Accumulated_Depr().divide(getA_QTY_Split(), 7, RoundingMode.HALF_UP);
+                        accumulatedDelta = depreciation.getA_Accumulated_Depr_Delta().divide(getA_QTY_Split(), 7, RoundingMode.HALF_UP);
+                        remaining = depreciation.getA_Asset_Remaining().divide(getA_QTY_Split(),  7, RoundingMode.HALF_UP);
+                        expense = depreciation.getExpense().divide(getA_QTY_Split(), 7, RoundingMode.HALF_UP);
 
-                        accumulatedFiscal = depreciation.getA_Accumulated_Depr_F().divide(getA_QTY_Split(), 7 , BigDecimal.ROUND_HALF_UP);
-                        accumulatedDeltaFiscal = depreciation.getA_Accumulated_Depr_F_Delta().divide(getA_QTY_Split(), 7 , BigDecimal.ROUND_HALF_UP);
-                        remainingFiscal = depreciation.getA_Asset_Remaining_F().divide(getA_QTY_Split(), 7 , BigDecimal.ROUND_HALF_UP);
+                        accumulatedFiscal = depreciation.getA_Accumulated_Depr_F().divide(getA_QTY_Split(), 7, RoundingMode.HALF_UP);
+                        accumulatedDeltaFiscal = depreciation.getA_Accumulated_Depr_F_Delta().divide(getA_QTY_Split(), 7, RoundingMode.HALF_UP);
+                        remainingFiscal = depreciation.getA_Asset_Remaining_F().divide(getA_QTY_Split(), 7, RoundingMode.HALF_UP);
                         expenseFiscal = depreciation.getExpense_F().divide(getA_QTY_Split());
                     }
 
                     if (MAssetSplit.A_SPLIT_TYPE_Amount.equals(getA_Split_Type())) {
-                        BigDecimal proportion = acquisitionCost.divide(depreciation.getA_Asset_Cost(),7 , BigDecimal.ROUND_HALF_UP);
+                        BigDecimal proportion = acquisitionCost.divide(depreciation.getA_Asset_Cost(), 7, RoundingMode.HALF_UP);
                         BigDecimal percentage = getA_Amount_Split().divide(getA_Asset_Cost());
 
                         accumulated = depreciation.getA_Accumulated_Depr().multiply(proportion).multiply(percentage);
@@ -632,7 +633,7 @@ public class MAssetSplit extends X_A_Asset_Split implements DocAction {
                     }
 
                     if (MAssetSplit.A_SPLIT_TYPE_Percentage.equals(getA_Split_Type())) {
-                        BigDecimal proportion = acquisitionCost.divide(depreciation.getA_Asset_Cost(),7 , BigDecimal.ROUND_HALF_UP);
+                        BigDecimal proportion = acquisitionCost.divide(depreciation.getA_Asset_Cost(), 7, RoundingMode.HALF_UP);
                         BigDecimal percentage = getA_Percent_Split().divide(BigDecimal.valueOf(100));
 
                         accumulated = depreciation.getA_Accumulated_Depr().multiply(proportion).multiply(percentage);

--- a/org.adempiere.pos/src/main/java/base/org/adempiere/pos/service/CPOS.java
+++ b/org.adempiere.pos/src/main/java/base/org/adempiere/pos/service/CPOS.java
@@ -17,6 +17,7 @@
 package org.adempiere.pos.service;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -2356,8 +2357,8 @@ public class CPOS {
 				String  productValue = resultSet.getString(2).trim();
 				String  productName = resultSet.getString(3).trim();
 				String  qtyAvailable = resultSet.getBigDecimal(4) != null ? resultSet.getBigDecimal(4).toString().trim() : "0";
-				String  priceStd = resultSet.getBigDecimal(5) != null ? resultSet.getBigDecimal(5).setScale(2, BigDecimal.ROUND_UP).toString().trim() :  "0";
-				String  priceList = resultSet.getBigDecimal(6) != null ? resultSet.getBigDecimal(6).setScale(2, BigDecimal.ROUND_UP).toString().trim() : "0 ";
+				String  priceStd = resultSet.getBigDecimal(5) != null ? resultSet.getBigDecimal(5).setScale(2, RoundingMode.UP).toString().trim() :  "0";
+				String  priceList = resultSet.getBigDecimal(6) != null ? resultSet.getBigDecimal(6).setScale(2, RoundingMode.UP).toString().trim() : "0 ";
 				columns.add(productId);
 				columns.add(productValue);
 				columns.add(productName);

--- a/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WCollect.java
+++ b/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WCollect.java
@@ -20,6 +20,7 @@ package org.adempiere.pos;
 import java.awt.Event;
 import java.awt.event.KeyEvent;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -461,7 +462,7 @@ public class WCollect extends Collect implements WPOSKeyListener, EventListener,
 		//
 		//m_PayAmt= m_PayAmt.add(getPrePayAmt());
 		balance = getBalance(posPanel.getOpenAmt());
-		balance = balance.setScale(2, BigDecimal.ROUND_HALF_UP);
+		balance = balance.setScale(2, RoundingMode.HALF_UP);
 		String currencyISO_Code = posPanel.getCurSymbol();
 		//	Change View
 		//fGrandTotal.setText(currencyISO_Code +" "+ m_Format.format(posPanel.getGrandTotal()));

--- a/org.adempiere.production/src/main/java/base/org/adempiere/process/CalculateReplenishPlan.java
+++ b/org.adempiere.production/src/main/java/base/org/adempiere/process/CalculateReplenishPlan.java
@@ -16,6 +16,7 @@
 package org.adempiere.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -501,7 +502,7 @@ public class CalculateReplenishPlan extends CalculateReplenishPlanAbstract {
 		}
 		else
 		{
-			createNoOfOrder = qty.divide(mrp.getQtyBatchSize(), 0, BigDecimal.ROUND_CEILING).intValue();
+			createNoOfOrder = qty.divide(mrp.getQtyBatchSize(), 0, RoundingMode.CEILING).intValue();
 			QtyPlan = mrp.getQtyBatchSize();
 		}
 

--- a/org.adempiere.project/src/main/java/org/compiere/model/CalloutProject.java
+++ b/org.adempiere.project/src/main/java/org/compiere/model/CalloutProject.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -62,7 +63,7 @@ public class CalloutProject extends CalloutEngine
 		//
 		BigDecimal PlannedAmt = PlannedQty.multiply(PlannedPrice);
 		if (PlannedAmt.scale() > StdPrecision)
-			PlannedAmt = PlannedAmt.setScale(StdPrecision, BigDecimal.ROUND_HALF_UP);
+			PlannedAmt = PlannedAmt.setScale(StdPrecision, RoundingMode.HALF_UP);
 		//
 		log.fine("PlannedQty=" + PlannedQty + " * PlannedPrice=" + PlannedPrice + " -> PlannedAmt=" + PlannedAmt + " (Precision=" + StdPrecision+ ")");
 		mTab.setValue("PlannedAmt", PlannedAmt);

--- a/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/ModelADServiceImpl.java
+++ b/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/ModelADServiceImpl.java
@@ -30,6 +30,7 @@
 package com._3e.ADInterface;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -1090,7 +1091,7 @@ public class ModelADServiceImpl implements ModelADService {
 			
 			// Set Quantity of Pages
 			if (records.size() != 0)
-				qtyPages = new BigDecimal(records.size()).divide(new BigDecimal(m_RecByPage)).setScale(0, BigDecimal.ROUND_UP).intValue();
+				qtyPages = new BigDecimal(records.size()).divide(new BigDecimal(m_RecByPage)).setScale(0, RoundingMode.UP).intValue();
 			
 			int begin= 0, end = 0;
 			begin = currentPage * m_RecByPage;

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/compiere/acct/Doc_HRProcess.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/compiere/acct/Doc_HRProcess.java
@@ -16,6 +16,7 @@
 package org.compiere.acct;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
@@ -130,7 +131,7 @@ public class   Doc_HRProcess extends Doc
 			//	Get Source Amount
 			BigDecimal sumAmount = line.getAmtSource();
 			// round amount according to currency
-			sumAmount = sumAmount.setScale(as.getStdPrecision(), BigDecimal.ROUND_HALF_UP);
+			sumAmount = sumAmount.setScale(as.getStdPrecision(), RoundingMode.HALF_UP);
 			MHRConcept concept = MHRConcept.getById(as.getCtx(), payrollDocLine.getHR_Concept_ID() , getTrxName());
 			//	Get Concept Account
 			X_HR_Concept_Acct conceptAcct = concept.getConceptAcct(

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRMovement.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRMovement.java
@@ -15,6 +15,7 @@
  *****************************************************************************/
 package org.eevolution.model;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -927,7 +928,7 @@ public class MHRMovement extends X_HR_Movement
 				//	Set from type
 				if(MHRConcept.COLUMNTYPE_Amount.equals(columnType)) {
 					BigDecimal amount = new BigDecimal(doubleValue)
-							.setScale(precision, BigDecimal.ROUND_HALF_UP);
+							.setScale(precision, RoundingMode.HALF_UP);
 					setAmount(amount);
 					setQty(Env.ZERO);
 				} else {

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRProcess.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/model/MHRProcess.java
@@ -18,6 +18,7 @@ package org.eevolution.model;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -1347,8 +1348,7 @@ public class MHRProcess extends X_HR_Process implements DocAction , DocumentReve
 				rate = MConversionRate.getRate(attribute.getC_Currency_ID(), getC_Currency_ID(), getDateAcct(), getC_ConversionType_ID(), getAD_Client_ID(), getAD_Org_ID());
 				if(rate != null) {
 					amount = rate.multiply(Optional.ofNullable(amount).orElse(Env.ZERO))
-							.setScale(precision, BigDecimal.ROUND_HALF_UP);
-					
+							.setScale(precision, RoundingMode.HALF_UP);	
 				}
 			}
 			movement.setAmount(amount);
@@ -1852,8 +1852,7 @@ public class MHRProcess extends X_HR_Process implements DocAction , DocumentReve
 				rate = MConversionRate.getRate(attribute.getC_Currency_ID(), getC_Currency_ID(), getDateAcct(), getC_ConversionType_ID(), getAD_Client_ID(), getAD_Org_ID());
 				if(rate != null) {
 					amount = rate.multiply(Optional.ofNullable(amount).orElse(Env.ZERO))
-							.setScale(precision, BigDecimal.ROUND_HALF_UP);
-					
+							.setScale(precision, RoundingMode.HALF_UP);
 				}
 			}
 			if(amount == null) {

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/process/HRPaySelectionCreateFrom.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/process/HRPaySelectionCreateFrom.java
@@ -23,6 +23,7 @@ import org.eevolution.model.MHRPaySelection;
 import org.eevolution.model.MHRPaySelectionLine;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -124,8 +125,8 @@ public class HRPaySelectionCreateFrom extends HRPaySelectionCreateFromAbstract {
             paySelectionLine.setPaymentRule(paymentRule);
             paySelectionLine.setAD_Org_ID(paySelection.getAD_Org_ID());
             paySelectionLine.setLine(lineNo.get());
-            paySelectionLine.setOpenAmt(movement.getAmount().setScale(2, BigDecimal.ROUND_HALF_DOWN));
-            paySelectionLine.setPayAmt(movement.getAmount().setScale(2, BigDecimal.ROUND_HALF_DOWN));
+            paySelectionLine.setOpenAmt(movement.getAmount().setScale(2, RoundingMode.HALF_DOWN));
+            paySelectionLine.setPayAmt(movement.getAmount().setScale(2, RoundingMode.HALF_DOWN));
             paySelectionLine.setDescription(partner.getName() + " " + partner.getName2());
             paySelectionLine.setDifferenceAmt(BigDecimal.ZERO);
             paySelectionLine.setDiscountAmt(BigDecimal.ZERO);

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/model/CalloutDistributionOrder.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/model/CalloutDistributionOrder.java
@@ -17,6 +17,7 @@
 package org.eevolution.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Properties;
 
 import org.adempiere.model.GridTabWrapper;
@@ -75,7 +76,7 @@ public class CalloutDistributionOrder extends CalloutEngine
 		{
 			int C_UOM_To_ID = ((Integer)value).intValue();
 			QtyEntered = (BigDecimal)mTab.getValue("QtyEntered");
-			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
 			if (QtyEntered.compareTo(QtyEntered1) != 0)
 			{
 				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID 
@@ -96,7 +97,7 @@ public class CalloutDistributionOrder extends CalloutEngine
 		{
 			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
 			QtyEntered = (BigDecimal)value;
-			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyEntered1 = QtyEntered.setScale(MUOM.getPrecision(ctx, C_UOM_To_ID), RoundingMode.HALF_UP);
 			if (QtyEntered.compareTo(QtyEntered1) != 0)
 			{
 				log.fine("Corrected QtyEntered Scale UOM=" + C_UOM_To_ID 
@@ -122,7 +123,7 @@ public class CalloutDistributionOrder extends CalloutEngine
 			int C_UOM_To_ID = Env.getContextAsInt(ctx, WindowNo, "C_UOM_ID");
 			QtyOrdered = (BigDecimal)value;
 			int precision = MProduct.get(ctx, M_Product_ID).getUOMPrecision(); 
-			BigDecimal QtyOrdered1 = QtyOrdered.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			BigDecimal QtyOrdered1 = QtyOrdered.setScale(precision, RoundingMode.HALF_UP);
 			if (QtyOrdered.compareTo(QtyOrdered1) != 0)
 			{
 				log.fine("Corrected QtyOrdered Scale " 

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/model/reasoner/StorageReasoner.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/model/reasoner/StorageReasoner.java
@@ -17,6 +17,7 @@
 package org.eevolution.model.reasoner;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.compiere.model.MAttribute;
 import org.compiere.model.MAttributeInstance;
@@ -195,7 +196,7 @@ public class StorageReasoner {
 			sumQtyReserved = sumQtyReserved.add(storage.getQtyReserved());
 		}
 
-		double available = sumQtyOnHand.subtract(sumQtyReserved).setScale(2, BigDecimal.ROUND_HALF_UP).doubleValue();
+		double available = sumQtyOnHand.subtract(sumQtyReserved).setScale(2, RoundingMode.HALF_UP).doubleValue();
 		if(count == 0 || (available <= 0.00d)) {
 			
 			return false;

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/msg/HTMLMessenger.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/msg/HTMLMessenger.java
@@ -17,6 +17,7 @@
 package org.eevolution.msg;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 
@@ -193,8 +194,8 @@ public class HTMLMessenger {
     	
     	Object[] obj = new Object[] {
     			p.getName()+" ("+p.getValue()+")",
-    			"1 x "+srcLength.setScale(2, BigDecimal.ROUND_HALF_DOWN)+" &#8594; "+pieces+" x "+tgtLength.setScale(2, BigDecimal.ROUND_HALF_DOWN),
-    			Msg.translate(Env.getCtx(), "Scrap")+": 1 x "+scrapLength.setScale(2, BigDecimal.ROUND_HALF_DOWN),
+    			"1 x "+srcLength.setScale(2, RoundingMode.HALF_DOWN)+" &#8594; "+pieces+" x "+tgtLength.setScale(2, RoundingMode.HALF_DOWN),
+    			Msg.translate(Env.getCtx(), "Scrap")+": 1 x "+scrapLength.setScale(2, RoundingMode.HALF_DOWN),
     	};
     	
 		return MessageFormat.format(LENGTHTRANSFORM_INFO_PATTERN, obj);	    	
@@ -317,7 +318,7 @@ public class HTMLMessenger {
 				if(MAttribute.ATTRIBUTEVALUETYPE_Number.equals(a.getAttributeValueType())) {
 					
 					BigDecimal number = ai.getValueNumber();
-					value = number.setScale(2, BigDecimal.ROUND_HALF_UP).toString();
+					value = number.setScale(2, RoundingMode.HALF_UP).toString();
 				}
 				else {
 					
@@ -403,7 +404,7 @@ public class HTMLMessenger {
 			sb.append(MessageFormat.format(STORAGE_SUM_LINE_INFO_PATTERN, obj));
 		}
 
-		double available = sumQtyOnHand.subtract(sumQtyReserved).setScale(2, BigDecimal.ROUND_HALF_UP).doubleValue();
+		double available = sumQtyOnHand.subtract(sumQtyReserved).setScale(2, RoundingMode.HALF_UP).doubleValue();
 		if(count == 0 || (available <= 0.00d)) {
 			
 			sb.append(MessageFormat.format(STORAGE_NOINVENTORY_INFO_PATTERN, obj));

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/process/MRP.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/process/MRP.java
@@ -980,7 +980,7 @@ public class MRP extends SvrProcess
 		// Check Order Pack
 		if (m_product_planning.getOrder_Pack().signum() > 0 && QtyPlanned.signum() > 0)
 		{
-			QtyPlanned = m_product_planning.getOrder_Pack().multiply(QtyPlanned.divide(m_product_planning.getOrder_Pack(), 0 , BigDecimal.ROUND_UP));
+			QtyPlanned = m_product_planning.getOrder_Pack().multiply(QtyPlanned.divide(m_product_planning.getOrder_Pack(), 0, RoundingMode.UP));
 		}
 		// Check Order Max                                                
 		if(QtyPlanned.compareTo(m_product_planning.getOrder_Max()) > 0 && m_product_planning.getOrder_Max().signum() > 0)
@@ -1027,7 +1027,7 @@ public class MRP extends SvrProcess
 			if (m_product_planning.getOrder_Policy().equals(X_PP_Product_Planning.ORDER_POLICY_FixedOrderQuantity))
 			{    
 				if (m_product_planning.getOrder_Qty().signum() != 0)
-					loops = (QtyPlanned.divide(m_product_planning.getOrder_Qty() , 0 , BigDecimal.ROUND_UP)).intValueExact();
+					loops = (QtyPlanned.divide(m_product_planning.getOrder_Qty(), 0, RoundingMode.UP)).intValueExact();
 				QtyPlanned = m_product_planning.getOrder_Qty();
 			}
 

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/process/RollupBillOfMaterial.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/process/RollupBillOfMaterial.java
@@ -18,6 +18,7 @@
 package org.eevolution.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -261,7 +262,7 @@ public class RollupBillOfMaterial extends RollupBillOfMaterialAbstract
 
 					BigDecimal qtyBatchSize = DB.getSQLValueBD(trxName, "SELECT QtyBatchSize FROM AD_Workflow WHERE AD_Workflow_ID=?",workflowId);
 					if (qtyBatchSize != null && qtyBatchSize.signum() != 0)
-						qty = qty.divide(qtyBatchSize , acctSchema.getCostingPrecision() , BigDecimal.ROUND_HALF_UP);
+						qty = qty.divide(qtyBatchSize, acctSchema.getCostingPrecision(), RoundingMode.HALF_UP);
 				}
 
 				BigDecimal componentCost = costPrice.multiply(qty);

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/OrderReceiptIssue.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/OrderReceiptIssue.java
@@ -441,7 +441,7 @@ public class OrderReceiptIssue extends GenForm {
 								// componentQtyReq =
 								// toDeliverQty.multiply(qtyBatchPerc); // TODO:
 								// set scale 4
-								componentQtyToDel = componentToDeliverQty.setScale(4, BigDecimal.ROUND_HALF_UP);
+								componentQtyToDel = componentToDeliverQty.setScale(4, RoundingMode.HALF_UP);
 								// issue.setValueAt(toDeliverQty.multiply(qtyBatchPerc),
 								// row, 6); // QtyRequired
 								issue.setValueAt(componentToDeliverQty, row, 8); // QtyToDelivery
@@ -452,8 +452,8 @@ public class OrderReceiptIssue extends GenForm {
 							componentToDeliverQty = qtyOpen;
 							if (componentToDeliverQty.signum() != 0) {
 								componentQtyReq = openQty.multiply(qtyBatchPerc); // scale 4
-								componentQtyToDel = componentToDeliverQty.setScale(4, BigDecimal.ROUND_HALF_UP);
-								issue.setValueAt(componentToDeliverQty.setScale(8, BigDecimal.ROUND_HALF_UP), row, 8); // QtyToDelivery
+								componentQtyToDel = componentToDeliverQty.setScale(4, RoundingMode.HALF_UP);
+								issue.setValueAt(componentToDeliverQty.setScale(8, RoundingMode.HALF_UP), row, 8); // QtyToDelivery
 								issue.setValueAt(openQty.multiply(qtyBatchPerc), row, 6); // QtyRequired
 							}
 						}
@@ -624,10 +624,8 @@ public class OrderReceiptIssue extends GenForm {
 										: "";
 								String desc = null;
 								row[3] = desc != null ? desc : "";
-								row[4] = toIssue.setScale(2,
-										BigDecimal.ROUND_HALF_UP).toString();
-								row[5] = getValueBigDecimal(issue, i, 7).setScale(
-										2, BigDecimal.ROUND_HALF_UP).toString();
+								row[4] = toIssue.setScale(2, RoundingMode.HALF_UP).toString();
+								row[5] = getValueBigDecimal(issue, i, 7).setScale(2, RoundingMode.HALF_UP).toString();
 								row[6] = getValueBigDecimal(issue, i, 9).toString();
 								table.add(row);
 							}
@@ -658,10 +656,8 @@ public class OrderReceiptIssue extends GenForm {
 							row[2] = m_uomkey != null ? m_uomkey.toString()
 									: "";
 							row[3] = desc != null ? desc : "";
-							row[4] = issueact.setScale(2,
-									BigDecimal.ROUND_HALF_UP).toString();
-							row[5] = getValueBigDecimal(issue, i, 7).setScale(
-									2, BigDecimal.ROUND_HALF_UP).toString();
+							row[4] = issueact.setScale(2, RoundingMode.HALF_UP).toString();
+							row[5] = getValueBigDecimal(issue, i, 7).setScale(2, RoundingMode.HALF_UP).toString();
 							row[6] = getValueBigDecimal(issue, i, 9).toString();
 							table.add(row);
 

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/crp/CRPDatasetFactory.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/crp/CRPDatasetFactory.java
@@ -134,7 +134,7 @@ public abstract class CRPDatasetFactory extends CRPReasoner implements CRPModel
 
 		// Pre-converts to minutes, because its the lowest time unit of compiere 
 		BigDecimal scale = new BigDecimal(1000*60);
-		BigDecimal minutes = new BigDecimal(millis).divide(scale, 2, BigDecimal.ROUND_HALF_UP);
+		BigDecimal minutes = new BigDecimal(millis).divide(scale, 2, RoundingMode.HALF_UP);
 		return convert(minutes);
 	}
 	

--- a/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
+++ b/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
@@ -17,6 +17,7 @@
 package org.spin.form;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -826,9 +827,9 @@ public class OutBoundOrder {
 					BigDecimal qtyAvailable = qtyOrdered
 							.subtract(qtyDelivered)
 							.subtract(qtyOrderLine)
-							.setScale(precision, BigDecimal.ROUND_HALF_UP);
+							.setScale(precision, RoundingMode.HALF_UP);
 					//	
-					if(qty.setScale(precision, BigDecimal.ROUND_HALF_UP).doubleValue() 
+					if(qty.setScale(precision, RoundingMode.HALF_UP).doubleValue() 
 							> qtyAvailable.doubleValue()) {
 						if(errorMessage.length() > 0) {
 							errorMessage.append(Env.NL);

--- a/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
+++ b/org.eevolution.warehouse/src/main/java/base/org/spin/form/OutBoundOrder.java
@@ -665,12 +665,15 @@ public class OutBoundOrder {
 				//	Valid Quantity On Hand
 				if(!deliveryRule.getID().equals(X_C_Order.DELIVERYRULE_Force) && !deliveryRule.getID().equals(X_C_Order.DELIVERYRULE_Manual)) {
 					//FR [ 1 ]
-					BigDecimal diff = ((BigDecimal)(isStocked ? Env.ONE : Env.ZERO)).multiply(qtyOnHand.subtract(qty).setScale(precision, BigDecimal.ROUND_HALF_UP));
+					BigDecimal diff = ((BigDecimal) (isStocked ? Env.ONE : Env.ZERO))
+						.multiply(
+							qtyOnHand.subtract(qty).setScale(precision, RoundingMode.HALF_UP)
+						);
 					//	Set Quantity
 					if(diff.doubleValue() < 0) {
 						qty = qty
 							.subtract(diff.abs())
-							.setScale(precision, BigDecimal.ROUND_HALF_UP);
+							.setScale(precision, RoundingMode.HALF_UP);
 					}
 					//	Valid Zero
 					if(qty.doubleValue() <= 0)

--- a/org.eevolution.warehouse/src/main/java/ui/zk/org/spin/form/WOutBoundOrder.java
+++ b/org.eevolution.warehouse/src/main/java/ui/zk/org/spin/form/WOutBoundOrder.java
@@ -17,6 +17,7 @@
 package org.spin.form;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -996,10 +997,10 @@ public class WOutBoundOrder extends OutBoundOrder
 				BigDecimal unitWeight = product.getWeight();
 				BigDecimal unitVolume = product.getVolume();
 				//	Calculate Weight
-				weight = qty.multiply(unitWeight).setScale(weightPrecision, BigDecimal.ROUND_HALF_UP);
+				weight = qty.multiply(unitWeight).setScale(weightPrecision, RoundingMode.HALF_UP);
 				orderLineTable.setValueAt(weight, row, OL_WEIGHT);
 				//	Calculate Volume
-				volume = qty.multiply(unitVolume).setScale(volumePrecision, BigDecimal.ROUND_HALF_UP);
+				volume = qty.multiply(unitVolume).setScale(volumePrecision, RoundingMode.HALF_UP);
 				orderLineTable.setValueAt(volume, row, OL_VOLUME);
 				
 				//  Load Stock Product
@@ -1103,7 +1104,7 @@ public class WOutBoundOrder extends OutBoundOrder
 			stockModel.setValueAt(qtyOnHand
 					.subtract(qtyInTransitOld)
 					.subtract(qtySet)
-					.setScale(2, BigDecimal.ROUND_HALF_UP), pos, SW_QTY_AVAILABLE);
+					.setScale(2, RoundingMode.HALF_UP), pos, SW_QTY_AVAILABLE);
 		} else if(isSelected) {
 			//	Get Quantity in Transit
 			Vector<Object> line = new Vector<Object>();
@@ -1116,7 +1117,7 @@ public class WOutBoundOrder extends OutBoundOrder
 			line.add(qtyOnHand
 					.subtract(qtyInTransit)
 					.subtract(qtySet)
-					.setScale(2, BigDecimal.ROUND_HALF_UP));
+					.setScale(2, RoundingMode.HALF_UP));
 			//	
 			stockModel.add(line);
 		}

--- a/org.spin.finance_management/src/main/java/base/org/compiere/acct/Doc_FMBatch.java
+++ b/org.spin.finance_management/src/main/java/base/org/compiere/acct/Doc_FMBatch.java
@@ -17,6 +17,7 @@
 package org.compiere.acct;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -116,7 +117,7 @@ public class   Doc_FMBatch extends Doc {
 			//	Get Source Amount
 			BigDecimal sumAmount = line.getAmtSource();
 			// round amount according to currency
-			sumAmount = sumAmount.setScale(as.getStdPrecision(), BigDecimal.ROUND_HALF_UP);
+			sumAmount = sumAmount.setScale(as.getStdPrecision(), RoundingMode.HALF_UP);
 			//	Get Concept Account
 			X_FM_TransactionType_Acct transactionTypeAcct = batchDocLine.getTransactionTypeAcct(as.getC_AcctSchema_ID());
 			if(transactionTypeAcct == null) {

--- a/org.spin.finance_management/src/main/java/base/org/spin/model/MFMBatch.java
+++ b/org.spin.finance_management/src/main/java/base/org/spin/model/MFMBatch.java
@@ -18,6 +18,7 @@ package org.spin.model;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.List;
@@ -594,7 +595,7 @@ public class MFMBatch extends X_FM_Batch implements DocAction, DocOptions {
 			amount = amount.multiply(conversionRate);
 		}
 		//	Set values
-		transaction.setAmount(amount.setScale(currency.getStdPrecision(), BigDecimal.ROUND_HALF_UP));
+		transaction.setAmount(amount.setScale(currency.getStdPrecision(), RoundingMode.HALF_UP));
 		transaction.saveEx();
 		return transaction;
 	}

--- a/org.spin.loan_management/src/main/java/base/org/spin/process/GenerateInvoiceFromLoan.java
+++ b/org.spin.loan_management/src/main/java/base/org/spin/process/GenerateInvoiceFromLoan.java
@@ -18,6 +18,7 @@
 package org.spin.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -250,7 +251,7 @@ public class GenerateInvoiceFromLoan extends GenerateInvoiceFromLoanAbstract {
 		}
 		invoiceLine.setQty(Env.ONE);
 		if(precision > 0) {
-			amount.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			amount.setScale(precision, RoundingMode.HALF_UP);
 		}
 		invoiceLine.setPrice(amount);
 		invoiceLine.setDescription(

--- a/org.spin.loan_management/src/main/java/base/org/spin/process/GeneratePaySelectionFromLoan.java
+++ b/org.spin.loan_management/src/main/java/base/org/spin/process/GeneratePaySelectionFromLoan.java
@@ -18,6 +18,7 @@
 package org.spin.process;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MBPartner;
@@ -251,7 +252,7 @@ public class GeneratePaySelectionFromLoan extends GeneratePaySelectionFromLoanAb
 		BigDecimal convertedAmt = sourceAmt.multiply(conversionRate.getMultiplyRate());
 		int stdPrecision = MCurrency.getStdPrecision(getCtx(), conversionRate.getC_Currency_ID_To());
 		if (convertedAmt.scale() > stdPrecision) {
-			convertedAmt = convertedAmt.setScale(stdPrecision, BigDecimal.ROUND_HALF_UP);
+			convertedAmt = convertedAmt.setScale(stdPrecision, RoundingMode.HALF_UP);
 		}
 		//	Default Return
 		return convertedAmt;

--- a/org.spin.loan_management/src/main/java/base/org/spin/util/FrenchLoanAmortization.java
+++ b/org.spin.loan_management/src/main/java/base/org/spin/util/FrenchLoanAmortization.java
@@ -17,6 +17,7 @@
 package org.spin.util;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,15 +83,15 @@ public class FrenchLoanAmortization extends AbstractFunctionalSetting {
 			for (AmortizationValue amortization : amortizationList) {
 				//Create Amortization
 				MFMAmortization.createAmortization(account.getCtx(), 
-													amortization.getCapitalAmtFee().setScale(currency.getStdPrecision(), BigDecimal.ROUND_HALF_UP), 
+													amortization.getCapitalAmtFee().setScale(currency.getStdPrecision(), RoundingMode.HALF_UP), 
 													"", 
 													amortization.getDueDate(), 
 													amortization.getEndDate(), 
 													account.getFM_Account_ID(), 
-													amortization.getInterestAmtFee().setScale(currency.getStdPrecision(), BigDecimal.ROUND_HALF_UP), 
+													amortization.getInterestAmtFee().setScale(currency.getStdPrecision(), RoundingMode.HALF_UP), 
 													amortization.getPeriodNo(), 
 													amortization.getStartDate(), 
-													amortization.getTaxAmtFee().setScale(currency.getStdPrecision(), BigDecimal.ROUND_HALF_UP), 
+													amortization.getTaxAmtFee().setScale(currency.getStdPrecision(), RoundingMode.HALF_UP), 
 													transactionName);
 			}
 			

--- a/org.spin.loan_management/src/main/java/ui/swing/org/spin/form/LoanSimulator.java
+++ b/org.spin.loan_management/src/main/java/ui/swing/org/spin/form/LoanSimulator.java
@@ -17,6 +17,7 @@
 package org.spin.form;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.List;
@@ -203,13 +204,13 @@ public abstract class LoanSimulator {
 		//	
 		List<AmortizationValue> amortizationList = (List<AmortizationValue>) returnValues.get("AMORTIZATION_LIST");
 		if(interestFeeAmt != null) {
-			setInterestFeeAmt(interestFeeAmt.setScale(currencyPrecision, BigDecimal.ROUND_HALF_UP));
+			setInterestFeeAmt(interestFeeAmt.setScale(currencyPrecision, RoundingMode.HALF_UP));
 		}
 		if(taxAmt != null) {
-			setTaxAmt(taxAmt.setScale(currencyPrecision, BigDecimal.ROUND_HALF_UP));
+			setTaxAmt(taxAmt.setScale(currencyPrecision, RoundingMode.HALF_UP));
 		}
 		if(grandTotal != null) {
-			setGrandToral(grandTotal.setScale(currencyPrecision, BigDecimal.ROUND_HALF_UP));
+			setGrandToral(grandTotal.setScale(currencyPrecision, RoundingMode.HALF_UP));
 		}
 		//	Reload table
 		reloadAmortization(amortizationList);

--- a/org.spin.loan_management/src/main/java/ui/zk/org/spin/form/WLoanSimulator.java
+++ b/org.spin.loan_management/src/main/java/ui/zk/org/spin/form/WLoanSimulator.java
@@ -17,6 +17,7 @@
 package org.spin.form;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Properties;
@@ -544,11 +545,11 @@ public class WLoanSimulator extends org.spin.form.LoanSimulator
 				line.add(amortizationLine.getStartDate());	//	StartDate
 				line.add(amortizationLine.getEndDate());	//	EndDate
 				line.add(amortizationLine.getDueDate());	//	DueDate
-				line.add(amortizationLine.getCapitalAmtFee().setScale(getStdPrecision(), BigDecimal.ROUND_HALF_UP));	//	CapitalAmtFee
-				line.add(amortizationLine.getInterestAmtFee().setScale(getStdPrecision(), BigDecimal.ROUND_HALF_UP));	//	InterestAmtFee
-				line.add(amortizationLine.getTaxAmtFee().setScale(getStdPrecision(), BigDecimal.ROUND_HALF_UP));	//	TaxAmtFee
-				line.add(amortizationLine.getFixedFeeAmt().setScale(getStdPrecision(), BigDecimal.ROUND_HALF_UP));	//	FixedFeeAmt
-				line.add(amortizationLine.getRemainingCapital().setScale(getStdPrecision(), BigDecimal.ROUND_HALF_UP));	//	RemainingCapital
+				line.add(amortizationLine.getCapitalAmtFee().setScale(getStdPrecision(), RoundingMode.HALF_UP));	//	CapitalAmtFee
+				line.add(amortizationLine.getInterestAmtFee().setScale(getStdPrecision(), RoundingMode.HALF_UP));	//	InterestAmtFee
+				line.add(amortizationLine.getTaxAmtFee().setScale(getStdPrecision(), RoundingMode.HALF_UP));	//	TaxAmtFee
+				line.add(amortizationLine.getFixedFeeAmt().setScale(getStdPrecision(), RoundingMode.HALF_UP));	//	FixedFeeAmt
+				line.add(amortizationLine.getRemainingCapital().setScale(getStdPrecision(), RoundingMode.HALF_UP));	//	RemainingCapital
 				//	Add to model
 				model.add(line);
 			}

--- a/org.spin.store/src/main/java/org/spin/util/VueStoreFrontUtil.java
+++ b/org.spin.store/src/main/java/org/spin/util/VueStoreFrontUtil.java
@@ -18,6 +18,7 @@
 package org.spin.util;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -222,10 +223,10 @@ public class VueStoreFrontUtil {
 		BigDecimal priceListAmount = productPricing.getPriceList().setScale(productPricing.getPrecision());
 		BigDecimal priceAmount = productPricing.getPriceStd().setScale(productPricing.getPrecision());
 		BigDecimal discount = productPricing.getDiscount();
-		BigDecimal lineListAmount = priceListAmount.multiply(quantity).setScale(productPricing.getPrecision(), BigDecimal.ROUND_HALF_UP);
-		BigDecimal lineDiscountAmount = lineListAmount.multiply(discount).divide(Env.ONEHUNDRED, BigDecimal.ROUND_HALF_UP).setScale(productPricing.getPrecision(), BigDecimal.ROUND_HALF_UP);
-		BigDecimal lineNetAmount = priceAmount.multiply(quantity).setScale(productPricing.getPrecision(), BigDecimal.ROUND_HALF_UP);
-		BigDecimal taxAmount = lineNetAmount.multiply(tax.getRate()).divide(Env.ONEHUNDRED, BigDecimal.ROUND_HALF_UP);
+		BigDecimal lineListAmount = priceListAmount.multiply(quantity).setScale(productPricing.getPrecision(), RoundingMode.HALF_UP);
+		BigDecimal lineDiscountAmount = lineListAmount.multiply(discount).divide(Env.ONEHUNDRED, RoundingMode.HALF_UP).setScale(productPricing.getPrecision(), RoundingMode.HALF_UP);
+		BigDecimal lineNetAmount = priceAmount.multiply(quantity).setScale(productPricing.getPrecision(), RoundingMode.HALF_UP);
+		BigDecimal taxAmount = lineNetAmount.multiply(tax.getRate()).divide(Env.ONEHUNDRED, RoundingMode.HALF_UP);
 		BigDecimal lineTotalAmount = lineNetAmount.add(taxAmount);
 		//	Set values
 		basketLine.set_ValueOfColumn(COLUMNNAME_M_Warehouse_ID, store.getM_Warehouse_ID());

--- a/sqlj/src/org/compiere/sqlj/Currency.java
+++ b/sqlj/src/org/compiere/sqlj/Currency.java
@@ -17,6 +17,7 @@
 package org.compiere.sqlj;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -257,7 +258,7 @@ public class Currency
 			int index = costing ? 2 : 1;
 			int prec = rs.getInt(index);
 			if (result.scale() > prec)
-				result = result.setScale(prec, BigDecimal.ROUND_HALF_UP);
+				result = result.setScale(prec, RoundingMode.HALF_UP);
 		}
 		rs.close();
 		pstmt.close();

--- a/sqlj/src/org/compiere/sqlj/PaymentTerm.java
+++ b/sqlj/src/org/compiere/sqlj/PaymentTerm.java
@@ -17,6 +17,7 @@
 package org.compiere.sqlj;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -309,7 +310,7 @@ public class PaymentTerm
 			//	Divide
 			if (discount.signum() != 0)
 			{
-				discount = discount.divide(Adempiere.HUNDRED, 6, BigDecimal.ROUND_HALF_UP);
+				discount = discount.divide(Adempiere.HUNDRED, 6, RoundingMode.HALF_UP);
 				discount = Currency.round(discount, p_C_Currency_ID, "N");
 			}
 		}	

--- a/sqlj/src/org/compiere/sqlj/Product.java
+++ b/sqlj/src/org/compiere/sqlj/Product.java
@@ -17,6 +17,7 @@
 package org.compiere.sqlj;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -372,7 +373,7 @@ public class Product
 				//hengsin, [ 1649453 ] bomQtyAvailable sqlj function throw ArithmeticException
 				//productQuantity = productQuantity.setScale(uomPrecision)
 				//	.divide(bomQty, uomPrecision, BigDecimal.ROUND_HALF_UP);
-				productQuantity = productQuantity.divide(bomQty, uomPrecision, BigDecimal.ROUND_HALF_UP);
+				productQuantity = productQuantity.divide(bomQty, uomPrecision, RoundingMode.HALF_UP);
 				//	How much can we make overall
 				if (productQuantity.compareTo(quantity) < 0)
 					quantity = productQuantity;
@@ -391,7 +392,7 @@ public class Product
 		if (quantity.signum() != 0)
 		{
 			int uomPrecision = getUOMPrecision(p_M_Product_ID);
-			return quantity.setScale(uomPrecision, BigDecimal.ROUND_HALF_UP);
+			return quantity.setScale(uomPrecision, RoundingMode.HALF_UP);
 		}
 		return Adempiere.ZERO;
 	}	//	bomQtyOnHand
@@ -602,8 +603,8 @@ public class Product
 				//	Get Rounding Precision
 				int StdPrecision = getUOMPrecision(M_ProductBOM_ID);
 				//	How much can we make with this product
-				productQuantity = productQuantity.setScale(StdPrecision, BigDecimal.ROUND_HALF_UP)
-					.divide(bomQty, BigDecimal.ROUND_HALF_UP);
+				productQuantity = productQuantity.setScale(StdPrecision, RoundingMode.HALF_UP)
+					.divide(bomQty, RoundingMode.HALF_UP);
 				//	How much can we make overall
 				if (productQuantity.compareTo(quantity) < 0)
 					quantity = productQuantity;
@@ -622,7 +623,7 @@ public class Product
 		if (quantity.signum() > 0)
 		{
 			int StdPrecision = getUOMPrecision(p_M_Product_ID);
-			return quantity.setScale(StdPrecision, BigDecimal.ROUND_HALF_UP);
+			return quantity.setScale(StdPrecision, RoundingMode.HALF_UP);
 		}
 		return Adempiere.ZERO;
 	}	//	bomQtyOnHand

--- a/webCM/src/main/servlet/org/compiere/cm/request/Request.java
+++ b/webCM/src/main/servlet/org/compiere/cm/request/Request.java
@@ -16,6 +16,7 @@
 package org.compiere.cm.request;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -367,7 +368,7 @@ public class Request {
 				l_bdValue = new BigDecimal(0);
 			}
 		}
-		l_bdValue = l_bdValue.setScale(2, BigDecimal.ROUND_CEILING);
+		l_bdValue = l_bdValue.setScale(2, RoundingMode.CEILING);
 		return l_bdValue;
 	}
 	

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/apps/graph/WGraph.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/apps/graph/WGraph.java
@@ -16,6 +16,7 @@ package org.adempiere.webui.apps.graph;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.logging.Level;
@@ -484,8 +485,7 @@ public class WGraph extends Div implements IdSpace {
 		td.setDynamicProperty("colspan", "2");
 		td.setSclass("pa-tdcontent");
 		tr.appendChild(td);
-		text = new Text(builder.getMGoal().getMeasureTarget().setScale(2,
-				BigDecimal.ROUND_HALF_UP).toPlainString());
+		text = new Text(builder.getMGoal().getMeasureTarget().setScale(2, RoundingMode.HALF_UP).toPlainString());
 		td.appendChild(text);
 
 		tr = new Tr();
@@ -499,8 +499,7 @@ public class WGraph extends Div implements IdSpace {
 		td.setDynamicProperty("colspan", "2");
 		td.setSclass("pa-tdcontent");
 		tr.appendChild(td);
-		text = new Text(builder.getMGoal().getMeasureActual().setScale(2,
-				BigDecimal.ROUND_HALF_UP).toPlainString());
+		text = new Text(builder.getMGoal().getMeasureActual().setScale(2, RoundingMode.HALF_UP).toPlainString());
 		td.appendChild(text);
 
 		GraphColumn[] bList = getGraphColumnList();
@@ -552,11 +551,11 @@ public class WGraph extends Div implements IdSpace {
 
 				});
 				a.setDynamicProperty("href", "javascript:;");
-				text = new Text(value.setScale(2, BigDecimal.ROUND_HALF_UP).toPlainString());
+				text = new Text(value.setScale(2, RoundingMode.HALF_UP).toPlainString());
 				a.appendChild(text);
 
 			} else {
-				text = new Text(value.setScale(2, BigDecimal.ROUND_HALF_UP).toPlainString());
+				text = new Text(value.setScale(2, RoundingMode.HALF_UP).toPlainString());
 			}
 		}
 		tr = new Tr();

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/window/WPAttributeDialog.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/window/WPAttributeDialog.java
@@ -17,6 +17,7 @@
 package org.adempiere.webui.window;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -821,7 +822,7 @@ public class WPAttributeDialog extends Window implements EventListener
 						mandatory += " - " + attributes[i].getName();
 					//setMAttributeInstance doesn't work without decimal point
 					if (value != null && value.scale() == 0)
-						value = value.setScale(1, BigDecimal.ROUND_HALF_UP);
+						value = value.setScale(1, RoundingMode.HALF_UP);
 					attributes[i].setMAttributeInstance(m_M_AttributeSetInstance_ID, value);
 				}
 				else


### PR DESCRIPTION
Currently there are multiple (625) warning messages concerning the deprecated bigdecimal round, set divide and set scale since java version 9:

`The method setScale(int, int) from the type BigDecimal is deprecated since version 9`
`The method divide(BigDecimal, int, int) from the type BigDecimal is deprecated since version 9`
`The field BigDecimal.ROUND_UP`
`The field BigDecimal.ROUND_EVEN`
`The field BigDecimal.ROUND_HALF_UP`
`The field BigDecimal.ROUND_HALF_DOWN`


![big-decimal-deprecated](https://user-images.githubusercontent.com/20288327/163520024-67fe1c9b-f83b-4c74-9bb2-f464e847728c.png)

That can work by implementing the `RoundingMode` class
