### PR TITLE
Solve "BUILD FAILED" Error running Github Action "ADempiere Build"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,19 @@ jobs:
         with:
             java-version: '11'
             java-package: jdk
+      
+      # Deploy Tomcat-Server
+      - name: Deploy Tomcat ...
+        run: |
+            echo  "Installing Tomcat version 9"
+            cd /opt
+            echo  "Download Tomcat version 9- version 9.0.64"
+            wget https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.64/bin/apache-tomcat-9.0.64.tar.gz
+            echo  "Extract Tomcat version 9"
+            tar -zxvf apache-tomcat-9.0.64.tar.gz
+            echo  "Rename to tomcat"
+            mv apache-tomcat-9.0.64 tomcat
+            echo  "Installing Tomcat version 9 FINISHED"
 
       # Build ADempiere with ant
       - name: Build Adempiere ...


### PR DESCRIPTION
Fixes https://github.com/adempiere/adempiere/issues/3931
Solves `BUILD FAILED` Error running Github Action _ADempiere Build_ (file: _main.yaml_).

The test would consist of checking out the Action log of _ADempiere Build_ started by this pull request and verifying there that the error `BUILD FAILED` disappears.

Besides, all other steps should run correctly and the artifacts should be generated.