### PR TITLE
Skip executing RUN_DBRestore to avoid importing seed twice

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -77,12 +77,12 @@
   	<exec dir="${env_directory}" executable="/bin/bash" failonerror="true">
     	<arg value="${RUN_ImportAdempiere}"/>
   	</exec>
-  	
+<!-- Skip Restore to avoid importing seed twice
   	<echo message="Run DB Restore Adempiere"/>
 	<exec dir="${env_directory}" executable="/bin/bash" failonerror="true">
     	<arg value="${RUN_DBRestore}"/>
   	</exec>
-  	
+-->
 	<echo message="Run Migrate XML"/>
 	<exec dir="${AD_directory}" executable="/bin/bash" failonerror="true">
     	<arg value="${RUN_MigrateXML}"/>


### PR DESCRIPTION
Fixes https://github.com/adempiere/adempiere/issues/3932

The test would consist of checking out the Action log of _ADempiere Build_ started by this pull request and verifying there that the database is imported only once.

Besides, all other steps (except the installation, which generates a **BUILD FAILED**) should run correctly and the artifacts are generated.