### PR TITLE
Correction of Favorites(User) Drag&Drop

### DIFF
--- a/zkwebui/WEB-INF/src/org/adempiere/webui/dashboard/DPFavourites.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/dashboard/DPFavourites.java
@@ -17,6 +17,7 @@ import java.util.Enumeration;
 
 import org.adempiere.exceptions.DBException;
 import org.adempiere.webui.component.ToolBarButton;
+import org.adempiere.webui.panel.MenuPanel;
 import org.adempiere.webui.session.SessionManager;
 import org.adempiere.webui.theme.ITheme;
 import org.adempiere.webui.window.FDialog;
@@ -84,7 +85,7 @@ public class DPFavourites extends DashboardPanel implements EventListener {
 		img.addEventListener(Events.ON_DROP, this);
 		//
         
-        favContent.setDroppable(FAVOURITE_DROPPABLE); 
+		favContent.setDroppable(MenuPanel.MENU_ITEM_DRAGGABLE_TYPE);
         favContent.addEventListener(Events.ON_DROP, this);
 	}
 	


### PR DESCRIPTION
Fixes: https://github.com/adempiere/adempiere/issues/3580

Now the user favorites panel can be filled via Drag/Drop:
![imagen](https://user-images.githubusercontent.com/1789408/177041223-3165e535-2f9e-4904-a6e4-e33c90dbded7.png)


Special thanks and credits go to @bma-robco who gave the hint to this solution.