### PR TITLE
Allows define discount based on combinations

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -76,6 +76,8 @@
 	<classpathentry kind="src" path="org.spin.loan_management/src/main/java/ui/swing"/>
 	<classpathentry kind="src" path="org.spin.finance_management/src/main/java/base"/>
 	<classpathentry kind="src" path="org.spin.store/src/main/java"/>
+	<classpathentry kind="src" path="org.spin.notifier.telegram/src/main/java/base"/>
+	<classpathentry kind="src" path="org.spin.notifier.discord/src/main/java/base"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>
@@ -427,5 +429,24 @@
 	<classpathentry kind="lib" path="tools/lib/log4j-core-2.17.1.jar"/>
 	<classpathentry kind="lib" path="tools/lib/HikariCP-5.0.1.jar"/>
 	<classpathentry kind="lib" path="tools/lib/vavr-1.0.0-alpha-4.jar"/>
+	<classpathentry kind="lib" path="tools/lib/telegrambots-6.0.1-jar-with-dependencies.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/annotations-23.0.0.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/commons-collections4-4.4.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/jackson-annotations-2.13.2.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/jackson-core-2.13.2.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/jackson-databind-2.13.2.2.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/JDA-5.0.0-alpha.11.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/jna-4.4.0.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/jsr305-3.0.2.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/kotlin-stdlib-1.4.10.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/kotlin-stdlib-common-1.4.10.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/nv-websocket-client-2.14.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/okhttp-4.9.3.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/okio-jvm-2.8.0.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/opus-java-1.1.1.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/opus-java-api-1.1.1.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/opus-java-natives-1.1.1.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/slf4j-api-1.7.36.jar"/>
+	<classpathentry kind="lib" path="tools/lib/discord/trove4j-3.0.3.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -76,8 +76,6 @@
 	<classpathentry kind="src" path="org.spin.loan_management/src/main/java/ui/swing"/>
 	<classpathentry kind="src" path="org.spin.finance_management/src/main/java/base"/>
 	<classpathentry kind="src" path="org.spin.store/src/main/java"/>
-	<classpathentry kind="src" path="org.spin.notifier.telegram/src/main/java/base"/>
-	<classpathentry kind="src" path="org.spin.notifier.discord/src/main/java/base"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>
 			<attribute name="module" value="true"/>
@@ -429,24 +427,5 @@
 	<classpathentry kind="lib" path="tools/lib/log4j-core-2.17.1.jar"/>
 	<classpathentry kind="lib" path="tools/lib/HikariCP-5.0.1.jar"/>
 	<classpathentry kind="lib" path="tools/lib/vavr-1.0.0-alpha-4.jar"/>
-	<classpathentry kind="lib" path="tools/lib/telegrambots-6.0.1-jar-with-dependencies.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/annotations-23.0.0.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/commons-collections4-4.4.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/jackson-annotations-2.13.2.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/jackson-core-2.13.2.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/jackson-databind-2.13.2.2.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/JDA-5.0.0-alpha.11.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/jna-4.4.0.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/jsr305-3.0.2.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/kotlin-stdlib-1.4.10.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/kotlin-stdlib-common-1.4.10.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/nv-websocket-client-2.14.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/okhttp-4.9.3.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/okio-jvm-2.8.0.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/opus-java-1.1.1.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/opus-java-api-1.1.1.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/opus-java-natives-1.1.1.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/slf4j-api-1.7.36.jar"/>
-	<classpathentry kind="lib" path="tools/lib/discord/trove4j-3.0.3.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/base/src/org/compiere/model/MDiscountSchema.java
+++ b/base/src/org/compiere/model/MDiscountSchema.java
@@ -17,15 +17,14 @@
 package org.compiere.model;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.sql.PreparedStatement;
+import java.math.MathContext;
 import java.sql.ResultSet;
-import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
-import java.util.logging.Level;
 
 import org.compiere.util.CCache;
-import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 
@@ -99,51 +98,55 @@ public class MDiscountSchema extends X_M_DiscountSchema
 	}	//	MDiscountSchema
 
 	/**	Breaks							*/
-	private MDiscountSchemaBreak[]	m_breaks  = null;
+	private List<MDiscountSchemaBreak>	breaks  = null;
 	/**	Lines							*/
-	private MDiscountSchemaLine[]	m_lines  = null;
+	private List<MDiscountSchemaLine>	lines  = null;
+	
+	/**
+	 * Get Break as List
+	 * @param reload
+	 * @return
+	 */
+	public List<MDiscountSchemaBreak> getBreaksAsList(boolean reload) {
+		if (breaks != null && !reload) {
+			return breaks;
+		}
+		//	Get from Query
+		breaks = new Query(getCtx(), I_M_DiscountSchemaBreak.Table_Name, I_M_DiscountSchemaBreak.COLUMNNAME_M_DiscountSchema_ID + " = ?", get_TrxName())
+				.setParameters(getM_DiscountSchema_ID())
+				.setOrderBy(I_M_DiscountSchemaBreak.COLUMNNAME_SeqNo)
+				.list();
+		return breaks;
+	}
+	
+	/**
+	 * Get Lines as List
+	 * @param reload
+	 * @return
+	 */
+	public List<MDiscountSchemaLine> getLinesAsList(boolean reload) {
+		if (lines != null && !reload) {
+			return lines;
+		}
+		//	Get from Query
+		lines = new Query(getCtx(), I_M_DiscountSchemaLine.Table_Name, I_M_DiscountSchemaLine.COLUMNNAME_M_DiscountSchema_ID + " = ?", get_TrxName())
+				.setParameters(getM_DiscountSchema_ID())
+				.setOrderBy(I_M_DiscountSchemaLine.COLUMNNAME_SeqNo)
+				.list();
+		return lines;
+	}
 	
 	/**
 	 * 	Get Breaks
 	 *	@param reload reload
 	 *	@return breaks
 	 */
