### PR TITLE
fix: Preview JasperReports on swing client.

### DIFF
--- a/JasperReports/src/org/compiere/report/ReportStarter.java
+++ b/JasperReports/src/org/compiere/report/ReportStarter.java
@@ -637,7 +637,7 @@ public class ReportStarter implements ProcessCall, ClientProcess
                     		prats.add(PrintUtil.getJobPriority(jasperPrint.getPages().size(), numCopies, true));
 
                     		// Create print service exporter
-                        	JRPrintServiceExporter exporter = new JRPrintServiceExporter();;
+                        	JRPrintServiceExporter exporter = new JRPrintServiceExporter();
                         	// Set parameters
                         	exporter.setParameter(JRExporterParameter.JASPER_PRINT, jasperPrint);
                         	exporter.setParameter(JRPrintServiceExporterParameter.PRINT_SERVICE, printerJob.getPrintService());
@@ -657,6 +657,7 @@ public class ReportStarter implements ProcessCall, ClientProcess
 						File PDF = File.createTempFile("mail", ".pdf");
 						JasperExportManager.exportReportToPdfFile(jasperPrint, PDF.getAbsolutePath());
 						processInfo.setPDFReport(PDF);
+						processInfo.setPrintPreview(true);
 						if (processInfo.isPrintPreview()) {
 							log.info("ReportStarter.startProcess run report -" + jasperPrint.getName());
 							JRViewerProvider viewerLauncher = getReportViewerProvider();


### PR DESCRIPTION

Currently the jasper reports are not previewed in the swing user interface, they do not generate any error/warning in the log or in the IDE console, however they work correctly in the Zk user interface.


#### Steps to reproduce
1. Apply `test_jasper_report.xml` migration.
2. Attach `test.jasper` file on report definition.
3. Run `Test` report.


Before this changes:

https://user-images.githubusercontent.com/20288327/175871966-a5b614f9-1c2f-49de-b86e-899bd5cf8adc.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/175871965-61d1db07-0ded-4248-9b54-20917968d628.mp4

#### Additional context

XML migration for Test report application dictionary and jasper report source for attachments:

[test-jasper-report.zip](https://github.com/adempiere/adempiere/files/8989134/test-jasper-report.zip)



