### PR TITLE
Add Support to Cost Engine Dynamic Load

### DIFF
--- a/base/src/org/adempiere/engine/UserDefinedCostingMethodExample.java
+++ b/base/src/org/adempiere/engine/UserDefinedCostingMethodExample.java
@@ -1,0 +1,121 @@
+/**
+ * 
+ */
+package org.adempiere.engine;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+import org.compiere.model.MAcctSchema;
+import org.compiere.model.MCost;
+import org.compiere.model.MCostDetail;
+import org.compiere.model.MProduct;
+import org.compiere.model.MTransaction;
+import org.compiere.util.Env;
+
+/**
+* @author Carlos Parada, cparada@erpya.com, ERPCyA http://www.erpya.com
+ * 
+ */
+public class UserDefinedCostingMethodExample extends AbstractCostingMethod
+		implements ICostingMethod {
+
+    /**
+     * Constructor for Cost Engine
+     * @param accountSchema
+     * @param transaction
+     * @param model
+     * @param dimension
+     * @param costThisLevel
+     * @param costLowLevel
+     * @param isSalesTransaction
+     */
+	public void setCostingMethod(MAcctSchema accountSchema, MTransaction transaction, IDocumentLine model,
+                                 MCost dimension, BigDecimal costThisLevel,
+                                 BigDecimal costLowLevel, Boolean isSalesTransaction) {
+		this.accountSchema = accountSchema;
+		this.transaction = transaction;
+		this.dimension = dimension;
+		this.costThisLevel = (costThisLevel == null ? Env.ZERO : costThisLevel);
+		this.costLowLevel = (costLowLevel == null ? Env.ZERO : costLowLevel);
+		this.model = model;
+		this.costingLevel = MProduct.get(this.transaction.getCtx(), this.transaction.getM_Product_ID())
+				.getCostingLevel(accountSchema, transaction.getAD_Org_ID());
+		// find if this transaction exist into cost detail
+		this.costDetail = MCostDetail.getByTransaction(this.model, this.transaction,
+				this.accountSchema.getC_AcctSchema_ID(), this.dimension.getM_CostType_ID(),
+				this.dimension.getM_CostElement_ID());
+
+
+        this.movementQuantity = transaction.getMovementQty();
+	}
+
+
+	public MCostDetail process() {	
+		costDetail = new MCostDetail(transaction, accountSchema.getC_AcctSchema_ID(),
+				dimension.getM_CostType_ID(),
+				dimension.getM_CostElement_ID(), Env.ONEHUNDRED.multiply(costThisLevel),
+				Env.ONEHUNDRED.multiply(costThisLevel),
+				movementQuantity, transaction.get_TrxName());
+		costDetail.setDescription("Example User Defined Costing Method");
+		costDetail.setDateAcct(model.getDateAcct());
+		costDetail.saveEx();
+		return costDetail;
+	}
+
+	@Override
+	protected List<CostComponent> getCalculatedCosts() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void updateAmountCost() {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, int roundingMode) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public BigDecimal getNewCurrentCostPrice(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public BigDecimal getNewAccumulatedAmount(MCostDetail cost) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, int roundingMode) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public BigDecimal getNewCurrentCostPriceLowerLevel(MCostDetail cost, int scale, RoundingMode roundingMode) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public BigDecimal getNewAccumulatedAmountLowerLevel(MCostDetail cost) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public BigDecimal getNewAccumulatedQuantity(MCostDetail cost) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/base/src/org/compiere/model/I_M_CostType.java
+++ b/base/src/org/compiere/model/I_M_CostType.java
@@ -3,7 +3,7 @@
  * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
  * This program is free software, you can redistribute it and/or modify it    *
  * under the terms version 2 of the GNU General Public License as published   *
- * or (at your option) any later version.										*
+ * or (at your option) any later version.                                     *
  * by the Free Software Foundation. This program is distributed in the hope   *
  * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
@@ -12,7 +12,8 @@
  * with this program, if not, write to the Free Software Foundation, Inc.,    *
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
  * For the text or an alternative of this public license, you may reach us    *
- * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
  *****************************************************************************/
 package org.compiere.model;
 
@@ -22,7 +23,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for M_CostType
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2
+ *  @version Release 3.9.3
  */
 public interface I_M_CostType 
 {
@@ -61,6 +62,19 @@ public interface I_M_CostType
 	  * Organizational entity within client
 	  */
 	public int getAD_Org_ID();
+
+    /** Column name Classname */
+    public static final String COLUMNNAME_Classname = "Classname";
+
+	/** Set Classname.
+	  * Java Classname
+	  */
+	public void setClassname (String Classname);
+
+	/** Get Classname.
+	  * Java Classname
+	  */
+	public String getClassname();
 
     /** Column name CostingMethod */
     public static final String COLUMNNAME_CostingMethod = "CostingMethod";

--- a/base/src/org/compiere/model/X_M_CostType.java
+++ b/base/src/org/compiere/model/X_M_CostType.java
@@ -3,7 +3,7 @@
  * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
  * This program is free software, you can redistribute it and/or modify it    *
  * under the terms version 2 of the GNU General Public License as published   *
- * or (at your option) any later version.										*
+ * or (at your option) any later version.                                     *
  * by the Free Software Foundation. This program is distributed in the hope   *
  * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
@@ -12,7 +12,8 @@
  * with this program, if not, write to the Free Software Foundation, Inc.,    *
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
  * For the text or an alternative of this public license, you may reach us    *
- * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
  *****************************************************************************/
 /** Generated Model - DO NOT CHANGE */
 package org.compiere.model;
@@ -23,14 +24,14 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Model for M_CostType
  *  @author Adempiere (generated) 
- *  @version Release 3.9.2 - $Id$ */
+ *  @version Release 3.9.3 - $Id$ */
 public class X_M_CostType extends PO implements I_M_CostType, I_Persistent 
 {
 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20191120L;
+	private static final long serialVersionUID = 20220510L;
 
     /** Standard Constructor */
     public X_M_CostType (Properties ctx, int M_CostType_ID, String trxName)
@@ -72,6 +73,23 @@ public class X_M_CostType extends PO implements I_M_CostType, I_Persistent
         .append(get_ID()).append("]");
       return sb.toString();
     }
+
+	/** Set Classname.
+		@param Classname 
+		Java Classname
+	  */
+	public void setClassname (String Classname)
+	{
+		set_Value (COLUMNNAME_Classname, Classname);
+	}
+
+	/** Get Classname.
+		@return Java Classname
+	  */
+	public String getClassname () 
+	{
+		return (String)get_Value(COLUMNNAME_Classname);
+	}
 
 	/** CostingMethod AD_Reference_ID=122 */
 	public static final int COSTINGMETHOD_AD_Reference_ID=122;

--- a/migration/393lts-394lts/09460_Add_ClassNameForCostType.xml
+++ b/migration/393lts-394lts/09460_Add_ClassNameForCostType.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add ClassName for Cost Type" ReleaseNo="3.9.4" SeqNo="9460">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="I" Record_ID="99414" Table="AD_Column">
+        <Data AD_Column_ID="112" Column="Description">Java Classname</Data>
+        <Data AD_Column_ID="548" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90939" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="549" Column="Created">2021-11-04 16:43:44.561</Data>
+        <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="551" Column="Updated">2021-11-04 16:43:44.561</Data>
+        <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="109" Column="AD_Column_ID">99414</Data>
+        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="111" Column="Name">Classname</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="120" Column="IsParent">false</Data>
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
+        <Data AD_Column_ID="6483" Column="IsSyncDatabase">N</Data>
+        <Data AD_Column_ID="119" Column="IsKey">false</Data>
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="56352" Column="FormatPattern" isNewNull="true"/>
+        <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
+        <Data AD_Column_ID="110" Column="Version">0</Data>
+        <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
+        <Data AD_Column_ID="116" Column="ColumnName">Classname</Data>
+        <Data AD_Column_ID="113" Column="Help">The Classname identifies the Java classname used by this report or process.</Data>
+        <Data AD_Column_ID="3360" Column="IsUpdateable">true</Data>
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="11617" Column="IsAlwaysUpdateable">false</Data>
+        <Data AD_Column_ID="128" Column="IsEncrypted">N</Data>
+        <Data AD_Column_ID="54358" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="56187" Column="IsAllowLogging">true</Data>
+        <Data AD_Column_ID="56149" Column="IsAutocomplete">false</Data>
+        <Data AD_Column_ID="68024" Column="IsRange">false</Data>
+        <Data AD_Column_ID="62199" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="127" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="6482" Column="EntityType">D</Data>
+        <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">586</Data>
+        <Data AD_Column_ID="550" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2608" Column="AD_Element_ID">1299</Data>
+        <Data AD_Column_ID="227" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="115" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="118" Column="FieldLength">255</Data>
+        <Data AD_Column_ID="226" Column="AD_Reference_ID">10</Data>
+        <Data AD_Column_ID="552" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="84306" Column="UUID">377ef173-6609-4208-b430-0b1337b281ee</Data>
+        <Data AD_Column_ID="3369" Column="AD_Process_ID" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="752" Action="I" Record_ID="99414" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12960" Column="Created">2021-11-04 16:43:55.06</Data>
+        <Data AD_Column_ID="12959" Column="IsActive">true</Data>
+        <Data AD_Column_ID="12952" Column="Updated">2021-11-04 16:43:55.06</Data>
+        <Data AD_Column_ID="12955" Column="AD_Column_ID">99414</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="12957" Column="Name">Classname</Data>
+        <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="12958" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="12956" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="84310" Column="UUID">7e0d250a-cf8a-4a21-8097-e525ec348cca</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="101798" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">Classname</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Java Classname</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo">0</Data>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help">The Classname identifies the Java classname used by this report or process.</Data>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth">0</Data>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">false</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">101798</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">D</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">80</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">99414</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">80</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">0</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">489</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">4a249979-66b3-4c35-96e8-b38d00f7923e</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2021-11-04 16:44:08.263</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2021-11-04 16:44:08.263</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="101798" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="84323" Column="UUID">771f6211-72d9-43d7-8980-de69b8682116</Data>
+        <Data AD_Column_ID="672" Column="Created">2021-11-04 16:44:10.303</Data>
+        <Data AD_Column_ID="674" Column="Updated">2021-11-04 16:44:10.303</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="287" Column="Description">Java Classname</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="286" Column="Name">Classname</Data>
+        <Data AD_Column_ID="288" Column="Help">The Classname identifies the Java classname used by this report or process.</Data>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">101798</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_MX</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
## Feature

Currently the Cost Engine class support is load statically, with this change in the cost type could be defined the behavior.

### Step by Step for Testing it 

1. Active the User Defined Costing Method for the test.
![1](https://user-images.githubusercontent.com/1847863/167720419-884658ca-1323-4302-8aad-c3e677c75381.png)

2. Create a new Costing Type with Costing Method **User Defined** and class name **org.adempiere.engine.UserDefinedCostingMethodExample**
![2](https://user-images.githubusercontent.com/1847863/167720631-02fa66d6-ba8c-4355-bcf3-44f1c7c74bc2.png)

3. Run the **Generate Cost Transaction** process with the next parameters
![3](https://user-images.githubusercontent.com/1847863/167720964-0fd05ae7-248b-4a01-b0bf-90499dd5a978.png)

4. Go to the Product Cost Window, search the **Azalea Bush** product and see cost detail
![4](https://user-images.githubusercontent.com/1847863/167721424-71ae45e0-d90c-4e4f-9c4e-59874cd51c3f.png)





