### PR TITLE
Add support to default PDF to Process Info

### DIFF
--- a/base/src/org/compiere/process/ProcessInfo.java
+++ b/base/src/org/compiere/process/ProcessInfo.java
@@ -963,6 +963,10 @@ public class ProcessInfo implements Serializable
 	 */
 	public void setReportAsFile(File reportAsFile) {
 		this.reportAsFile = reportAsFile;
+		if(reportAsFile != null
+				&& reportAsFile.getName().lastIndexOf(".pdf") > 0) {
+			pdfReportFile = reportAsFile;
+		}
 	}
 	
 	/**


### PR DESCRIPTION
A minor change that allows define the PDF file reference to `pdfReportFile` of Process Info when the `reportAsFile` object have a file with .pdf extension