### PR TITLE
This pull request just add support to gradle builder to org.adempiere.test source folder

### DIFF
--- a/base/test/src/org/compiere/model/IT_Inventory.java
+++ b/base/test/src/org/compiere/model/IT_Inventory.java
@@ -29,9 +29,9 @@ import java.util.stream.Stream;
 
 import org.adempiere.exceptions.DBException;
 import org.adempiere.test.CommonGWSetup;
+import org.adempiere.test.MMDocument;
+import org.adempiere.test.MMScenario;
 import org.compiere.process.DocAction;
-import org.compiere.process.MMDocument;
-import org.compiere.process.MMScenario;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Util;

--- a/base/test/src/org/compiere/model/InventoryUtil.java
+++ b/base/test/src/org/compiere/model/InventoryUtil.java
@@ -18,8 +18,8 @@ import java.sql.Timestamp;
 import java.util.Properties;
 
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.MMDocument;
 import org.compiere.process.DocAction;
-import org.compiere.process.MMDocument;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;

--- a/org.adempiere.test/build.gradle
+++ b/org.adempiere.test/build.gradle
@@ -1,0 +1,110 @@
+apply plugin: 'java-library'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(
+        dir: '../tools/lib/testing', 
+        include: [
+        'SuperCSV-with_src-1.52.jar'
+        ]
+    )
+    api 'io.github.adempiere:base:3.9.4-develop-1.0'
+    // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
+    api 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+    // https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
+    api 'org.mockito:mockito-junit-jupiter:3.6.0'
+    // https://mvnrepository.com/artifact/org.junit.platform/junit-platform-console-standalone
+    api 'org.junit.platform:junit-platform-console-standalone:1.7.0'
+}
+
+sourceSets {
+    main {
+         java {
+            srcDirs = ['src']
+         }
+    }
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+signing {
+    sign configurations.archives
+}
+
+def entityType = 'D'
+version = "3.9.4-develop-1.0"
+
+jar {
+    manifest {
+        attributes("Implementation-Title": "Adempiere Project Management",
+                   "Implementation-Version": version, 
+                   "EntityType": entityType)
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            credentials {
+                username = ossrhUsername ?: System.getenv("OSSRH_USER_NAME")
+                password = ossrhPassword ?: System.getenv("OSSRH_PASSWORD")
+            }
+        }
+    }
+    publications {
+        mavenJava(MavenPublication) {
+        	groupId 'io.github.adempiere'
+            artifactId 'test'
+            version
+           	from components.java
+           	pom {
+                name = 'Test'
+                description = 'Test api dedicated to manage project, and members.'
+                url = 'http://adempiere.io/'
+                licenses {
+                    license {
+                        name = 'GNU General Public License, version 2'
+                        url = 'https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'yamelsenih'
+                        name = 'Yamel Senih'
+                        email = 'ysenih@erpya.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/adempiere/adempiere.git'
+                    developerConnection = 'scm:git:ssh://github.com/adempiere/adempiere.git'
+                    url = 'http://github.com/adempiere/adempiere'
+                }
+            }
+		}
+	}
+}
+
+signing {
+    sign publishing.publications.mavenJava
+}

--- a/org.adempiere.test/build.gradle
+++ b/org.adempiere.test/build.gradle
@@ -75,11 +75,11 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
         	groupId 'io.github.adempiere'
-            artifactId 'test'
+            artifactId 'adempiere.test'
             version
            	from components.java
            	pom {
-                name = 'Test'
+                name = 'Adempiere Test'
                 description = 'Test api dedicated to manage project, and members.'
                 url = 'http://adempiere.io/'
                 licenses {

--- a/org.adempiere.test/src/test/java/org/adempiere/test/CSVFactory.java
+++ b/org.adempiere.test/src/test/java/org/adempiere/test/CSVFactory.java
@@ -27,8 +27,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-import org.compiere.process.MMDocument;
-import org.compiere.process.MMScenario;
 import org.supercsv.io.CsvListReader;
 import org.supercsv.io.ICsvListReader;
 import org.supercsv.prefs.CsvPreference;

--- a/org.adempiere.test/src/test/java/org/adempiere/test/MMDocument.java
+++ b/org.adempiere.test/src/test/java/org/adempiere/test/MMDocument.java
@@ -11,10 +11,12 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,    *
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
  *****************************************************************************/
-package org.compiere.process;
+package org.adempiere.test;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+
+import org.compiere.process.DocAction;
 
 /**
  * @author Teo Sarca, www.arhipac.ro

--- a/org.adempiere.test/src/test/java/org/adempiere/test/MMScenario.java
+++ b/org.adempiere.test/src/test/java/org/adempiere/test/MMScenario.java
@@ -11,7 +11,7 @@
  * with this program; if not, write to the Free Software Foundation, Inc.,    *
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
  *****************************************************************************/
-package org.compiere.process;
+package org.adempiere.test;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
The gradle structure is the follow:
- adempiereTrunk:
  - org.adempiere.test:
    - build.gradle

Now you can run the follow command to base source folder:
```Shell
gradle build
```
The dependence from tools is:
```Java
    implementation fileTree(
        dir: '../tools/lib/testing',
        include: [
        'SuperCSV-with_src-1.52.jar'
        ]
    )
    api 'io.github.adempiere:base:3.9.4-develop-1.0'
    // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
    api 'org.junit.jupiter:junit-jupiter-api:5.7.0'
    // https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
    api 'org.mockito:mockito-junit-jupiter:3.6.0'
    // https://mvnrepository.com/artifact/org.junit.platform/junit-platform-console-standalone
    api 'org.junit.platform:junit-platform-console-standalone:1.7.0'
```

Note that the library **SuperCSV-with_src-1.52.jar** is very very old and should be removed soon

See the result: https://repo1.maven.org/maven2/io/github/adempiere/adempiere.test/