### PR TITLE
GitHub Actions: Artifact "adempiere-postgresql-seed" generated with 0 Bytes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,14 +17,17 @@ on:
 jobs:
   # This workflow contains a single job called "build-all"
   build-all:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    # The type of runner that the job will run on. 
+    # For Linux, only ubuntu is supported.
+    # Taking a specific version number to avoid side effects.
+    runs-on: ubuntu-22.04
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres
+        # Ubuntu 22.04 seems to support only Postgres 14.5
+        image: postgres:14.5
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres

--- a/migration/393lts-394lts/09880_3987_SynchronizeEntityType.xml
+++ b/migration/393lts-394lts/09880_3987_SynchronizeEntityType.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Synchronize Entity Type" ReleaseNo="3.9.4" SeqNo="9880">
+  <Migration EntityType="D" Name="Synchronize an Entity Type" ReleaseNo="3.9.4" SeqNo="9880">
     <Comments>https://github.com/adempiere/adempiere/issues/3987</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="284" Action="I" Record_ID="54646" Table="AD_Process">


### PR DESCRIPTION
Fixes  #4006|

GitHub Actions allow only _Ubuntu_ as Linux Server (in Github Actions-lingo: **runner**). It is no allowed to use Debian as a runner.

Thus, it is not possible to test with the (as of now) latest Postgres version (15.0), which runs on _Debian:bullseye-slim_, but on _Ubuntu:22.04_.

PLEASE DO NOT ACCEPT THIS PULL REQUEST!!!
This pull request is just to test the changes needed. When the tests are finished, this pull request will be closed and a new pull request will be created with only the changes needed. It will for example not include a change of an XML file, which is needed for testing reasons to trigger the database seed generation.
