### PR TITLE
Add support to get document base type with transaction name

### DIFF
--- a/base/src/org/compiere/model/MDocBaseType.java
+++ b/base/src/org/compiere/model/MDocBaseType.java
@@ -98,11 +98,21 @@ public class MDocBaseType extends X_C_DocBaseType{
 	 * @return
 	 */
 	public static MDocBaseType get(int C_DocBaseType_ID) {
+		return get(C_DocBaseType_ID, null);
+	}
+	
+	/**
+	 * Get Document Base Type by Document Base Type Identifier
+	 * @param C_DocBaseType_ID
+	 * @param trxName
+	 * @return
+	 */
+	public static MDocBaseType get(int C_DocBaseType_ID, String trxName) {
 		MDocBaseType docBaseType = doc_cache.get(C_DocBaseType_ID);
 		
 		if (docBaseType == null) {
 			String whereClause = "C_DocBaseType_ID = ? ";
-			docBaseType = new Query(Env.getCtx(), MDocBaseType.Table_Name, whereClause, null)
+			docBaseType = new Query(Env.getCtx(), MDocBaseType.Table_Name, whereClause, trxName)
 							.setParameters(C_DocBaseType_ID)
 							.first();
 			doc_cache.put(C_DocBaseType_ID, docBaseType);
@@ -116,11 +126,21 @@ public class MDocBaseType extends X_C_DocBaseType{
 	 * @return
 	 */
 	public static MDocBaseType get(String DocBaseType) {
+		return get(DocBaseType, null);
+	}
+	
+	/**
+	 * Get Document Base by Document Base Type Static 
+	 * @param DocBaseType
+	 * @param trxName
+	 * @return
+	 */
+	public static MDocBaseType get(String DocBaseType, String trxName) {
 		MDocBaseType docBaseType = cache.get(DocBaseType);
 		
 		if (docBaseType == null) {
 			String whereClause = "DocBaseType = ? ";
-			docBaseType = new Query(Env.getCtx(), MDocBaseType.Table_Name, whereClause, null)
+			docBaseType = new Query(Env.getCtx(), MDocBaseType.Table_Name, whereClause, trxName)
 							.setParameters(DocBaseType)
 							.setOrderBy("IsDefault DESC")
 							.first();

--- a/base/src/org/compiere/model/MDocType.java
+++ b/base/src/org/compiere/model/MDocType.java
@@ -365,15 +365,17 @@ public class MDocType extends X_C_DocType
 		Optional<MTable> maybeTable= Optional.ofNullable(MTable.get(Env.getCtx(), MDocBaseType.Table_Name)) ;
 		maybeTable.ifPresent(table ->{
 			if (getC_DocBaseType_ID()==0) {
-				Optional<MDocBaseType> maybeDocBaseType = Optional.ofNullable(MDocBaseType.get(getDocBaseType()));
+				Optional<MDocBaseType> maybeDocBaseType = Optional.ofNullable(MDocBaseType.get(getDocBaseType(), get_TrxName()));
 				maybeDocBaseType.ifPresent(docBaseType ->{
 					setC_DocBaseType_ID(docBaseType.get_ID());
 				});
 				
 			}
-			MDocBaseType docBaseType =MDocBaseType.get(getC_DocBaseType_ID());
-			if (!docBaseType.getDocBaseType().equals(getDocBaseType()))
-				valid.set(false);
+			Optional.ofNullable(MDocBaseType.get(getC_DocBaseType_ID(), get_TrxName())).ifPresent(documentBaseType -> {
+				if (!documentBaseType.getDocBaseType().equals(getDocBaseType())) {
+					valid.set(false);
+				}
+			});
 		});
 		return valid.get();
 	}


### PR DESCRIPTION
### This pull request just add two changes:

- Get document base type record with transaction name
- Prevents NPE at validate Document Type if Defined Document Base Type don't exists.