### PR TITLE
Fix #3968 - POInfo cached sql sintax error

### DIFF
--- a/base/src/org/compiere/model/POInfo.java
+++ b/base/src/org/compiere/model/POInfo.java
@@ -17,6 +17,7 @@
 package org.compiere.model;
 
 import io.vavr.collection.List;
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.util.CCache;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
@@ -53,6 +54,8 @@ import java.util.logging.Level;
  *  @author Michael McKay, mckayERP@gmail.com
  *  		<li><A href="https://github.com/adempiere/adempiere/issues/2428">#2428 Allow changes to AD_Column and AD_Table</a>
  *  		Uses explicit references to column names rather than '*'
+ *  @author Raul Capecce, Openup Solutions http://openupsolutions.com/
+ *  		<li><a href="https://github.com/adempiere/adempiere/issues/3968">#3968 [Bug Report] POInfo cached sql sintax error</a></li>
  */
 public class POInfo implements Serializable
 {
@@ -245,6 +248,8 @@ public class POInfo implements Serializable
 								trxName);
 					}).toList();
 					list.addAll(infoColumns.asJava());
+				}).onFailure(throwable -> {
+					throw new AdempiereException(throwable);
 				});
 		//  convert to array
 		columns = new POInfoColumn[list.size()];
@@ -298,9 +303,6 @@ public class POInfo implements Serializable
 	 */
 	private StringBuffer getPOInfoColumnList(boolean baseLanguage) {
 
-		if (columnListCache != null && columnListCache.length() > 0)
-			return columnListCache;
-		
 		StringBuilder columnList = new StringBuilder("t.TableName, "
 				+ "c.ColumnName, "
 				+ "c.AD_Reference_ID,"

--- a/base/src/org/compiere/model/POInfo.java
+++ b/base/src/org/compiere/model/POInfo.java
@@ -107,6 +107,8 @@ public class POInfo implements Serializable
 	// #2428
 	/** Cache of POInfo Columns     */
 	private static StringBuffer  columnListCache = null;
+	/** Cached of POInfo Translated Columns     */
+	private static StringBuffer translatedColumnListCache = null;
 
 	/**************************************************************************
 	 *  Create Persistent Info
@@ -303,6 +305,16 @@ public class POInfo implements Serializable
 	 */
 	private StringBuffer getPOInfoColumnList(boolean baseLanguage) {
 
+		if (baseLanguage) {
+			if (columnListCache != null && columnListCache.length() > 0) {
+				return columnListCache;
+			}
+		} else {
+			if (translatedColumnListCache != null && translatedColumnListCache.length() > 0) {
+				return translatedColumnListCache;
+			}
+		}
+
 		StringBuilder columnList = new StringBuilder("t.TableName, "
 				+ "c.ColumnName, "
 				+ "c.AD_Reference_ID,"
@@ -404,8 +416,13 @@ public class POInfo implements Serializable
 			conn = null;
 		}
 
-		columnListCache = new StringBuffer().append(columnList).append(extraColumns);
-		return columnListCache;
+		if (baseLanguage) {
+			columnListCache = new StringBuffer().append(columnList).append(extraColumns);
+			return columnListCache;
+		} else {
+			translatedColumnListCache = new StringBuffer().append(columnList).append(extraColumns);
+			return translatedColumnListCache;
+		}
 	}
 	
 	/**
@@ -415,6 +432,7 @@ public class POInfo implements Serializable
 	 */
 	public static void resetPOInfoColumnList() {
 		columnListCache = null;
+		translatedColumnListCache = null;
 	}
 
 	/**


### PR DESCRIPTION
In the same execution, in some cases it takes the base language and in others it doesn't, and since the sql is cached, it throws an sql syntax error because there is a SELECT reference to the cached translation table that in the FROM doesn't this.

Since the getPOInfoColumnList method is called only from one place and since it does not use cache from there, for consistency this line is left uncached.

Fix #3968