### PR TITLE
This pull request just add support to gradle builder to org.spin.hr_time_and_attendance source folder

### DIFF
--- a/org.spin.hr_time_and_attendance/build.gradle
+++ b/org.spin.hr_time_and_attendance/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 sourceSets {
     main {
          java {
-            srcDirs = ['src']
+            srcDirs = ['src/main/java/base']
          }
     }
 }
@@ -41,7 +41,7 @@ signing {
 }
 
 def entityType = 'D'
-version = "3.9.4-develop-1.0"
+version = "3.9.4-develop-1.1"
 
 jar {
     manifest {

--- a/org.spin.hr_time_and_attendance/build.gradle
+++ b/org.spin.hr_time_and_attendance/build.gradle
@@ -1,0 +1,99 @@
+apply plugin: 'java-library'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+        }
+    }
+}
+
+dependencies {
+    api 'io.github.adempiere:base:3.9.4-develop-1.1'
+    api 'io.github.adempiere:human-resource-and-payroll:3.9.4-develop-1.0'
+}
+
+sourceSets {
+    main {
+         java {
+            srcDirs = ['src']
+         }
+    }
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
+signing {
+    sign configurations.archives
+}
+
+def entityType = 'D'
+version = "3.9.4-develop-1.0"
+
+jar {
+    manifest {
+        attributes("Implementation-Title": "Adempiere Project Management",
+                   "Implementation-Version": version, 
+                   "EntityType": entityType)
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            credentials {
+                username = ossrhUsername ?: System.getenv("OSSRH_USER_NAME")
+                password = ossrhPassword ?: System.getenv("OSSRH_PASSWORD")
+            }
+        }
+    }
+    publications {
+        mavenJava(MavenPublication) {
+        	groupId 'io.github.adempiere'
+            artifactId 'time-and-attendance'
+            version
+           	from components.java
+           	pom {
+                name = 'Time and Attendance Management'
+                description = 'Time and Attendance Management dedicated to manage Attendance, and members.'
+                url = 'http://adempiere.io/'
+                licenses {
+                    license {
+                        name = 'GNU General Public License, version 2'
+                        url = 'https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'yamelsenih'
+                        name = 'Yamel Senih'
+                        email = 'ysenih@erpya.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/adempiere/adempiere.git'
+                    developerConnection = 'scm:git:ssh://github.com/adempiere/adempiere.git'
+                    url = 'http://github.com/adempiere/adempiere'
+                }
+            }
+		}
+	}
+}
+
+signing {
+    sign publishing.publications.mavenJava
+}

--- a/org.spin.hr_time_and_attendance/src/main/java/base/org/spin/model/MHRShiftIncidence.java
+++ b/org.spin.hr_time_and_attendance/src/main/java/base/org/spin/model/MHRShiftIncidence.java
@@ -28,7 +28,6 @@ import org.compiere.util.CCache;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.compiere.util.Util;
-import org.jfree.data.time.Millisecond;
 
 /**
  * 	Class added for handle shift incidence
@@ -91,7 +90,7 @@ public class MHRShiftIncidence extends X_HR_ShiftIncidence {
 	}
 	
 	/**
-	 * Get Duration in {@link Millisecond}, it can be used after evaluate time
+	 * Get Duration in Millisecond, it can be used after evaluate time
 	 * A example for entrance
 	 * <li>[(8:00)------------(8:30)----------------------------(9:30)-------------------------(12:00)]
 	 * <li>[(From)--------(Beginning Time)-----------------(Attendance Time)----------------------(To)]


### PR DESCRIPTION
The gradle structure is the follow:
- adempiereTrunk:
  - org.spin.hr_time_and_attendance:
    - build.gradle

Now you can run the follow command to base source folder:
```Shell
gradle build
```
The dependence from tools is:
```Java
    api 'io.github.adempiere:base:3.9.4-develop-1.1'
    api 'io.github.adempiere:human-resource-and-payroll:3.9.4-develop-1.0'
```

See the result:
https://repo1.maven.org/maven2/io/github/adempiere/time-and-attendance/