### PR TITLE
fix: Run ADempiere-All launcher.

### DIFF
--- a/base/ADempiere-all.launch
+++ b/base/ADempiere-all.launch
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/adempiere/base/src/org/compiere/Adempiere.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
-<listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.compiere.Adempiere"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="adempiere"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-DPropertyFile=${workspace_loc}/adempiere/adempiere/Adempiere/Adempiere.properties&#13;&#10;-DADEMPIERE_HOME=${workspace_loc}/adempiere/adempiere/Adempiere&#13;&#10;-Xms128M&#13;&#10;-Xmx256M&#10;-Dorg.adempiere.server.embedded=true&#10;-Dsun.awt.disablegrab=true"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/adempiere/client/src/org/adempiere/Adempiere.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+        <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.adempiere.Adempiere"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="adempiere"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="adempiere"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-DPropertyFile=${workspace_loc}/adempiere/adempiere/Adempiere/Adempiere.properties&#13;&#10;-DADEMPIERE_HOME=${workspace_loc}/adempiere/adempiere/Adempiere&#13;&#10;-Xms128M&#13;&#10;-Xmx256M&#10;-Dorg.adempiere.server.embedded=true&#10;-Dsun.awt.disablegrab=true"/>
 </launchConfiguration>


### PR DESCRIPTION
Unable to launch the project because the Adempiere class was moved from the org.compiere.Adempiere package to org.adempiere.Adempiere:

`Error: Main method not found in class org.compiere.Adempiere, define main method as follows:\n public static void main(String[] args)\n Otherwise, an Application class will need to be extended JavaFX javafx.application.Application`

Before this changes:

https://user-images.githubusercontent.com/20288327/165013373-dd63ab0a-30ae-439e-b682-5255ea097474.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/165013375-73ef22c8-2f8c-438e-8ebf-fb1d8cea821d.mp4


introduced in the PR https://github.com/adempiere/adempiere/pull/3784