### PR TITLE
Prevent NPE when openResult is called

### DIFF
--- a/client/src/org/compiere/apps/ProcessController.java
+++ b/client/src/org/compiere/apps/ProcessController.java
@@ -806,8 +806,12 @@ public abstract class ProcessController extends SmallViewController {
 			return;
 		}
 		List<Integer> keys = new ArrayList<Integer>();
-		for(int key : getProcessInfo().getIDs()) {
-			keys.add(key);
+		int[] keysAsarray = getProcessInfo().getIDs();
+		if(keysAsarray != null
+				&& keysAsarray.length > 0) {
+			for(int key : keysAsarray) {
+				keys.add(key);
+			}
 		}
 		//	
 		String tableName = getProcessInfo().getResultTableName();


### PR DESCRIPTION
This pull request just prevent a NPE when the `openResult` method is called without records.

The openResult feature was added by me here #1854