### PR TITLE
GitHub Actions: Artifact "adempiere-postgresql-seed" generated with 0 Bytes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,16 @@ jobs:
   # This workflow contains a single job called "build-all"
   build-all:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    # For Linux, only Ubuntu is supported.
+    # Taking a specific version number to avoid side effects.
+    runs-on: ubuntu-22.04
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres
+        # Ubuntu 22.04 supports only Postgres 14.5
+        image: postgres:14.5
         # Provide the password for postgres
         env:
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Fixes #4006

This pull request makes sure that the GitHub Action generating the seed runs on Ubuntu 22.04 and Postgres 14.5, thus avoiding the bug described in #4006.
The newest Postgres version is as of now 15.0, but it runs only on a Debian image (_bullseye-slim_), which is not possible to instantiate on GitHub Actions because GitHub Actions runners run only on Ubuntu.

This means that although Adempiere may run n Postgres 15.0, the CI/CD test is done on Postgres 14.5.

The correctness of the modifications was tested with the following pull request: https://github.aom/adempiere/adempiere/pull/4007. See the results of GitHub Actions there: https://github.com/adempiere/adempiere/actions/runs/3388914703/jobs/5631431907 .
Image:
![imagen](https://user-images.githubusercontent.com/1789408/199990143-78c4b05b-6246-4593-a341-40cf8bfd7d05.png)


This pull request will not generate a seed; this is why the pull request https://github.aom/adempiere/adempiere/pull/4007 was issued in the first place.