### PR TITLE
feat: Add selection columns in Conversion Rate.

### DIFF
--- a/migration/393lts-394lts/09700_ConversionRate_Selection_Columns.xml
+++ b/migration/393lts-394lts/09700_ConversionRate_Selection_Columns.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Conversion Rate Selection Columns" ReleaseNo="3.9.4" SeqNo="9700">
+    <Comments>Add selection columns to easy search, and same line currency to field in currency window</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="10294" Table="AD_Column">
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="786" Table="AD_Column">
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="787" Table="AD_Column">
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="456" Table="AD_Column">
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="455" Table="AD_Column">
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="453" Table="AD_Column">
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="454" Table="AD_Column">
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn" oldValue="false">true</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="107" Action="U" Record_ID="432" Table="AD_Field">
+        <Data AD_Column_ID="183" Column="IsSameLine" oldValue="false">true</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
They are added as selection columns:
* Currency.
* Currency To.
* Conversion Type.
* Valid From.
* Valid To.
* Divide Rate.
* Multiply Rate.

![conversion-rate-lookup](https://user-images.githubusercontent.com/20288327/172081782-9cd01415-336a-4423-bab5-1f57a207e798.png)

In order to be able to perform a simple search for records, since the option currently available is the advanced search and although it may be more accurate, it is not the most practical.

Before these changes:

https://user-images.githubusercontent.com/20288327/172081103-75e77171-b185-4e62-a70c-c7c4362fa79b.mp4


After these changes:

https://user-images.githubusercontent.com/20288327/172081100-a52a158b-1561-4542-8488-5a725f7c400a.mp4


Additionally, the `Currency To` field is marked as the same line, to have the same visual consistency of the `Conversion Rate` tab in the `Currency` window (left) as in the `Conversion Rate` window (right).

Before this changes:

![conversion-rate-without-same-line](https://user-images.githubusercontent.com/20288327/172082558-8591eaf8-6b57-4b6c-8b63-4e8a645f8ddc.png)

After this changes:

![conversion-rate-same-line](https://user-images.githubusercontent.com/20288327/172082566-dfcb6e38-89bc-43b1-bd02-8a242faefa70.png)

