### PR TITLE
Just change rounding up to decimal 128

### DIFF
--- a/base/src/org/compiere/model/CalloutEngine.java
+++ b/base/src/org/compiere/model/CalloutEngine.java
@@ -18,7 +18,7 @@ package org.compiere.model;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
-import java.math.RoundingMode;
+import java.math.MathContext;
 import java.sql.Timestamp;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -254,7 +254,7 @@ public class CalloutEngine implements Callout
 		BigDecimal one = new BigDecimal(1.0);
 
 		if (rate1.doubleValue() != 0.0)	//	no divide by zero
-			rate2 = one.divide(rate1, 12, RoundingMode.HALF_UP);
+			rate2 = one.divide(rate1, MathContext.DECIMAL128);
 		//
 		if (mField.getColumnName().equals("MultiplyRate"))
 			mTab.setValue("DivideRate", rate2);


### PR DESCRIPTION
Currently the `rate` method of CalloutEngine have a rounding mode to half up, this pull request just add a decimal 128 of digits because a rounding can be little explicit if you use it on conversion rates and others functionalities with many difference.


This error affect to countries with many difference between two currency, example:
USD **1** ~ VES **4,500,000.239**
With a conversion from USD to VES