### PR TITLE
Add P_ADEMPIERE_APPS_TYPE support to Ini loader

### DIFF
--- a/base/src/org/compiere/db/DB_MariaDB.java
+++ b/base/src/org/compiere/db/DB_MariaDB.java
@@ -524,7 +524,7 @@ public class DB_MariaDB implements AdempiereDatabase {
 				datasourceLongRunning = new HikariDataSource(config);;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(System.getenv("ADEMPIERE_APPS_TYPE"));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
 				datasourceLongRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {
@@ -603,7 +603,7 @@ public class DB_MariaDB implements AdempiereDatabase {
 				datasourceShortRunning = cpds;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(System.getenv("ADEMPIERE_APPS_TYPE"));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
 				datasourceShortRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {

--- a/base/src/org/compiere/db/DB_MariaDB.java
+++ b/base/src/org/compiere/db/DB_MariaDB.java
@@ -524,7 +524,7 @@ public class DB_MariaDB implements AdempiereDatabase {
 				datasourceLongRunning = new HikariDataSource(config);;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Ini.getApplicationType());
 				datasourceLongRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {
@@ -603,7 +603,7 @@ public class DB_MariaDB implements AdempiereDatabase {
 				datasourceShortRunning = cpds;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Ini.getApplicationType());
 				datasourceShortRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {

--- a/base/src/org/compiere/db/DB_MySQL.java
+++ b/base/src/org/compiere/db/DB_MySQL.java
@@ -558,7 +558,7 @@ public class DB_MySQL implements AdempiereDatabase {
 				datasourceLongRunning = new HikariDataSource(config);;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(System.getenv("ADEMPIERE_APPS_TYPE"));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
 				datasourceLongRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {
@@ -637,7 +637,7 @@ public class DB_MySQL implements AdempiereDatabase {
 				datasourceShortRunning = cpds;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(System.getenv("ADEMPIERE_APPS_TYPE"));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
 				datasourceShortRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {

--- a/base/src/org/compiere/db/DB_MySQL.java
+++ b/base/src/org/compiere/db/DB_MySQL.java
@@ -558,7 +558,7 @@ public class DB_MySQL implements AdempiereDatabase {
 				datasourceLongRunning = new HikariDataSource(config);;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Ini.getApplicationType());
 				datasourceLongRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {
@@ -637,7 +637,7 @@ public class DB_MySQL implements AdempiereDatabase {
 				datasourceShortRunning = cpds;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Ini.getApplicationType());
 				datasourceShortRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {

--- a/base/src/org/compiere/db/DB_Oracle.java
+++ b/base/src/org/compiere/db/DB_Oracle.java
@@ -586,7 +586,7 @@ public class DB_Oracle implements AdempiereDatabase
                 datasourceLongRunning = new HikariDataSource(config);
                 log.warning("Starting Client Hikari Connection Pool");
             } else {
-                Optional<String> maybeApplicationType = Optional.ofNullable(System.getenv("ADEMPIERE_APPS_TYPE"));
+            	Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
                 datasourceLongRunning = maybeApplicationType
                         .map(applicationType -> {
                             if ("wildfly".equals(applicationType)) {
@@ -665,7 +665,7 @@ public class DB_Oracle implements AdempiereDatabase
                 datasourceShortRunning = cpds;
                 log.warning("Starting Client Hikari Connection Pool");
             } else {
-                Optional<String> maybeApplicationType = Optional.ofNullable(System.getenv("ADEMPIERE_APPS_TYPE"));
+            	Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
                 datasourceShortRunning = maybeApplicationType
                         .map(applicationType -> {
                             if ("wildfly".equals(applicationType)) {

--- a/base/src/org/compiere/db/DB_Oracle.java
+++ b/base/src/org/compiere/db/DB_Oracle.java
@@ -586,7 +586,7 @@ public class DB_Oracle implements AdempiereDatabase
                 datasourceLongRunning = new HikariDataSource(config);
                 log.warning("Starting Client Hikari Connection Pool");
             } else {
-            	Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
+            	Optional<String> maybeApplicationType = Optional.ofNullable(Ini.getApplicationType());
                 datasourceLongRunning = maybeApplicationType
                         .map(applicationType -> {
                             if ("wildfly".equals(applicationType)) {
@@ -665,7 +665,7 @@ public class DB_Oracle implements AdempiereDatabase
                 datasourceShortRunning = cpds;
                 log.warning("Starting Client Hikari Connection Pool");
             } else {
-            	Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
+            	Optional<String> maybeApplicationType = Optional.ofNullable(Ini.getApplicationType());
                 datasourceShortRunning = maybeApplicationType
                         .map(applicationType -> {
                             if ("wildfly".equals(applicationType)) {

--- a/base/src/org/compiere/db/DB_PostgreSQL.java
+++ b/base/src/org/compiere/db/DB_PostgreSQL.java
@@ -596,7 +596,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 				datasourceLongRunning = new HikariDataSource(config);;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(System.getenv("ADEMPIERE_APPS_TYPE"));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
 				datasourceLongRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {

--- a/base/src/org/compiere/db/DB_PostgreSQL.java
+++ b/base/src/org/compiere/db/DB_PostgreSQL.java
@@ -675,7 +675,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 				datasourceShortRunning = cpds;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(System.getenv("ADEMPIERE_APPS_TYPE"));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
 				datasourceShortRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {

--- a/base/src/org/compiere/db/DB_PostgreSQL.java
+++ b/base/src/org/compiere/db/DB_PostgreSQL.java
@@ -596,7 +596,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 				datasourceLongRunning = new HikariDataSource(config);;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Ini.getApplicationType());
 				datasourceLongRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {
@@ -675,7 +675,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 				datasourceShortRunning = cpds;
 				log.warning("Starting Client Hikari Connection Pool");
 			} else {
-				Optional<String> maybeApplicationType = Optional.ofNullable(Optional.ofNullable(Ini.getApplicationType()).orElse(System.getenv("ADEMPIERE_APPS_TYPE")));
+				Optional<String> maybeApplicationType = Optional.ofNullable(Ini.getApplicationType());
 				datasourceShortRunning = maybeApplicationType
 						.map(applicationType -> {
 							if ("wildfly".equals(applicationType)) {

--- a/base/src/org/compiere/util/Ini.java
+++ b/base/src/org/compiere/util/Ini.java
@@ -535,7 +535,7 @@ public final class Ini implements Serializable
 	public static String getAsString()
 	{
 		StringBuffer buf = new StringBuffer ("Ini[");
-		Enumeration<?> e = s_prop.keys();
+		Enumeration e = s_prop.keys();
 		while (e.hasMoreElements())
 		{
 			String key = (String)e.nextElement();

--- a/base/src/org/compiere/util/Ini.java
+++ b/base/src/org/compiere/util/Ini.java
@@ -33,10 +33,6 @@ import java.util.logging.Logger;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-
-import org.adempiere.exceptions.AdempiereException;
-//import org.adempiere.plaf.AdempiereLookAndFeel;
-//import org.adempiere.plaf.AdempiereThemeInnova;
 import org.compiere.model.ModelValidationEngine;
 
 /**
@@ -171,6 +167,7 @@ public final class Ini implements Serializable
 	private static final String DEFAULT_WARNING =	"Do_not_change_any_of_the_data_as_they_will_have_undocumented_side_effects.";
 	private static final String P_WARNING_de =		"WarningD";
 	private static final String DEFAULT_WARNING_de ="Einstellungen_nicht_aendern,_da_diese_undokumentierte_Nebenwirkungen_haben.";
+	public static final String P_ADEMPIERE_APPS_TYPE = "ADEMPIERE_APPS_TYPE";
 	
 	/** Charset */
 	public static final String P_CHARSET = "Charset";
@@ -262,6 +259,14 @@ public final class Ini implements Serializable
 		log.finer(fileName);
 	}	//	save
 
+	/**
+	 * Get Application Type
+	 * @return
+	 */
+	public static String getApplicationType() {
+		return getProperty(P_ADEMPIERE_APPS_TYPE);
+	}
+	
 	/**
 	 *	Load INI parameters from disk
 	 *  @param reload reload
@@ -530,7 +535,7 @@ public final class Ini implements Serializable
 	public static String getAsString()
 	{
 		StringBuffer buf = new StringBuffer ("Ini[");
-		Enumeration e = s_prop.keys();
+		Enumeration<?> e = s_prop.keys();
 		while (e.hasMoreElements())
 		{
 			String key = (String)e.nextElement();


### PR DESCRIPTION
Currently exists a enviroment variable added to ADempiere connection pool, the problem is that it jus is setted as OS variable instead of Ini loader like is all ini enviroment of adempiere. This pull request add support to Ini loader and keep the OS enviroment as second option.

The follow error is throwed if not exist the enviroment variable:
```Shell
org.adempiere.exceptions.AdempiereException: The ADEMPIERE_APPS_TYPE environment variable is not set, so it is not possible to initialize the Hikari Connection Pool
	at org.compiere.db.DB_PostgreSQL.lambda$getDataSource$1(DB_PostgreSQL.java:639)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at org.compiere.db.DB_PostgreSQL.getDataSource(DB_PostgreSQL.java:639)
	at org.compiere.db.DB_PostgreSQL.getFromConnectionPool(DB_PostgreSQL.java:532)
	at org.compiere.db.CConnection.getConnection(CConnection.java:1363)
	at org.compiere.util.DB.createConnection(DB.java:463)
	at org.compiere.util.DB.getConnectionRW(DB.java:393)
	at org.compiere.util.DB.isConnected(DB.java:361)
	at org.compiere.util.CLogErrorBuffer.publish(CLogErrorBuffer.java:211)
	at java.logging/java.util.logging.Logger.log(Logger.java:980)
	at java.logging/java.util.logging.Logger.doLog(Logger.java:1007)
	at java.logging/java.util.logging.Logger.log(Logger.java:1030)
	at java.logging/java.util.logging.Logger.severe(Logger.java:1777)
	at org.compiere.db.CConnection.getConnection(CConnection.java:1367)
	at org.compiere.util.DB.createConnection(DB.java:463)
	at org.compiere.util.DB.getConnectionRO(DB.java:412)
	at org.compiere.model.POInfo.getPOInfoColumnList(POInfo.java:355)
	at org.compiere.model.POInfo.loadInfo(POInfo.java:173)
	at org.compiere.model.POInfo.<init>(POInfo.java:129)
	at org.compiere.model.POInfo.getPOInfo(POInfo.java:84)
	at org.compiere.model.X_AD_Client.initPO(X_AD_Client.java:79)
	at org.compiere.model.PO.<init>(PO.java:223)
	at org.compiere.model.PO.<init>(PO.java:183)
	at org.compiere.model.X_AD_Client.<init>(X_AD_Client.java:38)
	at org.compiere.model.MClient.<init>(MClient.java:122)
	at org.compiere.model.MClient.<init>(MClient.java:153)
	at org.compiere.model.MClient.get(MClient.java:77)
	at org.compiere.model.MClient.get(MClient.java:106)
	at org.compiere.model.MCountry.loadAllCountries(MCountry.java:128)
	at org.compiere.model.MCountry.getCountries(MCountry.java:114)
	at org.spin.grpc.service.AccessServiceImplementation.<init>(AccessServiceImplementation.java:87)
	at org.spin.server.AllInOneServices.start(AllInOneServices.java:64)
	at org.spin.server.AllInOneServices.main(AllInOneServices.java:179)
===========> CConnection.getConnection: Cannot invoke "javax.sql.DataSource.getConnection()" because "this.datasourceLongRunning" is null [1]
===========> CConnection.getConnection: Cannot invoke "javax.sql.DataSource.getConnection()" because "this.datasourceLongRunning" is null [1]
===========> CConnection.getConnection: Cannot invoke "javax.sql.DataSource.getConnection()" because "this.datasourceLongRunning" is null [1]
```