### PR TITLE
Validate Class Name for document tables

### DIFF
--- a/base/src/org/adempiere/util/GenerateModel.java
+++ b/base/src/org/adempiere/util/GenerateModel.java
@@ -71,7 +71,7 @@ public class GenerateModel
 	 */
 	public static void main (String[] args)
 	{
-		Adempiere.startupEnvironment((args.length > 4 && args[4].equals("Client")));
+		Adempiere.startupEnvironment(true);
 		CLogMgt.setLevel(Level.FINE);
 		log.info("Generate Model   $Revision: 1.42 $");
 		log.info("----------------------------------");

--- a/base/src/org/adempiere/util/GenerateModelJPA.java
+++ b/base/src/org/adempiere/util/GenerateModelJPA.java
@@ -60,7 +60,7 @@ public class GenerateModelJPA
 	public static final String COPY = 
 		 "/******************************************************************************\n"
 		+" * Product: Adempiere ERP & CRM Smart Business Solution                       *\n"
-		+" * Copyright (C) 2006-2008 Adempiere Bazaar. All Rights Reserved.                *\n"
+		+" * Copyright (C) 2006-2008 Adempiere Bazaar. All Rights Reserved.             *\n"
 		+" * This program is free software; you can redistribute it and/or modify it    *\n"
 		+" * under the terms version 2 of the GNU General Public License as published   *\n"
 		+" * by the Free Software Foundation. This program is distributed in the hope   *\n"
@@ -69,10 +69,8 @@ public class GenerateModelJPA
 		+" * See the GNU General Public License for more details.                       *\n"
 		+" * You should have received a copy of the GNU General Public License along    *\n"
 		+" * with this program; if not, write to the Free Software Foundation, Inc.,    *\n"
-		//+" * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *\n"
-		//+" * For the text or an alternative of this public license, you may reach us    *\n"
-		+" * or via www.adempiere.org or http://www.adempiere.org/wiki		           *\n"
-                   +" * Contributor: Victor Perez Juarez                                           *\n" 
+		+" * or via https://adempiere.io                                                *\n"
+        +" * Contributor: ADempiere ERP (generated)                                     *\n" 
 		+" *****************************************************************************/\n";
 	
 	/**	Generated on					*/
@@ -145,7 +143,7 @@ public class GenerateModelJPA
                         + "import org.adempiere.util.*;"                        
 			//	Class
 			+ "/** Generated Model for ").append(tableName).append("\n"
-			+ " *  @author Victor Perez (generated) \n"
+			+ " *  @author ADempiere ERP (generated) \n"
 			+ " *  @version ").append(Adempiere.MAIN_VERSION).append(" - ").append(s_run).append(" */\n"
                         + " @Entity"
                         + "@Table(name=\""+ tableName +"\")" 
@@ -314,7 +312,7 @@ public class GenerateModelJPA
 		boolean virtualColumn, boolean IsEncrypted)
 	{
 		//	Clazz
-		Class clazz = DisplayType.getClass(displayType, true);
+		Class<?> clazz = DisplayType.getClass(displayType, true);
 		if (defaultValue == null)
 			defaultValue = "";
 		if (DisplayType.isLOB(displayType))		//	No length check for LOBs

--- a/base/src/org/adempiere/util/ModelClassGenerator.java
+++ b/base/src/org/adempiere/util/ModelClassGenerator.java
@@ -88,23 +88,25 @@ public class ModelClassGenerator
 		StringBuffer mandatory = new StringBuffer();
 		StringBuffer sb = createColumns(AD_Table_ID, mandatory);
 		// Header
-		String tableName = createHeader(table, sb, mandatory, packageName);
+		String className = createHeader(table, sb, mandatory, packageName);
 		// Save
 		if ( ! directory.endsWith(File.separator) )
 			directory += File.separator;
 		//	Write to file "X_" class
-		writeToFile (sb, directory + tableName + ".java");
+		writeToFile (sb, directory + className + ".java");
 		//	Create Document Class
 		if(table.isDocument()) {
 			sb = new StringBuffer();
-			tableName = createHeaderDocument(table, tableName, sb, packageName);
-			//	Write to file "M" class
-			String fileName = directory + tableName + ".java";
-			//	Validate if exists
-			File out = new File (fileName);
-			if(!out.exists()) {
-				//	Create a File
-				writeToFile (sb, fileName);
+			className = createHeaderDocument(table, className, sb, packageName);
+			if(className != null) {
+				//	Write to file "M" class
+				String fileName = directory + className + ".java";
+				//	Validate if exists
+				File out = new File (fileName);
+				if(!out.exists()) {
+					//	Create a File
+					writeToFile (sb, fileName);
+				}
 			}
 		}
 	}
@@ -264,7 +266,11 @@ public class ModelClassGenerator
 	private String createHeaderDocument(MTable p_Table, String p_ParentClassName, StringBuffer sb, String packageName) {
 		String tableName = p_Table.getTableName();
 		String keyColumn = tableName + "_ID";
-		String className = "M" + tableName.replaceAll("_", "");
+		Class<?> clazz = MTable.getClass(tableName);
+		if(clazz == null) {
+			return null;
+		}
+		String className = clazz.getSimpleName();
 		//
 		StringBuffer start = new StringBuffer ()
 			.append (ModelInterfaceGenerator.COPY)

--- a/base/src/org/adempiere/util/ModelInterfaceGenerator.java
+++ b/base/src/org/adempiere/util/ModelInterfaceGenerator.java
@@ -91,7 +91,7 @@ public class ModelInterfaceGenerator
 		+" * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *\n"
 		+" * This program is free software, you can redistribute it and/or modify it    *\n"
 		+" * under the terms version 2 of the GNU General Public License as published   *\n"
-		+" * or (at your option) any later version.										*\n"
+		+" * or (at your option) any later version.                                     *\n"
 		+" * by the Free Software Foundation. This program is distributed in the hope   *\n"
 		+" * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *\n"
 		+" * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *\n"
@@ -100,7 +100,8 @@ public class ModelInterfaceGenerator
 		+" * with this program, if not, write to the Free Software Foundation, Inc.,    *\n"
 		+" * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *\n"
 		+" * For the text or an alternative of this public license, you may reach us    *\n"
-		+" * or via info@adempiere.net or http://www.adempiere.net/license.html         *\n"
+		+" * or via info@adempiere.net                                                  *\n"
+		+" * or https://github.com/adempiere/adempiere/blob/develop/license.html        *\n"
 		+" *****************************************************************************/\n";
 	
 	/** Logger */
@@ -626,6 +627,25 @@ public class ModelInterfaceGenerator
 		return fieldName;
 	}
 	
+	/**
+	 * Validate if is a native model package name or is a new module
+	 * @param modelpackage
+	 * @return
+	 */
+	private static boolean isCoreModelpackage(String modelpackage) {
+		if(modelpackage == null) {
+			return false;
+		}
+		return modelpackage.equals("org.compiere.model") 
+				|| modelpackage.equals("org.compiere.report") 
+				|| modelpackage.equals("org.compiere.print") 
+				|| modelpackage.equals("compiere.model") 
+				|| modelpackage.equals("adempiere.model") 
+				|| modelpackage.equals("org.adempiere.model") 
+				|| modelpackage.equals("org.eevolution.model") 
+				|| modelpackage.equals("org.spin.model");
+	}
+	
 	public static String getReferenceClassName(int AD_Table_ID, String columnName, int displayType, int AD_Reference_ID)
 	{
 		String referenceClassName = null;
@@ -645,7 +665,8 @@ public class ModelInterfaceGenerator
 				{						
 					referenceClassName = modelpackage+"."+referenceClassName;
 				}
-				if (!isGenerateModelGetterForEntity(AD_Table_ID, entityType))
+				if (!isGenerateModelGetterForEntity(AD_Table_ID, entityType)
+						|| !isCoreModelpackage(modelpackage))
 				{
 					referenceClassName = null; 
 				}
@@ -691,7 +712,8 @@ public class ModelInterfaceGenerator
 						{
 							referenceClassName = modelpackage+"."+referenceClassName;
 						}
-						if (!isGenerateModelGetterForEntity(AD_Table_ID, entityType))
+						if (!isGenerateModelGetterForEntity(AD_Table_ID, entityType)
+								|| !isCoreModelpackage(modelpackage))
 						{
 							referenceClassName = null;
 						}


### PR DESCRIPTION
This pull request just add a validation to generate model class with
correct name:

The previous problem is that if a table like C_Invoice was generated, the model class generated is MCInvoice instead MInvoice (and validating it).

Also allows validate core packages to generate references