-	public MDiscountSchemaBreak[] getBreaks(boolean reload)
-	{
-		if (m_breaks != null && !reload)
-			return m_breaks;
-		
-		String sql = "SELECT * FROM M_DiscountSchemaBreak WHERE M_DiscountSchema_ID=? ORDER BY SeqNo";
-		ArrayList<MDiscountSchemaBreak> list = new ArrayList<MDiscountSchemaBreak>();
-		PreparedStatement pstmt = null;
-		try
-		{
-			pstmt = DB.prepareStatement (sql, get_TrxName());
-			pstmt.setInt (1, getM_DiscountSchema_ID());
-			ResultSet rs = pstmt.executeQuery ();
-			while (rs.next ())
-				list.add(new MDiscountSchemaBreak(getCtx(), rs, get_TrxName()));
-			rs.close ();
-			pstmt.close ();
-			pstmt = null;
-		}
-		catch (Exception e)
-		{
-			log.log(Level.SEVERE, sql, e);
-		}
-		try
-		{
-			if (pstmt != null)
-				pstmt.close ();
-			pstmt = null;
-		}
-		catch (Exception e)
-		{
-			pstmt = null;
-		}
-		m_breaks = new MDiscountSchemaBreak[list.size ()];
-		list.toArray (m_breaks);
-		return m_breaks;
+	public MDiscountSchemaBreak[] getBreaks(boolean reload) {
+		getBreaksAsList(reload);
+		MDiscountSchemaBreak [] breaksAsArray = new MDiscountSchemaBreak[breaks.size ()];
+		breaks.toArray(breaksAsArray);
+		set_TrxName(breaksAsArray, get_TrxName());
+		return breaksAsArray;
 	}	//	getBreaks
 	
 	/**
@@ -151,44 +154,12 @@ public class MDiscountSchema extends X_M_DiscountSchema
 	 *	@param reload reload
 	 *	@return lines
 	 */
-	public MDiscountSchemaLine[] getLines(boolean reload)
-	{
-		if (m_lines != null && !reload) {
-			set_TrxName(m_lines, get_TrxName());
-			return m_lines;
-		}
-		
-		String sql = "SELECT * FROM M_DiscountSchemaLine WHERE M_DiscountSchema_ID=? ORDER BY SeqNo";
-		ArrayList<MDiscountSchemaLine> list = new ArrayList<MDiscountSchemaLine>();
-		PreparedStatement pstmt = null;
-		try
-		{
-			pstmt = DB.prepareStatement (sql, get_TrxName());
-			pstmt.setInt (1, getM_DiscountSchema_ID());
-			ResultSet rs = pstmt.executeQuery ();
-			while (rs.next ())
-				list.add(new MDiscountSchemaLine(getCtx(), rs, get_TrxName()));
-			rs.close ();
-			pstmt.close ();
-			pstmt = null;
-		}
-		catch (Exception e)
-		{
-			log.log(Level.SEVERE, sql, e);
-		}
-		try
-		{
-			if (pstmt != null)
-				pstmt.close ();
-			pstmt = null;
-		}
-		catch (Exception e)
-		{
-			pstmt = null;
-		}
-		m_lines = new MDiscountSchemaLine[list.size ()];
-		list.toArray (m_lines);
-		return m_lines;
+	public MDiscountSchemaLine[] getLines(boolean reload) {
+		getLinesAsList(reload);
+		MDiscountSchemaLine[] linesAsArray = new MDiscountSchemaLine[lines.size ()];
+		lines.toArray (linesAsArray);
+		set_TrxName(linesAsArray, get_TrxName());
+		return linesAsArray;
 	}	//	getBreaks
 
 	/**
@@ -221,7 +192,7 @@ public class MDiscountSchema extends X_M_DiscountSchema
 		//
 		BigDecimal onehundred = new BigDecimal(100);
 		BigDecimal multiplier = (onehundred).subtract(discount);
-		multiplier = multiplier.divide(onehundred, 6, RoundingMode.HALF_UP);
+		multiplier = multiplier.divide(onehundred, MathContext.DECIMAL128);
 		BigDecimal newPrice = Price.multiply(multiplier);
 		log.fine("=>" + newPrice);
 		return newPrice;
@@ -229,15 +200,15 @@ public class MDiscountSchema extends X_M_DiscountSchema
 
 	/**
 	 * 	Calculate Discount Percentage
-	 *	@param Qty quantity
+	 *	@param quantity quantity
 	 *	@param Price price
-	 *	@param M_Product_ID product
-	 *	@param M_Product_Category_ID category
+	 *	@param productId product
+	 *	@param productCategoryId category
 	 *	@param BPartnerFlatDiscount flat discount
 	 *	@return discount or zero
 	 */
-	public BigDecimal calculateDiscount (BigDecimal Qty, BigDecimal Price,  
-		int M_Product_ID, int M_Product_Category_ID,
+	public BigDecimal calculateDiscount (BigDecimal quantity, BigDecimal Price,  
+		int productId, int productCategoryId,
 		BigDecimal BPartnerFlatDiscount)
 	{
 		if (BPartnerFlatDiscount == null)
@@ -259,48 +230,46 @@ public class MDiscountSchema extends X_M_DiscountSchema
 		}
 		
 		//	Price Breaks
-		getBreaks(true);
-		boolean found = false;
-		BigDecimal Amt = Price.multiply(Qty);
+		getBreaksAsList(true);
+		BigDecimal amount = Price.multiply(quantity);
 		if (isQuantityBased())
-			log.finer("Qty=" + Qty + ",M_Product_ID=" + M_Product_ID + ",M_Product_Category_ID=" + M_Product_Category_ID);
+			log.finer("Qty=" + quantity + ",M_Product_ID=" + productId + ",M_Product_Category_ID=" + productCategoryId);
 		else
-			log.finer("Amt=" + Amt + ",M_Product_ID=" + M_Product_ID + ",M_Product_Category_ID=" + M_Product_Category_ID);
-		for (int i = 0; i < m_breaks.length; i++)
-		{
-			MDiscountSchemaBreak br = m_breaks[i];
-			if (!br.isActive())
-				continue;
-			
-			if (isQuantityBased())
-			{
-				if (!br.applies(Qty, M_Product_ID, M_Product_Category_ID))
-				{
-					log.finer("No: " + br);
-					continue;
-				}
-				log.finer("Yes: " + br);
-			}
-			else
-			{
-				if (!br.applies(Amt, M_Product_ID, M_Product_Category_ID))
-				{
-					log.finer("No: " + br);
-					continue;
-				}
-				log.finer("Yes: " + br);
-			}
-			
+			log.finer("Amt=" + amount + ",M_Product_ID=" + productId + ",M_Product_Category_ID=" + productCategoryId);
+		//	First for product
+		Optional<MDiscountSchemaBreak> maybeDiscount = breaks.stream()
+			.filter(breakLine -> breakLine.isActive() && breakLine.getM_Product_ID() > 0)
+			.filter(breakLine -> breakLine.applies((isQuantityBased()? quantity: amount), productId, productCategoryId))
+			.sorted(Comparator.comparing(MDiscountSchemaBreak::getSeqNo))
+			.findFirst();
+		//	for Category
+		if(!maybeDiscount.isPresent()) {
+			maybeDiscount = breaks.stream()
+					.filter(breakLine -> breakLine.isActive() && breakLine.getM_Product_Category_ID() > 0)
+					.filter(breakLine -> breakLine.applies((isQuantityBased()? quantity: amount), productId, productCategoryId))
+					.sorted(Comparator.comparing(MDiscountSchemaBreak::getSeqNo))
+					.findFirst();
+		}
+		//	For any
+		if(!maybeDiscount.isPresent()) {
+			maybeDiscount = breaks.stream()
+					.filter(breakLine -> breakLine.isActive() && breakLine.getM_Product_Category_ID() == 0 && breakLine.getM_Product_ID() == 0)
+					.filter(breakLine -> breakLine.applies((isQuantityBased()? quantity: amount), productId, productCategoryId))
+					.sorted(Comparator.comparing(MDiscountSchemaBreak::getSeqNo))
+					.findFirst();
+		}
+		//	If exist any match
+		if(maybeDiscount.isPresent()) {
 			//	Line applies
 			BigDecimal discount = null;
-			if (br.isBPartnerFlatDiscount())
+			if (maybeDiscount.get().isBPartnerFlatDiscount()) {
 				discount = BPartnerFlatDiscount;
-			else
-				discount = br.getBreakDiscount();
+			} else {
+				discount = maybeDiscount.get().getBreakDiscount();
+			}
 			log.fine("Discount=>" + discount);
 			return discount;
-		}	//	for all breaks
-		
+		}
 		return Env.ZERO;
 	}	//	calculateDiscount
 	
@@ -337,7 +306,7 @@ public class MDiscountSchema extends X_M_DiscountSchema
 					count++;
 			}
 		}
