### PR TITLE
fix: Clean warning HashMap should be parameterized

### DIFF
--- a/JasperReports/src/org/compiere/report/JasperViewer.java
+++ b/JasperReports/src/org/compiere/report/JasperViewer.java
@@ -104,7 +104,7 @@ public class JasperViewer extends javax.swing.JFrame {
 	public static void main(String args[]) {
         try {
         	JasperReport myjasperReport = (JasperReport) JasperCompileManager.compileReport(args[0] );
-        	JasperPrint myjasperPrint = JasperFillManager.fillReport( myjasperReport, new HashMap(), getConnection());
+        	JasperPrint myjasperPrint = JasperFillManager.fillReport(myjasperReport, new HashMap<String, Object>(), getConnection());
             JasperViewer.viewReport(myjasperPrint);
            } 
         catch (Exception e) {

--- a/base/src/org/adempiere/pipo/handler/DataElementHandler.java
+++ b/base/src/org/adempiere/pipo/handler/DataElementHandler.java
@@ -201,8 +201,8 @@ public class DataElementHandler extends AbstractElementHandler {
 				genericPO.setIsDirectLoad(true);
 				// Set defaults.
 				//TODO: get defaults from configuration
-				HashMap defaults = new HashMap();
-				HashMap thisDefault = (HashMap)defaults.get(d_tablename);
+				HashMap<Object, Object> defaults = new HashMap<Object, Object>();
+				HashMap<?, ?> thisDefault = (HashMap<?, ?>) defaults.get(d_tablename);
 				if (thisDefault != null) {
 					Iterator iter = thisDefault.values().iterator();
 					ArrayList thisValue = null;

--- a/base/src/org/compiere/model/MIssue.java
+++ b/base/src/org/compiere/model/MIssue.java
@@ -88,14 +88,13 @@ public class MIssue extends X_AD_Issue
 	@SuppressWarnings("unchecked")
 	public static MIssue create (Properties ctx, String hexInput)
 	{
-		HashMap hmIn = null;
+		HashMap<String, String> hmIn = null;
 		try		//	encode in report
 		{
 			byte[] byteArray = Secure.convertHexString(hexInput);	
 			ByteArrayInputStream bIn = new ByteArrayInputStream(byteArray);
 			ObjectInputStream oIn = new ObjectInputStream(bIn);
-			hmIn = (HashMap)oIn.readObject();
-		
+			hmIn = (HashMap<String, String>) oIn.readObject();
 		}
 		catch (Exception e) 
 		{
@@ -103,7 +102,7 @@ public class MIssue extends X_AD_Issue
 			return null;
 		}
 
-		MIssue issue = new MIssue(ctx, (HashMap<String,String>)hmIn);
+		MIssue issue = new MIssue(ctx, (HashMap<String,String>) hmIn);
 		return issue;
 	}	//	create
 	
@@ -422,7 +421,7 @@ public class MIssue extends X_AD_Issue
 		if (getRecord_ID() == 1)	//	new
 		{
 			parameter.append("ISSUE=");
-			HashMap htOut = get_HashMap();
+			HashMap<String,String> htOut = get_HashMap();
 			try		//	deserializing in create
 			{
 				ByteArrayOutputStream bOut = new ByteArrayOutputStream();

--- a/base/src/org/compiere/model/MLookupCache.java
+++ b/base/src/org/compiere/model/MLookupCache.java
@@ -36,7 +36,7 @@ public class MLookupCache
 	/** Static Logger					*/
 	private static CLogger 		s_log = CLogger.getCLogger(MLookupCache.class);
 	/** Static Lookup data with MLookupInfo -> HashMap  */
-	private static CCache<String,HashMap> s_loadedLookups = new CCache<String,HashMap>("MLookupCache", 50);
+	private static CCache<String, HashMap<Object, Object>> s_loadedLookups = new CCache<String, HashMap<Object, Object>>("MLookupCache", 50);
 	
 	/**
 	 *  MLookup Loader starts loading - ignore for now
@@ -53,7 +53,7 @@ public class MLookupCache
 	 *  @param info
 	 *  @param lookup
 	 */
-	protected static void loadEnd (MLookupInfo info, HashMap lookup)
+	protected static void loadEnd(MLookupInfo info, HashMap<Object, Object> lookup)
 	{
 		if (info.IsValidated && lookup.size() > 0)
 			s_loadedLookups.put(getKey(info), lookup);
@@ -92,7 +92,7 @@ public class MLookupCache
 	protected static boolean loadFromCache (MLookupInfo info, HashMap<Object,Object> lookupTarget)
 	{
 		String key = getKey(info);
-		HashMap cache = (HashMap)s_loadedLookups.get(key);
+		HashMap<Object, Object> cache = (HashMap<Object, Object>) s_loadedLookups.get(key);
 		if (cache == null)
 			return false;
 		//  Nothing cached

--- a/client/src/org/compiere/grid/ed/VButton.java
+++ b/client/src/org/compiere/grid/ed/VButton.java
@@ -332,7 +332,7 @@ public final class VButton extends CButton
 	 *	Return value/name
 	 *  @return HashMap with Value/Names
 	 */
-	public HashMap getValues()
+	public HashMap<String, String> getValues()
 	{
 		return m_values;
 	}	//	getValues

--- a/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/ADServiceImpl.java
+++ b/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/ADServiceImpl.java
@@ -275,8 +275,8 @@ public class ADServiceImpl implements ADService {
     	
     }
     
-    private HashMap WindowVOCache =new HashMap();
-    private HashMap WindowCache =new HashMap();
+    private HashMap<String, GridWindowVO> WindowVOCache = new HashMap<String, GridWindowVO>();
+    private HashMap<String, WindowDocument> WindowCache = new HashMap<String, WindowDocument>();
     
     
     private GridWindowVO getWindowVO( int WindowNo, int AD_Window_ID, int AD_Menu_ID)
@@ -342,7 +342,7 @@ public class ADServiceImpl implements ADService {
 	}
 	
 
-	private Map WindowStatusMap = new HashMap(); 
+	private Map<Integer, WWindowStatus> WindowStatusMap = new HashMap<Integer, WWindowStatus>(); 
 
 	/*
 	public WindowTabDataDocument getWindowTabData(int WindowNo, int AD_Window_ID, int AD_Menu_ID, int TabNo, int PrevTabNo, int PrevRecNo, boolean getData)	{
@@ -765,7 +765,7 @@ public class ADServiceImpl implements ADService {
         		boolean error = updateFields( ws, dr0 );
 
         		DataField f[] = dr0.getFieldArray();
-        		HashMap fmap = new HashMap();
+        		HashMap<String, Object> fmap = new HashMap<String, Object>();
         		for (int i=0; i<f.length; i++)
         			fmap.put(f[i].getColumn(), f[i].getVal());
         		

--- a/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/Process.java
+++ b/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/Process.java
@@ -330,7 +330,7 @@ public class Process {
 	private static MPInstance fillParameter(CompiereService compiereService, DataRow dataRow, MProcess process) throws Exception {
 		MPInstance instance = new MPInstance(process, 0);
 		DataField dataFields[] = dataRow.getFieldArray();
-		HashMap hashMap = new HashMap();
+		HashMap<String, Object> hashMap = new HashMap<String, Object>();
 		for (int i = 0; i < dataFields.length; i++)
 			hashMap.put(dataFields[i].getColumn(), dataFields[i].getVal());
 		//

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/CompiereDataSourceFactory.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/CompiereDataSourceFactory.java
@@ -41,10 +41,11 @@ import org.compiere.process.ProcessInfo;
 public class CompiereDataSourceFactory
 {
 
-    public static compiereDataSource createDataSource(Properties ctx, ReportInfo ri, ProcessInfo pi, HashMap params)
+    public static compiereDataSource createDataSource(Properties ctx, ReportInfo ri, ProcessInfo pi, HashMap<String, Object> params)
 	{
-	    if(ri.getReportViewID() > 0)
-	        return new ReportViewDataSource(ctx, pi, params);
+	    if (ri.getReportViewID() > 0) {
+	        return new ReportViewDataSource(ctx, pi);
+	    }
 	    
 	  return new DBDataSource(ctx, ri, params);
 	}

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/DBDataSource.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/DBDataSource.java
@@ -51,11 +51,11 @@ public class DBDataSource extends compiereDataSource
     private PreparedStatement m_pstmt = null;
     private ResultSet	m_resultSet = null;
     
-    public DBDataSource(Properties ctx, ReportInfo ri, HashMap params)
+    public DBDataSource(Properties ctx, ReportInfo ri, HashMap<String, Object> params)
     {
         JasperReport jr = ri.getJasperReport();
         //Generate parameters map
-        HashMap parametersMap = new HashMap();
+        HashMap<String, JRParameter> parametersMap = new HashMap<String, JRParameter>();
         JRParameter[] jpara = jr.getParameters();
         for (int i=0; i<jpara.length; i++)
         {

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/ReportViewDataSource.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/ReportViewDataSource.java
@@ -51,10 +51,28 @@ public class ReportViewDataSource extends compiereDataSource
 	private PrintData		m_printData = null;
 	private int				m_index	= 0;
 	
-    public ReportViewDataSource(Properties ctx, ProcessInfo pi, HashMap params)
+	/**
+	 * @deprecated Please use {@link ReportViewDataSource#ReportViewDataSource(Properties, ProcessInfo)}
+	 * @param ctx
+	 * @param pi
+	 * @param params
+	 */
+	@Deprecated
+    public ReportViewDataSource(Properties ctx, ProcessInfo pi, HashMap<Object, Object> params)
     {
         ReportEngine re = ReportEngine.get(ctx, pi);
         m_printData = re.getPrintData();        
+    }
+    
+	/**
+	 * 
+	 * @param ctx
+	 * @param pi
+	 */
+    public ReportViewDataSource(Properties ctx, ProcessInfo pi)
+    {
+        ReportEngine re = ReportEngine.get(ctx, pi);
+        m_printData = re.getPrintData();
     }
     
 

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportInfo.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportInfo.java
@@ -56,7 +56,7 @@ public class ReportInfo
         to the main Report in case of subreports. Marco LOMBARDO
     */
     private JasperReport jasperReport;
-    private HashMap subReport = new HashMap();
+    private HashMap<String, String> subReport = new HashMap<String, String>();
     private boolean hasSubReport = false;
     private boolean hasError = false;
     private ArrayList errorMsg = new ArrayList();
@@ -371,7 +371,7 @@ public class ReportInfo
     /**
      * @return Returns the subReport.
      */
-    protected HashMap getSubReport()
+    protected HashMap<String, String> getSubReport()
     {
         return subReport;
     }

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportPool.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportPool.java
@@ -38,7 +38,7 @@ import org.compiere.util.CLogger;
  */
 public class ReportPool
 {
-    private static HashMap   pool   = new HashMap();
+    private static HashMap<Integer, ReportInfo> pool = new HashMap<Integer, ReportInfo>();
 
     private static final int MAXNUM = 15;
     private static int 	size = 0;

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportProcessor.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportProcessor.java
@@ -82,7 +82,7 @@ public class ReportProcessor
 		m_AD_Process_ID	= pi.getAD_Process_ID();
         m_Record_ID = pi.getRecord_ID();        
         //m_isPrint = pi.getIsPrint();
-        m_Param = new HashMap();        
+        m_Param = new HashMap<String, Object>();        
         m_ctx = ctx;
         m_pi = pi;
 	}   //  ReportServer
@@ -261,7 +261,7 @@ public class ReportProcessor
     private int m_AD_Process_ID = 0;
     private int m_Record_ID = 0;
     private boolean m_isPrint = false;
-    private HashMap m_Param = null;
+    private HashMap<String, Object> m_Param = null;
     private Properties m_ctx = null;   
     private JasperPrint m_jasperPrint = null;
     private ProcessInfo m_pi = null;

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/jasperreports/engine/util/JRQueryExecuter.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/jasperreports/engine/util/JRQueryExecuter.java
@@ -55,8 +55,8 @@ public class JRQueryExecuter
      *
      */
     private JRQuery query = null;
-    private Map parametersMap = new HashMap();
-    private Map parameterValues = null;
+    private Map<String, JRParameter> parametersMap = new HashMap<String, JRParameter>();
+    private Map<String, Object> parameterValues = null;
     private String queryString = "";
     private List parameterNames = new ArrayList();
 
@@ -64,7 +64,7 @@ public class JRQueryExecuter
     /**
      *
      */
-    protected JRQueryExecuter(JRQuery query, Map parameters, Map values)
+    protected JRQueryExecuter(JRQuery query, Map<String, JRParameter> parameters, Map<String, Object> values)
     {
         this.query = query;
         this.parametersMap = parameters;
@@ -79,8 +79,8 @@ public class JRQueryExecuter
      */
     public static PreparedStatement getStatement(
         JRQuery query,
-        Map parameters,
-        Map values,
+        Map<String, JRParameter> parameters,
+        Map<String, Object> values,
         Connection conn
         ) throws JRException
     {

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/BOMMessenger.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/BOMMessenger.java
@@ -37,12 +37,12 @@ public class BOMMessenger extends HTMLMessenger {
 	
 	protected JTree bomTree;
 	protected BOMTreeCellRenderer bomTreeCellRenderer;
-	protected HashMap cache;
+	protected HashMap<DefaultMutableTreeNode, String> cache;
 	
 	public BOMMessenger(JTree bomTree) {
 		
 		this.bomTree = bomTree;
-		this.cache = new HashMap();
+		this.cache = new HashMap<DefaultMutableTreeNode, String>();
 	}
 	
 	public String getToolTipText(MouseEvent evt){

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/BOMTreeCellRenderer.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/BOMTreeCellRenderer.java
@@ -30,8 +30,7 @@ import org.eevolution.form.tree.MapTreeCellRenderer;
  */
 public class BOMTreeCellRenderer extends MapTreeCellRenderer {
 
-	public BOMTreeCellRenderer(HashMap map) {
-		
+	public BOMTreeCellRenderer(HashMap<?, ?> map) {
 		super(map);
 	}
 

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/BOMTreeFactory.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/BOMTreeFactory.java
@@ -39,7 +39,7 @@ import org.eevolution.model.wrapper.BOMWrapper;
 public abstract class BOMTreeFactory implements BOMTreeModel {
 
 	protected JTree tree;
-	protected HashMap mapping;
+	protected HashMap<DefaultMutableTreeNode, String> mapping;
 	protected BOMMessenger msg;
 	
 	private StorageReasoner reasoner;
@@ -85,8 +85,7 @@ public abstract class BOMTreeFactory implements BOMTreeModel {
 	}
 	
 	protected DefaultMutableTreeNode buildStructure(PO po, StorageReasoner reasoner) {
-		
-		mapping = new HashMap();
+		mapping = new HashMap<DefaultMutableTreeNode, String>();
 
 		DefaultMutableTreeNode root = new DefaultMutableTreeNode(po);
         mapping.put(root, getTreeNodeRepresentation(root));
@@ -113,8 +112,7 @@ public abstract class BOMTreeFactory implements BOMTreeModel {
         return root;
 	}
 	
-    protected DefaultMutableTreeNode getNode(BOMWrapper bom, BigDecimal qty, HashMap map) {
-    	
+    protected DefaultMutableTreeNode getNode(BOMWrapper bom, BigDecimal qty, HashMap<DefaultMutableTreeNode, String> map) {
         MProduct product = new MProduct(Env.getCtx(), bom.getM_Product_ID(),MProduct.Table_Name);
         
         DefaultMutableTreeNode parent = new DefaultMutableTreeNode(bom);;
@@ -145,8 +143,7 @@ public abstract class BOMTreeFactory implements BOMTreeModel {
         return parent;
     }
         
-    protected DefaultMutableTreeNode addLeafs(MProduct M_Product, BigDecimal qty, HashMap map) {   
-  
+    protected DefaultMutableTreeNode addLeafs(MProduct M_Product, BigDecimal qty, HashMap<DefaultMutableTreeNode, String> map) {
         int[] ids = getStorageReasoner().getPOIDs(BOMWrapper.tableName(type()), "Value = '"+M_Product.getValue()+"'", null);
 
         BOMWrapper bom = null;
@@ -198,8 +195,7 @@ public abstract class BOMTreeFactory implements BOMTreeModel {
  		return this.tree;
  	}
 
- 	public HashMap getNodeMapping() {
- 	 	
+	public HashMap<DefaultMutableTreeNode, String> getNodeMapping() {
  		return this.mapping;
  	}
 

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/BOMTreeModel.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/bom/BOMTreeModel.java
@@ -18,6 +18,7 @@ package org.eevolution.form.bom;
 import java.util.HashMap;
 
 import javax.swing.JTree;
+import javax.swing.tree.DefaultMutableTreeNode;
 
 /**
  * @author Gunther Hoppe, tranSIT GmbH Ilmenau/Germany
@@ -27,7 +28,7 @@ public interface BOMTreeModel {
 
 	public JTree getTree();
 	
-	public HashMap getNodeMapping();
+	public HashMap<DefaultMutableTreeNode, String> getNodeMapping();
 
 	public BOMMessenger getBOMMessenger();
 }

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/tree/CachableTreeCellRenderer.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/tree/CachableTreeCellRenderer.java
@@ -29,7 +29,7 @@ import javax.swing.tree.DefaultTreeCellRenderer;
 public abstract class CachableTreeCellRenderer extends DefaultTreeCellRenderer {
 
 	private boolean virtual;
-	private HashMap cache;
+	private HashMap<Object, Object> cache;
 	private CachableTreeCellRenderer complement;
 	
 	protected abstract void init(Object value);
@@ -44,7 +44,7 @@ public abstract class CachableTreeCellRenderer extends DefaultTreeCellRenderer {
 		super();
 
 		this.virtual = virtual;
-		cache = new HashMap();
+		cache = new HashMap<Object, Object>();
 	}
     
 	public Component getTreeCellRendererComponent(JTree tree, Object value, boolean sel, boolean expanded, boolean leaf, int row, boolean hasFocus) {


### PR DESCRIPTION
Currently there are multiple (66) warning messages concerning the hashmap is a raw type:

`HashMap is a raw type. References to generic type HashMap<K,V> should be parameterized`

![hashmap-warning](https://user-images.githubusercontent.com/20288327/165193411-35e9519c-b5fa-40c2-a29e-3204c2a8869c.png)