-		m_lines = null;
+		lines = null;
 		
 		//	Breaks
 		MDiscountSchemaBreak[] breaks = getBreaks(true);
@@ -351,7 +320,7 @@ public class MDiscountSchema extends X_M_DiscountSchema
 					count++;
 			}
 		}
-		m_breaks = null;
+		breaks = null;
 		return count;
 	}	//	reSeq
 	

--- a/base/src/org/compiere/model/MDiscountSchemaBreak.java
+++ b/base/src/org/compiere/model/MDiscountSchemaBreak.java
@@ -63,18 +63,17 @@ public class MDiscountSchemaBreak extends X_M_DiscountSchemaBreak
 	
 	/**
 	 * 	Criteria apply
-	 *	@param Value amt or qty
-	 *	@param M_Product_ID product
-	 *	@param M_Product_Category_ID category
+	 *	@param value amt or qty
+	 *	@param productId product
+	 *	@param productCategoryId category
 	 *	@return true if criteria met
 	 */
-	public boolean applies (BigDecimal Value, int M_Product_ID, int M_Product_Category_ID)
-	{
+	public boolean applies (BigDecimal value, int productId, int productCategoryId) {
 		if (!isActive())
 			return false;
 		
 		//	below break value
-		if (Value.compareTo(getBreakValue()) < 0)
+		if (value.compareTo(getBreakValue()) < 0)
 			return false;
 		
 		//	No Product / Category 
@@ -83,15 +82,16 @@ public class MDiscountSchemaBreak extends X_M_DiscountSchemaBreak
 			return true;
 		
 		//	Product
-		if (getM_Product_ID() == M_Product_ID)
+		if (getM_Product_ID() == productId)
 			return true;
 		
 		//	Category
-		if (M_Product_Category_ID != 0)
-			return getM_Product_Category_ID() == M_Product_Category_ID;
+		if (productCategoryId != 0
+				&& getM_Product_Category_ID() == productCategoryId)
+			return true;
 
 		//	Look up Category of Product
-		return MProductCategory.isCategory(getM_Product_Category_ID(), M_Product_ID);
+		return MProductCategory.isCategory(getM_Product_Category_ID(), productId);
 	}	//	applies
 	
 	@Override

--- a/migration/393lts-394lts/09470_Add_GardenWorld_Discount_Example.xml
+++ b/migration/393lts-394lts/09470_Add_GardenWorld_Discount_Example.xml
@@ -1,0 +1,409 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add GardenWorld Discount Example" ReleaseNo="3.9.4" SeqNo="9470">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="475" Action="I" Record_ID="50000" Table="M_DiscountSchema">
+        <Data AD_Column_ID="6591" Column="ValidFrom">2022-05-10 00:00:00.0</Data>
+        <Data AD_Column_ID="84922" Column="UUID">6ed0c184-76c7-4ffa-a9b5-13eac43fa601</Data>
+        <Data AD_Column_ID="6588" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6587" Column="Updated">2022-05-10 15:03:30.76</Data>
+        <Data AD_Column_ID="6593" Column="Script" isNewNull="true"/>
+        <Data AD_Column_ID="6597" Column="Processing">false</Data>
+        <Data AD_Column_ID="6589" Column="Name">Combined Discount</Data>
+        <Data AD_Column_ID="6581" Column="M_DiscountSchema_ID">50000</Data>
+        <Data AD_Column_ID="6595" Column="IsQuantityBased">true</Data>
+        <Data AD_Column_ID="12737" Column="IsBPartnerFlatDiscount">false</Data>
+        <Data AD_Column_ID="6584" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6594" Column="FlatDiscount">0</Data>
+        <Data AD_Column_ID="6592" Column="DiscountType">B</Data>
+        <Data AD_Column_ID="6590" Column="Description">Combined Discount schema</Data>
+        <Data AD_Column_ID="6596" Column="CumulativeLevel">L</Data>
+        <Data AD_Column_ID="6586" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="6585" Column="Created">2022-05-10 15:03:30.76</Data>
+        <Data AD_Column_ID="6583" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="6582" Column="AD_Client_ID">11</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="476" Action="I" Record_ID="50000" Table="M_DiscountSchemaBreak">
+        <Data AD_Column_ID="84923" Column="UUID">0345546a-165f-47f4-81b3-485565b58d30</Data>
+        <Data AD_Column_ID="6605" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6604" Column="Updated">2022-05-10 15:05:06.593</Data>
+        <Data AD_Column_ID="6607" Column="SeqNo">10</Data>
+        <Data AD_Column_ID="6611" Column="M_Product_ID">133</Data>
+        <Data AD_Column_ID="6610" Column="M_Product_Category_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6606" Column="M_DiscountSchema_ID">50000</Data>
+        <Data AD_Column_ID="6598" Column="M_DiscountSchemaBreak_ID">50000</Data>
+        <Data AD_Column_ID="12399" Column="IsBPartnerFlatDiscount">false</Data>
+        <Data AD_Column_ID="6601" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6603" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="6602" Column="Created">2022-05-10 15:05:06.593</Data>
+        <Data AD_Column_ID="6608" Column="BreakValue">0</Data>
+        <Data AD_Column_ID="6609" Column="BreakDiscount">7.000000000000</Data>
+        <Data AD_Column_ID="6600" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="6599" Column="AD_Client_ID">11</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="476" Action="I" Record_ID="50001" Table="M_DiscountSchemaBreak">
+        <Data AD_Column_ID="84923" Column="UUID">9d0292e1-bc55-414a-8249-0897e5a5627a</Data>
+        <Data AD_Column_ID="6605" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6604" Column="Updated">2022-05-10 15:06:12.159</Data>
+        <Data AD_Column_ID="6607" Column="SeqNo">20</Data>
+        <Data AD_Column_ID="6611" Column="M_Product_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6610" Column="M_Product_Category_ID">109</Data>
+        <Data AD_Column_ID="6606" Column="M_DiscountSchema_ID">50000</Data>
+        <Data AD_Column_ID="6598" Column="M_DiscountSchemaBreak_ID">50001</Data>
+        <Data AD_Column_ID="12399" Column="IsBPartnerFlatDiscount">false</Data>
+        <Data AD_Column_ID="6601" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6603" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="6602" Column="Created">2022-05-10 15:06:12.159</Data>
+        <Data AD_Column_ID="6608" Column="BreakValue">0</Data>
+        <Data AD_Column_ID="6609" Column="BreakDiscount">5.000000000000</Data>
+        <Data AD_Column_ID="6600" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="6599" Column="AD_Client_ID">11</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="476" Action="I" Record_ID="50002" Table="M_DiscountSchemaBreak">
+        <Data AD_Column_ID="84923" Column="UUID">0e7173f8-75ad-4ffc-a285-099a34712f41</Data>
+        <Data AD_Column_ID="6605" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="6604" Column="Updated">2022-05-10 15:07:16.68</Data>
+        <Data AD_Column_ID="6607" Column="SeqNo">30</Data>
+        <Data AD_Column_ID="6611" Column="M_Product_ID">137</Data>
+        <Data AD_Column_ID="6610" Column="M_Product_Category_ID" isNewNull="true"/>
+        <Data AD_Column_ID="6606" Column="M_DiscountSchema_ID">50000</Data>
+        <Data AD_Column_ID="6598" Column="M_DiscountSchemaBreak_ID">50002</Data>
+        <Data AD_Column_ID="12399" Column="IsBPartnerFlatDiscount">false</Data>
+        <Data AD_Column_ID="6601" Column="IsActive">true</Data>
+        <Data AD_Column_ID="6603" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="6602" Column="Created">2022-05-10 15:07:16.679</Data>
+        <Data AD_Column_ID="6608" Column="BreakValue">0</Data>
+        <Data AD_Column_ID="6609" Column="BreakDiscount">10.000000000000</Data>
+        <Data AD_Column_ID="6600" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="6599" Column="AD_Client_ID">11</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="291" Action="U" Record_ID="117" Table="C_BPartner">
+        <Data AD_Column_ID="84609" Column="UUID" isOldNull="true">8e3c4233-f26a-459c-81aa-6af7f8ec6528</Data>
+        <Data AD_Column_ID="6579" Column="M_DiscountSchema_ID" isOldNull="true">50000</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="259" Action="I" Record_ID="50055" Table="C_Order">
+        <Data AD_Column_ID="59038" Column="ProcessedOn">0</Data>
+        <Data AD_Column_ID="3398" Column="Processed">false</Data>
+        <Data AD_Column_ID="4650" Column="Posted">false</Data>
+        <Data AD_Column_ID="2170" Column="DocStatus">DR</Data>
+        <Data AD_Column_ID="2171" Column="DocAction">CO</Data>
+        <Data AD_Column_ID="92893" Column="BOMDrop">N</Data>
+        <Data AD_Column_ID="97251" Column="FM_Agreement_ID" isNewNull="true"/>
+        <Data AD_Column_ID="97186" Column="W_Basket_ID" isNewNull="true"/>
+        <Data AD_Column_ID="96704" Column="M_Freight_ID" isNewNull="true"/>
+        <Data AD_Column_ID="96703" Column="FreightRate">0</Data>
+        <Data AD_Column_ID="95434" Column="C_SalesRegion_ID" isNewNull="true"/>
+        <Data AD_Column_ID="94997" Column="M_RMAType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84683" Column="UUID">d4bd6536-0416-4fa9-9470-fe33e0ac3125</Data>
+        <Data AD_Column_ID="2453" Column="Processing">false</Data>
+        <Data AD_Column_ID="58601" Column="User4_ID" isNewNull="true"/>
+        <Data AD_Column_ID="58600" Column="User3_ID" isNewNull="true"/>
+        <Data AD_Column_ID="56376" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="55314" Column="DropShip_BPartner_ID" isNewNull="true"/>
+        <Data AD_Column_ID="55315" Column="DropShip_Location_ID" isNewNull="true"/>
+        <Data AD_Column_ID="10297" Column="C_ConversionType_ID">114</Data>
+        <Data AD_Column_ID="3400" Column="C_BPartner_Location_ID">112</Data>
+        <Data AD_Column_ID="2454" Column="C_Campaign_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3046" Column="C_Charge_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2186" Column="SalesRep_ID">101</Data>
+        <Data AD_Column_ID="2173" Column="C_DocTypeTarget_ID">135</Data>
+        <Data AD_Column_ID="55322" Column="Link_Order_ID" isNewNull="true"/>
+        <Data AD_Column_ID="55316" Column="DropShip_User_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9568" Column="User2_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9331" Column="AD_OrgTrx_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8766" Column="Bill_Location_ID">112</Data>
+        <Data AD_Column_ID="8763" Column="Bill_User_ID" isNewNull="true"/>
+        <Data AD_Column_ID="9569" Column="User1_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3402" Column="C_Project_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3403" Column="C_Activity_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8764" Column="Bill_BPartner_ID">117</Data>
+        <Data AD_Column_ID="2197" Column="M_Shipper_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2762" Column="C_BPartner_ID">117</Data>
+        <Data AD_Column_ID="2183" Column="DateAcct">2022-05-10 00:00:00.0</Data>
+        <Data AD_Column_ID="2204" Column="M_PriceList_ID">101</Data>
+        <Data AD_Column_ID="2191" Column="C_Currency_ID">100</Data>
+        <Data AD_Column_ID="2168" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2187" Column="C_PaymentTerm_ID">105</Data>
+        <Data AD_Column_ID="2202" Column="M_Warehouse_ID">50002</Data>
+        <Data AD_Column_ID="2763" Column="AD_User_ID" isNewNull="true"/>
+        <Data AD_Column_ID="10924" Column="Pay_Location_ID" isNewNull="true"/>
+        <Data AD_Column_ID="5349" Column="C_CashLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2162" Column="AD_Client_ID">11</Data>
+        <Data AD_Column_ID="5348" Column="C_Payment_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2172" Column="C_DocType_ID">0</Data>
+        <Data AD_Column_ID="2161" Column="C_Order_ID">50055</Data>
+        <Data AD_Column_ID="2166" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2163" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="10925" Column="Pay_BPartner_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2195" Column="FreightAmt">0</Data>
+        <Data AD_Column_ID="52065" Column="AmountRefunded">0.0</Data>
+        <Data AD_Column_ID="57127" Column="PromotionCode" isNewNull="true"/>
+        <Data AD_Column_ID="15900" Column="Weight">0</Data>
+        <Data AD_Column_ID="15899" Column="Volume">0</Data>
+        <Data AD_Column_ID="3718" Column="IsSOTrx">true</Data>
+        <Data AD_Column_ID="3719" Column="DatePrinted" isNewNull="true"/>
+        <Data AD_Column_ID="2181" Column="DateOrdered">2022-05-10 00:00:00.0</Data>
+        <Data AD_Column_ID="2180" Column="IsTransferred">false</Data>
+        <Data AD_Column_ID="2179" Column="IsPrinted">false</Data>
+        <Data AD_Column_ID="2178" Column="IsInvoiced">false</Data>
+        <Data AD_Column_ID="97252" Column="FM_Account_ID" isNewNull="true"/>
+        <Data AD_Column_ID="58409" Column="C_OrderSource_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52070" Column="C_POS_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52063" Column="OrderType" isNewNull="true"/>
+        <Data AD_Column_ID="8765" Column="CopyFrom">N</Data>
+        <Data AD_Column_ID="8166" Column="SendEMail">false</Data>
+        <Data AD_Column_ID="3721" Column="DeliveryRule">A</Data>
+        <Data AD_Column_ID="3722" Column="FreightCostRule">I</Data>
+        <Data AD_Column_ID="3045" Column="POReference">Order Reference 1234</Data>
+        <Data AD_Column_ID="3047" Column="ChargeAmt">0</Data>
+        <Data AD_Column_ID="2196" Column="DeliveryViaRule">P</Data>
+        <Data AD_Column_ID="4298" Column="IsDiscountPrinted">true</Data>
+        <Data AD_Column_ID="4019" Column="PaymentRule">B</Data>
+        <Data AD_Column_ID="2198" Column="PriorityRule">5</Data>
+        <Data AD_Column_ID="11580" Column="IsDropShip">false</Data>
+        <Data AD_Column_ID="4651" Column="IsTaxIncluded">false</Data>
+        <Data AD_Column_ID="2182" Column="DatePromised">2022-05-10 00:00:00.0</Data>
+        <Data AD_Column_ID="2177" Column="IsDelivered">false</Data>
+        <Data AD_Column_ID="2176" Column="IsCreditApproved">false</Data>
+        <Data AD_Column_ID="10926" Column="Ref_Order_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62180" Column="C_Opportunity_ID" isNewNull="true"/>
+        <Data AD_Column_ID="52064" Column="AmountTendered">0.0</Data>
+        <Data AD_Column_ID="2167" Column="Updated">2022-05-10 15:08:47.825</Data>
+        <Data AD_Column_ID="2192" Column="InvoiceRule">D</Data>
+        <Data AD_Column_ID="2201" Column="GrandTotal">0</Data>
+        <Data AD_Column_ID="2200" Column="TotalLines">0</Data>
+        <Data AD_Column_ID="2165" Column="Created">2022-05-10 15:08:47.825</Data>
+        <Data AD_Column_ID="2164" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2174" Column="Description">Order Description from Business Partner Definition</Data>
+        <Data AD_Column_ID="2175" Column="IsApproved">false</Data>
+        <Data AD_Column_ID="8832" Column="IsSelfService">false</Data>
+        <Data AD_Column_ID="2169" Column="DocumentNo">800</Data>
+        <Data AD_Column_ID="4699" Column="IsSelected">false</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="259" Action="U" Record_ID="50055" Table="C_Order">
+        <Data AD_Column_ID="4019" Column="PaymentRule" oldValue="B">P</Data>
+        <Data AD_Column_ID="2192" Column="InvoiceRule" oldValue="D">I</Data>
+        <Data AD_Column_ID="2169" Column="DocumentNo" oldValue="800">&lt;500&gt;</Data>
+        <Data AD_Column_ID="2187" Column="C_PaymentTerm_ID" oldValue="105">106</Data>
+        <Data AD_Column_ID="2173" Column="C_DocTypeTarget_ID" oldValue="135">132</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="260" Action="I" Record_ID="50063" Table="C_OrderLine">
+        <Data AD_Column_ID="84684" Column="UUID">22aa2e65-71c2-479d-9501-2ef51f2e022e</Data>
+        <Data AD_Column_ID="58603" Column="User4_ID" isNewNull="true"/>
+        <Data AD_Column_ID="58602" Column="User3_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15850" Column="User2_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15849" Column="User1_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2212" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2211" Column="Updated">2022-05-10 15:24:06.564</Data>
+        <Data AD_Column_ID="6775" Column="S_ResourceAssignment_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15459" Column="RRStartDate" isNewNull="true"/>
+        <Data AD_Column_ID="15460" Column="RRAmt">0</Data>
+        <Data AD_Column_ID="7812" Column="Ref_OrderLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="95761" Column="Ref_InvoiceLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="94969" Column="Ref_InOutLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2225" Column="QtyReserved">0</Data>
+        <Data AD_Column_ID="2224" Column="QtyOrdered">1</Data>
+        <Data AD_Column_ID="14206" Column="QtyLostSales">0</Data>
+        <Data AD_Column_ID="2227" Column="QtyInvoiced">0</Data>
+        <Data AD_Column_ID="12876" Column="QtyEntered">1</Data>
+        <Data AD_Column_ID="2226" Column="QtyDelivered">0</Data>
+        <Data AD_Column_ID="12069" Column="Processed">false</Data>
+        <Data AD_Column_ID="2231" Column="PriceList">35</Data>
+        <Data AD_Column_ID="4022" Column="PriceLimit">30</Data>
+        <Data AD_Column_ID="12875" Column="PriceEntered">31.35</Data>
+        <Data AD_Column_ID="14200" Column="PriceCost">0</Data>
+        <Data AD_Column_ID="2232" Column="PriceActual">31.35</Data>
+        <Data AD_Column_ID="56532" Column="PP_Cost_Collector_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67789" Column="PickedQty">0</Data>
+        <Data AD_Column_ID="2223" Column="M_Warehouse_ID">50002</Data>
+        <Data AD_Column_ID="2229" Column="M_Shipper_ID" isNewNull="true"/>
+        <Data AD_Column_ID="94998" Column="M_RMAType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="94260" Column="M_RequisitionLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57128" Column="M_Promotion_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2221" Column="M_Product_ID">50007</Data>
+        <Data AD_Column_ID="81230" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8767" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="55323" Column="Link_OrderLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3723" Column="LineNetAmt">31.35</Data>
+        <Data AD_Column_ID="2214" Column="Line">10</Data>
+        <Data AD_Column_ID="9868" Column="IsDescription">false</Data>
+        <Data AD_Column_ID="64175" Column="IsConsumesForecast">false</Data>
+        <Data AD_Column_ID="2208" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3049" Column="FreightAmt">0</Data>
+        <Data AD_Column_ID="4031" Column="Discount">10.43</Data>
+        <Data AD_Column_ID="2220" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="2217" Column="DatePromised">2022-05-10 00:00:00.0</Data>
+        <Data AD_Column_ID="2216" Column="DateOrdered">2022-05-10 00:00:00.0</Data>
+        <Data AD_Column_ID="2219" Column="DateInvoiced" isNewNull="true"/>
+        <Data AD_Column_ID="2218" Column="DateDelivered" isNewNull="true"/>
+        <Data AD_Column_ID="2222" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="2235" Column="C_Tax_ID">104</Data>
+        <Data AD_Column_ID="69035" Column="CreateShipment">N</Data>
+        <Data AD_Column_ID="68954" Column="CreateFrom">N</Data>
+        <Data AD_Column_ID="2210" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2209" Column="Created">2022-05-10 15:24:06.563</Data>
+        <Data AD_Column_ID="15458" Column="C_ProjectTask_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15457" Column="C_ProjectPhase_ID" isNewNull="true"/>
+        <Data AD_Column_ID="14092" Column="C_Project_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2205" Column="C_OrderLine_ID">50063</Data>
+        <Data AD_Column_ID="2213" Column="C_Order_ID">50055</Data>
+        <Data AD_Column_ID="2230" Column="C_Currency_ID">100</Data>
+        <Data AD_Column_ID="3050" Column="C_Charge_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15847" Column="C_Campaign_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3404" Column="C_BPartner_Location_ID">112</Data>
+        <Data AD_Column_ID="2764" Column="C_BPartner_ID">117</Data>
+        <Data AD_Column_ID="15848" Column="C_Activity_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15861" Column="AD_OrgTrx_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2207" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2206" Column="AD_Client_ID">11</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="90" StepType="AD">
+      <PO AD_Table_ID="314" Action="I" Record_ID="50055" Table="C_OrderTax">
+        <Data AD_Column_ID="84686" Column="UUID">fc8faf38-f30e-4dca-a37c-afce7eedbf1c</Data>
+        <Data AD_Column_ID="3354" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3353" Column="Updated">2022-05-10 15:24:11.07</Data>
+        <Data AD_Column_ID="3766" Column="TaxBaseAmt">31.35</Data>
+        <Data AD_Column_ID="3767" Column="TaxAmt">0</Data>
+        <Data AD_Column_ID="12061" Column="Processed">false</Data>
+        <Data AD_Column_ID="13041" Column="IsTaxIncluded">false</Data>
+        <Data AD_Column_ID="3350" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3356" Column="C_Tax_ID">104</Data>
+        <Data AD_Column_ID="3352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3351" Column="Created">2022-05-10 15:24:11.07</Data>
+        <Data AD_Column_ID="3355" Column="C_Order_ID">50055</Data>
+        <Data AD_Column_ID="3349" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3348" Column="AD_Client_ID">11</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="100" StepType="AD">
+      <PO AD_Table_ID="260" Action="U" Record_ID="50063" Table="C_OrderLine">
+        <Data AD_Column_ID="2224" Column="QtyOrdered" oldValue="1">3</Data>
+        <Data AD_Column_ID="12876" Column="QtyEntered" oldValue="1">3</Data>
+        <Data AD_Column_ID="3723" Column="LineNetAmt" oldValue="31.35">94.05</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="110" StepType="AD">
+      <PO AD_Table_ID="314" Action="I" Record_ID="50055" Table="C_OrderTax">
+        <Data AD_Column_ID="84686" Column="UUID">df5c992b-6082-493b-9e54-b7c82eb995f4</Data>
+        <Data AD_Column_ID="3354" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3353" Column="Updated">2022-05-10 15:37:42.171</Data>
+        <Data AD_Column_ID="3766" Column="TaxBaseAmt">94.05</Data>
+        <Data AD_Column_ID="3767" Column="TaxAmt">0</Data>
+        <Data AD_Column_ID="12061" Column="Processed">false</Data>
+        <Data AD_Column_ID="13041" Column="IsTaxIncluded">false</Data>
+        <Data AD_Column_ID="3350" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3356" Column="C_Tax_ID">104</Data>
+        <Data AD_Column_ID="3352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3351" Column="Created">2022-05-10 15:37:42.171</Data>
+        <Data AD_Column_ID="3355" Column="C_Order_ID">50055</Data>
+        <Data AD_Column_ID="3349" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3348" Column="AD_Client_ID">11</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="120" StepType="AD">
+      <PO AD_Table_ID="260" Action="I" Record_ID="50064" Table="C_OrderLine">
+        <Data AD_Column_ID="84684" Column="UUID">ebd09f7a-982a-4412-9b41-8edb26c8ac25</Data>
+        <Data AD_Column_ID="58603" Column="User4_ID" isNewNull="true"/>
+        <Data AD_Column_ID="58602" Column="User3_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15850" Column="User2_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15849" Column="User1_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2212" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2211" Column="Updated">2022-05-10 15:39:59.131</Data>
+        <Data AD_Column_ID="6775" Column="S_ResourceAssignment_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15459" Column="RRStartDate" isNewNull="true"/>
+        <Data AD_Column_ID="15460" Column="RRAmt">0</Data>
+        <Data AD_Column_ID="7812" Column="Ref_OrderLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="95761" Column="Ref_InvoiceLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="94969" Column="Ref_InOutLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2225" Column="QtyReserved">0</Data>
+        <Data AD_Column_ID="2224" Column="QtyOrdered">1</Data>
+        <Data AD_Column_ID="14206" Column="QtyLostSales">0</Data>
+        <Data AD_Column_ID="2227" Column="QtyInvoiced">0</Data>
+        <Data AD_Column_ID="12876" Column="QtyEntered">1</Data>
+        <Data AD_Column_ID="2226" Column="QtyDelivered">0</Data>
+        <Data AD_Column_ID="12069" Column="Processed">false</Data>
+        <Data AD_Column_ID="2231" Column="PriceList">3</Data>
+        <Data AD_Column_ID="4022" Column="PriceLimit">2.7</Data>
+        <Data AD_Column_ID="12875" Column="PriceEntered">2.70</Data>
+        <Data AD_Column_ID="14200" Column="PriceCost">0</Data>
+        <Data AD_Column_ID="2232" Column="PriceActual">2.70</Data>
+        <Data AD_Column_ID="56532" Column="PP_Cost_Collector_ID" isNewNull="true"/>
+        <Data AD_Column_ID="67789" Column="PickedQty">0</Data>
+        <Data AD_Column_ID="2223" Column="M_Warehouse_ID">50002</Data>
+        <Data AD_Column_ID="2229" Column="M_Shipper_ID" isNewNull="true"/>
+        <Data AD_Column_ID="94998" Column="M_RMAType_ID" isNewNull="true"/>
+        <Data AD_Column_ID="94260" Column="M_RequisitionLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="57128" Column="M_Promotion_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2221" Column="M_Product_ID">137</Data>
+        <Data AD_Column_ID="81230" Column="M_FreightCategory_ID" isNewNull="true"/>
+        <Data AD_Column_ID="8767" Column="M_AttributeSetInstance_ID">0</Data>
+        <Data AD_Column_ID="55323" Column="Link_OrderLine_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3723" Column="LineNetAmt">2.70</Data>
+        <Data AD_Column_ID="2214" Column="Line">20</Data>
+        <Data AD_Column_ID="9868" Column="IsDescription">false</Data>
+        <Data AD_Column_ID="64175" Column="IsConsumesForecast">false</Data>
+        <Data AD_Column_ID="2208" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3049" Column="FreightAmt">0</Data>
+        <Data AD_Column_ID="4031" Column="Discount">10.00</Data>
+        <Data AD_Column_ID="2220" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="2217" Column="DatePromised">2022-05-10 00:00:00.0</Data>
+        <Data AD_Column_ID="2216" Column="DateOrdered">2022-05-10 00:00:00.0</Data>
+        <Data AD_Column_ID="2219" Column="DateInvoiced" isNewNull="true"/>
+        <Data AD_Column_ID="2218" Column="DateDelivered" isNewNull="true"/>
+        <Data AD_Column_ID="2222" Column="C_UOM_ID">100</Data>
+        <Data AD_Column_ID="2235" Column="C_Tax_ID">104</Data>
+        <Data AD_Column_ID="69035" Column="CreateShipment">N</Data>
+        <Data AD_Column_ID="68954" Column="CreateFrom">N</Data>
+        <Data AD_Column_ID="2210" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2209" Column="Created">2022-05-10 15:39:59.131</Data>
+        <Data AD_Column_ID="15458" Column="C_ProjectTask_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15457" Column="C_ProjectPhase_ID" isNewNull="true"/>
+        <Data AD_Column_ID="14092" Column="C_Project_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2205" Column="C_OrderLine_ID">50064</Data>
+        <Data AD_Column_ID="2213" Column="C_Order_ID">50055</Data>
+        <Data AD_Column_ID="2230" Column="C_Currency_ID">100</Data>
+        <Data AD_Column_ID="3050" Column="C_Charge_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15847" Column="C_Campaign_ID" isNewNull="true"/>
+        <Data AD_Column_ID="3404" Column="C_BPartner_Location_ID">112</Data>
+        <Data AD_Column_ID="2764" Column="C_BPartner_ID">117</Data>
+        <Data AD_Column_ID="15848" Column="C_Activity_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15861" Column="AD_OrgTrx_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2207" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="2206" Column="AD_Client_ID">11</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="130" StepType="AD">
+      <PO AD_Table_ID="314" Action="I" Record_ID="50055" Table="C_OrderTax">
+        <Data AD_Column_ID="84686" Column="UUID">5b9e97d4-b8d9-44b0-a8ad-05f59ffa2a6b</Data>
+        <Data AD_Column_ID="3354" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="3353" Column="Updated">2022-05-10 15:40:00.357</Data>
+        <Data AD_Column_ID="3766" Column="TaxBaseAmt">96.75</Data>
+        <Data AD_Column_ID="3767" Column="TaxAmt">0</Data>
+        <Data AD_Column_ID="12061" Column="Processed">false</Data>
+        <Data AD_Column_ID="13041" Column="IsTaxIncluded">false</Data>
+        <Data AD_Column_ID="3350" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3356" Column="C_Tax_ID">104</Data>
+        <Data AD_Column_ID="3352" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="3351" Column="Created">2022-05-10 15:40:00.357</Data>
+        <Data AD_Column_ID="3355" Column="C_Order_ID">50055</Data>
+        <Data AD_Column_ID="3349" Column="AD_Org_ID">50001</Data>
+        <Data AD_Column_ID="3348" Column="AD_Client_ID">11</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/migration/393lts-394lts/09480_Add_default_value_to_Discount_Schema_Break.xml
+++ b/migration/393lts-394lts/09480_Add_default_value_to_Discount_Schema_Break.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add default value to Discount Schema Break" ReleaseNo="3.9.4" SeqNo="9480">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="6610" Table="AD_Column">
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">M_Product_Category_ID</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isOldNull="true">-1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="6611" Table="AD_Column">
+        <Data AD_Column_ID="92542" Column="NameOldValue" isOldNull="true">M_Product_ID</Data>
+        <Data AD_Column_ID="92541" Column="RequiresSync" oldValue="false">true</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isOldNull="true">-1</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
This pull request allows define many discounts combinations based on real combination and hierarchy of filters.

Currently the discount schema apply a search based on sequence and it don't have a way for create a combination like **Product** and **Business Partner** directly.

With this change the hierarchy can be defined like the follow:

1. Product
2. Business Partner
3. Product Category
4. Business Partner Group

Now you can define a combination like:

- Product + Business Partner
- Product + Business Partner Group
- Product Category + Business Partner
- Product Category + Business Partner Group
- Product Only
- Product Category Only
- Business Partner Only
- Business Partner Group Only
- Any

It is very useful for retailers customers and is tested with a customer


## Step by step to test it:

- Go to window **"Discount Schema"**
- Note that already exist a discount schema named **"Combined Discount"**
- You can see the follow combination:

Product Category | Product | Break Value | B.Partner Flat Discount | Break Discount %
-- | -- | -- | -- | --
  | PChair_Patio Chair | 0.0 | No | 7.0
Chemicals |   | 0.0 | No | 5.0
  | Mulch_Mulch 10# | 0.0 | No | 10.0

Note that Chemicals category have  the follows products:
Search Key | Name
-- | --
Fertilizer#50 | Fertilizer #50
Fertilizer#70 | Fertilizer #70
Mulch | Mulch 10#


Like you can see the product **Mulch 10#** is part of **Chemicals** and exist a specific discount for him of **10.0 %** however exists other discount applied to **Chemicals** category of **5.0 %**

You can see a example with the order **500** created for **C&W Construction** (Note that C&W Construction have configured the **Combined Discount** on **Customer** tab)

## Formula
The formula used is a standard calculation of discount, you can see a dynamic calculator [here](https://www.omnicalculator.com/finance/percentage-discount)


### Data
 - The base price for discount is **Standar Price**
 - The percentage applied is based on combination getted from Discount Schema

## Result:
- The first line is for **Fertilizer#70** and the discount applied is **5%**
- The second line is for **Mulch10#**, note that this product is inside **Chemicals** category but it have a special discount of **10%**

## Some interest comments
If you see the discount applied on **Sales Order** for **Fertilizer#70** tou can see **10.43** (Ohh this is wrong..... No, remember that the discount is calculated between **Standard Price** and **Unit Price**). The discount calculated in sales order is based on **Price List** and **Unit Price**.

For **Fertilizer #70** has the follows values:
- Price List: **35.00**
- Standard Price: **33.00**
- Price with Discount: **31.35**

A simple calculation of discount is:
```Java
StandardPrice = 33.00
DiscountPercentage = 5

New Price Calculation
-----------------------------------------------
NewPrice = ((100 - DiscountPercentage) / 100) * StandardPrice
NewPrice = ((100 - 5) / 100) * 33.00
NewPrice = 31.35

Discount Amount
-----------------------------------------------
DiscountAmount = StandardPrice - NewPrice
DiscountAmount = 33.00 - 31.35
DiscountAmount = 1.65

Discount Rate based on Sales Order
-----------------------------------------------
DiscountRate = ((PriceList - NewPrice) / PriceList) * 100
DiscountRate = ((35.00 - 31.35) / 35.00) * 100
DiscountRate = ((3.65) / 35.00) * 100
DiscountRate = (0.104285714) * 100
DiscountRate = 10.4285714 ~ 10.43
```

Here exist a XML with the taste: https://github.com/adempiere/adempiere/pull/3852/files#diff-e495c5a1cca88974283598b52fe8d82ba678850b3b1d4a72d64fa174b351ce5c