### PR TITLE
Re-number XML Migration Files Previous to 394 Release

### DIFF
--- a/migration/393lts-394lts/05581_3659_Migration_Improvement_adding_indexes.xml
+++ b/migration/393lts-394lts/05581_3659_Migration_Improvement_adding_indexes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Migration Improvement adding indexes #3656" ReleaseNo="3.9.4" SeqNo="5549">
+  <Migration EntityType="D" Name="Migration Improvement adding indexes #3656" ReleaseNo="3.9.4" SeqNo="5581">
     <Comments>https://github.com/adempiere/adempiere/issues/3656</Comments>
     <Step DBType="ALL" Parse="Y" SeqNo="10" StepType="SQL">
       <SQLStatement>CREATE INDEX ad_column_columnname             on ad_column(columnname) ;

--- a/migration/393lts-394lts/05582_0213_AutomaticAndProcessSync.xml
+++ b/migration/393lts-394lts/05582_0213_AutomaticAndProcessSync.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="#213 Automatic&amp;ProcessSyncing" ReleaseNo="3.9.4" SeqNo="5550">
+  <Migration EntityType="D" Name="#213 Automatic&amp;ProcessSyncing" ReleaseNo="3.9.4" SeqNo="5582">
     <Comments>See https://github.com/adempiere/adempiere/issues/213
 and https://github.com/adempiere/adempiere/pull/2078</Comments>
     <Step SeqNo="10" StepType="AD">

--- a/migration/393lts-394lts/05583_2943_FixTheFilterDocTypeAndParaTargetDocType.xml
+++ b/migration/393lts-394lts/05583_2943_FixTheFilterDocTypeAndParaTargetDocType.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="The filter Document Type and Target Document Type" ReleaseNo="3.9.4" SeqNo="5555">
+  <Migration EntityType="D" Name="The filter Document Type and Target Document Type" ReleaseNo="3.9.4" SeqNo="5583">
     <Comments>https://github.com/adempiere/adempiere/issues/2943</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="452" Action="U" Record_ID="54502" Table="AD_TreeNodeMM">

--- a/migration/393lts-394lts/05584_2968_ShowOppositeSignForALineCalculated.xml
+++ b/migration/393lts-394lts/05584_2968_ShowOppositeSignForALineCalculated.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Change sign for calculated line, It is also required, there " ReleaseNo="3.9.4" SeqNo="5560">
+  <Migration EntityType="D" Name="Change sign for calculated line, It is also required, there " ReleaseNo="3.9.4" SeqNo="5584">
     <Comments>https://github.com/adempiere/adempiere/issues/2968</Comments>
     <Step SeqNo="50" StepType="AD">
       <PO AD_Table_ID="107" Action="U" Record_ID="80199" Table="AD_Field">

--- a/migration/393lts-394lts/05585_Add_Clean_Definition_for_Client.xml
+++ b/migration/393lts-394lts/05585_Add_Clean_Definition_for_Client.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add clean definition for delete entities #3011" ReleaseNo="3.9.4" SeqNo="5570">
+  <Migration EntityType="D" Name="Add clean definition for delete entities #3011" ReleaseNo="3.9.4" SeqNo="5585">
     <Comments>See: https://github.com/adempiere/adempiere/pull/3011</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="116" Action="I" Record_ID="54557" Table="AD_Menu">

--- a/migration/393lts-394lts/05586_Add_Attribute_set_instance_search_for_import_inventory.xml
+++ b/migration/393lts-394lts/05586_Add_Attribute_set_instance_search_for_import_inventory.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add Attribute set instance search for import inventory" ReleaseNo="3.9.4" SeqNo="5580">
+  <Migration EntityType="D" Name="Add Attribute set instance search for import inventory" ReleaseNo="3.9.4" SeqNo="5586">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="I" Record_ID="95481" Table="AD_Column">
         <Data AD_Column_ID="110" Column="Version">0</Data>

--- a/migration/393lts-394lts/05587_Add_Support_to_Import_Business_Partner_Bank_Account.xml
+++ b/migration/393lts-394lts/05587_Add_Support_to_Import_Business_Partner_Bank_Account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add Support to Import Business Partner Bank Account" ReleaseNo="3.9.4" SeqNo="5575">
+  <Migration EntityType="D" Name="Add Support to Import Business Partner Bank Account" ReleaseNo="3.9.4" SeqNo="5587">
     <Comments>See https://github.com/adempiere/adempiere/pull/2963</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="I" Record_ID="95536" Table="AD_Column">

--- a/migration/393lts-394lts/05610_Fixed_document_flag_for_tables.xml
+++ b/migration/393lts-394lts/05610_Fixed_document_flag_for_tables.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Fixed document flag for tables" ReleaseNo="3.9.4" SeqNo="5610">
+  <Migration EntityType="D" Name="Fixed document flag for tables" ReleaseNo="3.9.4" SeqNo="5610">
     <Comments>See: https://github.com/adempiere/adempiere/pull/3041</Comments>
     <Step DBType="ALL" Parse="Y" SeqNo="10" StepType="SQL">
       <Comments>Update all tables</Comments>

--- a/migration/393lts-394lts/05710_3046_ProcessToCreateInvoiceFromPaymentAddProduct.xml
+++ b/migration/393lts-394lts/05710_3046_ProcessToCreateInvoiceFromPaymentAddProduct.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Process to Create Invoice from Payment online #3046#3103" ReleaseNo="3.9.4" SeqNo="5701">
+  <Migration EntityType="D" Name="Process to Create Invoice from Payment online #3046#3103" ReleaseNo="3.9.4" SeqNo="5710">
     <Comments>https://github.com/adempiere/adempiere/issues/3046</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="285" Action="I" Record_ID="57665" Table="AD_Process_Para">

--- a/migration/393lts-394lts/05785_Add_supportto_currency_for_Withdrawal.xml
+++ b/migration/393lts-394lts/05785_Add_supportto_currency_for_Withdrawal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add support to currency for Withdrawal" ReleaseNo="3.9.4" SeqNo="5785">
+  <Migration EntityType="D" Name="Add support to POS Withdrawal Currency" ReleaseNo="3.9.4" SeqNo="5785">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="120" Action="U" Record_ID="54045" Table="AD_Menu_Trl">
         <Data AD_Column_ID="248" Column="Description" isOldNull="true">Permite Retiros de Puntos de Venta</Data>

--- a/migration/393lts-394lts/05830_Add_AmazonS3_API_Support.xml
+++ b/migration/393lts-394lts/05830_Add_AmazonS3_API_Support.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add AmazonS3 API support" ReleaseNo="3.9.4" SeqNo="5830">
+  <Migration EntityType="D" Name="Add Amazon S3 API support" ReleaseNo="3.9.4" SeqNo="5830">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54542" Action="I" Record_ID="50012" Table="AD_AppSupport">
         <Data AD_Column_ID="91310" Column="UUID">c5ab522b-0645-4aba-b242-dac5662d36c7</Data>

--- a/migration/393lts-394lts/05860_Add_Role_Copy_From_Window.xml
+++ b/migration/393lts-394lts/05860_Add_Role_Copy_From_Window.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Add Role Copy From Window" ReleaseNo="3.9.4" SeqNo="5860">
+  <Migration EntityType="D" Name="Add Role Copy From Window" ReleaseNo="3.9.4" SeqNo="5860">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="53230" Action="I" Record_ID="50181" Table="AD_View">
         <Data AD_Column_ID="58070" Column="Updated">2020-07-01 22:04:06.529</Data>

--- a/migration/393lts-394lts/05920_Fixed_Return_Quantity_for_Shipment_Details_report.xml
+++ b/migration/393lts-394lts/05920_Fixed_Return_Quantity_for_Shipment_Details_report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Fixed Return Quantity for Shipment Details report" ReleaseNo="3.9.4" SeqNo="5920">
+  <Migration EntityType="D" Name="Fixed Return Quantity for Shipment Details report" ReleaseNo="3.9.4" SeqNo="5920">
     <Step DBType="Postgres" Parse="Y" SeqNo="10" StepType="SQL">
       <SQLStatement>CREATE OR REPLACE VIEW RV_INOUTDETAILS
 (AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, CREATEDBY, 

--- a/migration/393lts-394lts/06200_Fixed_conversion_base_function.xml
+++ b/migration/393lts-394lts/06200_Fixed_conversion_base_function.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Fixed conversion base function" ReleaseNo="3.9.4" SeqNo="6200">
+  <Migration EntityType="D" Name="Fixed conversion base function" ReleaseNo="3.9.4" SeqNo="6200">
     <Step DBType="Postgres" Parse="N" SeqNo="10" StepType="SQL">
       <SQLStatement>create or replace FUNCTION currencyBase
 (

--- a/migration/393lts-394lts/06300_Add_Model_Validator_for_Client.xml
+++ b/migration/393lts-394lts/06300_Add_Model_Validator_for_Client.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add Model Validator for Client" ReleaseNo="3.9.4" SeqNo="6300">
+  <Migration EntityType="D" Name="Add Client Model Validator" ReleaseNo="3.9.4" SeqNo="6300">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="100" Action="U" Record_ID="53014" Table="AD_Table">
         <Data AD_Column_ID="354" Column="AccessLevel" oldValue="4">6</Data>

--- a/migration/393lts-394lts/06450_Fixed_Error_with_Replenish_Browser.xml
+++ b/migration/393lts-394lts/06450_Fixed_Error_with_Replenish_Browser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Fixed Error with Replenish Browser" ReleaseNo="3.9.4" SeqNo="6450">
+  <Migration EntityType="D" Name="Fixed Error with Replenish Browser" ReleaseNo="3.9.4" SeqNo="6450">
   <!--
       /******************************************************************************
       * Product: Adempiere ERP &amp; CRM Smart Business Solution                   *

--- a/migration/393lts-394lts/06460_Add_document_Type_for_bank_Transfer.xml
+++ b/migration/393lts-394lts/06460_Add_document_Type_for_bank_Transfer.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add document Type for Bank Transfer" ReleaseNo="3.9.4" SeqNo="6460">
+  <Migration EntityType="D" Name="Add Bank Transfer Document Type" ReleaseNo="3.9.4" SeqNo="6460">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="285" Action="I" Record_ID="57772" Table="AD_Process_Para">
         <Data AD_Column_ID="2820" Column="Updated">2020-08-12 16:48:59.208</Data>

--- a/migration/393lts-394lts/06480_Add_Smart_Browse_for_Generate_Invoice_from_Order.xml
+++ b/migration/393lts-394lts/06480_Add_Smart_Browse_for_Generate_Invoice_from_Order.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add Smart Browse for Generate Invoice from Order" ReleaseNo="3.9.4" SeqNo="6480">
+  <Migration EntityType="D" Name="Add Smart Browse for Invoice Generation from Order" ReleaseNo="3.9.4" SeqNo="6480">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="53230" Action="I" Record_ID="50192" Table="AD_View">
         <Data AD_Column_ID="58068" Column="IsActive">true</Data>

--- a/migration/393lts-394lts/06495_Add_some_columns_for_Aging_report.xml
+++ b/migration/393lts-394lts/06495_Add_some_columns_for_Aging_report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add some columns for Aging report" ReleaseNo="3.9.4" SeqNo="6495">
+  <Migration EntityType="D" Name="Add columns for Aging report" ReleaseNo="3.9.4" SeqNo="6495">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="276" Action="I" Record_ID="61459" Table="AD_Element">
         <Data AD_Column_ID="2603" Column="Name">Due 15-30</Data>

--- a/migration/393lts-394lts/06497_Increase_Business_Partner_Name_and_Name_2.xml
+++ b/migration/393lts-394lts/06497_Increase_Business_Partner_Name_and_Name_2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Increase Business Partner Name and Name 2" ReleaseNo="3.9.4" SeqNo="6497">
+  <Migration EntityType="D" Name="Increase Lenth of Business Partner Name and Name 2" ReleaseNo="3.9.4" SeqNo="6497">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="U" Record_ID="2902" Table="AD_Column">
         <Data AD_Column_ID="118" Column="FieldLength" oldValue="60">255</Data>

--- a/migration/393lts-394lts/06497_Increase_Business_Partner_Name_and_Name_2.xml
+++ b/migration/393lts-394lts/06497_Increase_Business_Partner_Name_and_Name_2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Increase Lenth of Business Partner Name and Name 2" ReleaseNo="3.9.4" SeqNo="6497">
+  <Migration EntityType="D" Name="Increase Length of Business Partner Name and Name 2" ReleaseNo="3.9.4" SeqNo="6497">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="U" Record_ID="2902" Table="AD_Column">
         <Data AD_Column_ID="118" Column="FieldLength" oldValue="60">255</Data>

--- a/migration/393lts-394lts/06550_Add_Collecting_Agent_Reference_to_Payment.xml
+++ b/migration/393lts-394lts/06550_Add_Collecting_Agent_Reference_to_Payment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Add Collecting Agent Reference to Payment" ReleaseNo="3.9.4" SeqNo="6550">
+  <Migration EntityType="D" Name="Add Collecting Agent Reference to Payment" ReleaseNo="3.9.4" SeqNo="6550">
     <Comments>RV_PAYMENT</Comments>
     <Step SeqNo="7" StepType="AD">
       <PO AD_Table_ID="276" Action="I" Record_ID="61514" Table="AD_Element">

--- a/migration/393lts-394lts/06560_Add_Report_View_for_Cash_waiting_for_Deposit.xml
+++ b/migration/393lts-394lts/06560_Add_Report_View_for_Cash_waiting_for_Deposit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add Report View for Cash waiting for Deposit" ReleaseNo="3.9.4" SeqNo="6560">
+  <Migration EntityType="D" Name="Add Cash Waiting for Deposit Report View" ReleaseNo="3.9.4" SeqNo="6560">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="361" Action="I" Record_ID="53332" Table="AD_ReportView">
         <Data AD_Column_ID="4388" Column="Created">2020-10-29 11:29:41.472</Data>

--- a/migration/393lts-394lts/07000_Add_ID_for_Product_Price.xml
+++ b/migration/393lts-394lts/07000_Add_ID_for_Product_Price.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add ID for Product Price" ReleaseNo="3.9.4" SeqNo="7000">
+  <Migration EntityType="D" Name="Add Product Price ID" ReleaseNo="3.9.4" SeqNo="7000">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="102" Action="I" Record_ID="54252" Table="AD_Reference">
         <Data AD_Column_ID="556" Column="Updated">2020-11-23 09:08:53.117</Data>

--- a/migration/393lts-394lts/07050_Add_Filter_values_for_Price_List_Create.xml
+++ b/migration/393lts-394lts/07050_Add_Filter_values_for_Price_List_Create.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add Filter values for Price List Create" ReleaseNo="3.9.4" SeqNo="7050">
+  <Migration EntityType="D" Name="Add Filter values for Price List Creation" ReleaseNo="3.9.4" SeqNo="7050">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="285" Action="I" Record_ID="58010" Table="AD_Process_Para">
         <Data AD_Column_ID="2820" Column="Updated">2020-11-30 15:35:42.22</Data>

--- a/migration/393lts-394lts/07130_UpdateReplenishView.xml
+++ b/migration/393lts-394lts/07130_UpdateReplenishView.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Fixed Error with Replenish Browser" ReleaseNo="3.9.4" SeqNo="7130">
+  <Migration EntityType="D" Name="Fixed Error with Replenish Browser" ReleaseNo="3.9.4" SeqNo="7130">
     <Step DBType="Postgres" Parse="N" SeqNo="10" StepType="SQL">
       <SQLStatement>CREATE OR REPLACE VIEW RV_M_Replenish AS
 SELECT r.AD_Client_ID, 

--- a/migration/393lts-394lts/07237_Fixed_error_with_Reversal_ID_and_ReversalLine_ID.xml
+++ b/migration/393lts-394lts/07237_Fixed_error_with_Reversal_ID_and_ReversalLine_ID.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Fixed error with Reversal ID and ReversalLine ID" ReleaseNo="3.9.4" SeqNo="7237">
+  <Migration EntityType="D" Name="Fixed error with Reversal ID and ReversalLine ID" ReleaseNo="3.9.4" SeqNo="7237">
     <Step DBType="ALL" Parse="Y" SeqNo="10" StepType="SQL">
       <SQLStatement>UPDATE AD_Column SET IsAllowCopy = 'N' WHERE ColumnName IN('Reversal_ID', 'ReversalLine_ID', 'Processed', 'ProcessedOn', 'Processing', 'Posted', 'DocStatus', 'DocAction');
 UPDATE AD_Field SET IsAllowCopy = 'N' WHERE EXISTS(SELECT 1 FROM AD_Column WHERE AD_Column_ID = AD_Field.AD_Column_ID AND ColumnName IN('Reversal_ID', 'ReversalLine_ID', 'Processed', 'ProcessedOn', 'Processing', 'Posted', 'DocStatus', 'DocAction'));</SQLStatement>

--- a/migration/393lts-394lts/07250_Fixed_translation_for_summary_menu.xml
+++ b/migration/393lts-394lts/07250_Fixed_translation_for_summary_menu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Fixed translation for summary menu" ReleaseNo="3.9.4" SeqNo="7250">
+  <Migration EntityType="D" Name="Fix Summary Menu Translation" ReleaseNo="3.9.4" SeqNo="7250">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="116" Action="U" Record_ID="54269" Table="AD_Menu">
         <Data AD_Column_ID="59134" Column="IsCentrallyMaintained" oldValue="true">false</Data>

--- a/migration/393lts-394lts/07677_Add_grid_Sequence_for_field_customization.xml
+++ b/migration/393lts-394lts/07677_Add_grid_Sequence_for_field_customization.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add grid Sequence for field customization" ReleaseNo="3.9.4" SeqNo="7677">
+  <Migration EntityType="D" Name="Add Field Customization Grid Sequence" ReleaseNo="3.9.4" SeqNo="7677">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="U" Record_ID="92659" Table="AD_Column">
         <Data AD_Column_ID="117" Column="DefaultValue" isOldNull="true">N</Data>

--- a/migration/393lts-394lts/07840_3473_AdddingFieldToWeightAndVolume.xml
+++ b/migration/393lts-394lts/07840_3473_AdddingFieldToWeightAndVolume.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Addding field to calculating Weight and Volume" ReleaseNo="3.9.4" SeqNo="7840">
+  <Migration EntityType="D" Name="Add Field for Weight and Volume Calculation" ReleaseNo="3.9.4" SeqNo="7840">
     <Comments>https://github.com/adempiere/adempiere/issues/3473</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="107" Action="U" Record_ID="79919" Table="AD_Field">

--- a/migration/393lts-394lts/07915_3659_Drop_Index_on_Migration_data.xml
+++ b/migration/393lts-394lts/07915_3659_Drop_Index_on_Migration_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Drop Index on Migration Data" ReleaseNo="3.9.4" SeqNo="7919">
+  <Migration EntityType="D" Name="Drop Index on Migration Data" ReleaseNo="3.9.4" SeqNo="7915">
     <Comments>https://github.com/adempiere/adempiere/issues/3656</Comments>
     <Step DBType="ALL" Parse="Y" SeqNo="10" StepType="SQL">
       <SQLStatement>DROP INDEX ad_migrationdata_IDX01 ;</SQLStatement>

--- a/migration/393lts-394lts/07930_Add_support_to_Class_Group_and_classification.xml
+++ b/migration/393lts-394lts/07930_Add_support_to_Class_Group_and_classification.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add support to Class, Group and classification" ReleaseNo="3.9.4" SeqNo="7930">
+  <Migration EntityType="D" Name="Add support to Class, Group and Classification" ReleaseNo="3.9.4" SeqNo="7930">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
         <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_MX">es_MX</Data>

--- a/migration/393lts-394lts/07940_Add_support_to_Chart_for_PA_Goal.xml
+++ b/migration/393lts-394lts/07940_Add_support_to_Chart_for_PA_Goal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add support to Chart for PA Goal" ReleaseNo="3.9.4" SeqNo="7940">
+  <Migration EntityType="D" Name="Add support to PA Goal Chart" ReleaseNo="3.9.4" SeqNo="7940">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="I" Record_ID="99008" Table="AD_Column">
         <Data AD_Column_ID="112" Column="Description" isNewNull="true"/>

--- a/migration/393lts-394lts/08250_Queue_Add_Queue_Functionality_Entity_Type.xml
+++ b/migration/393lts-394lts/08250_Queue_Add_Queue_Functionality_Entity_Type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add Queue Functionality Entity Type" ReleaseNo="3.9.4" SeqNo="8250">
+  <Migration EntityType="D" Name="Add Queue Functionality Entity Type" ReleaseNo="3.9.4" SeqNo="8250">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="882" Action="I" Record_ID="50115" Table="AD_EntityType">
         <Data AD_Column_ID="15607" Column="Processing">false</Data>

--- a/migration/393lts-394lts/08260_Queue_Add_System_Queue_Functionality.xml
+++ b/migration/393lts-394lts/08260_Queue_Add_System_Queue_Functionality.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add System Queue Functionality" ReleaseNo="3.9.4" SeqNo="8260">
+  <Migration EntityType="D" Name="Add System Queue Functionality" ReleaseNo="3.9.4" SeqNo="8260">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="100" Action="I" Record_ID="54843" Table="AD_Table">
         <Data AD_Column_ID="546" Column="Updated">2021-05-28 11:52:47.454</Data>

--- a/migration/393lts-394lts/08270_Queue_Change_Parameters_type_for_Flush_Queue_Process.xml
+++ b/migration/393lts-394lts/08270_Queue_Change_Parameters_type_for_Flush_Queue_Process.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Change Parameters type for Flush Queue Process" ReleaseNo="3.9.4" SeqNo="8270">
+  <Migration EntityType="D" Name="Change Parameters type for Flush Queue Process" ReleaseNo="3.9.4" SeqNo="8270">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="276" Action="U" Record_ID="61755" Table="AD_Element">
         <Data AD_Column_ID="58588" Column="AD_Reference_ID" oldValue="29">11</Data>

--- a/migration/393lts-394lts/08310_Queue_Add_Test_Queue_Manager.xml
+++ b/migration/393lts-394lts/08310_Queue_Add_Test_Queue_Manager.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add Test Queue Manager" ReleaseNo="3.9.4" SeqNo="8310">
+  <Migration EntityType="D" Name="Add Test Queue Manager" ReleaseNo="3.9.4" SeqNo="8310">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="104" Action="I" Record_ID="55612" Table="AD_Ref_List">
         <Data AD_Column_ID="563" Column="IsActive">true</Data>

--- a/migration/393lts-394lts/08320_Queue_Add_Test_Queue_Manager_Implementation.xml
+++ b/migration/393lts-394lts/08320_Queue_Add_Test_Queue_Manager_Implementation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add Test Queue Manager Implementation" ReleaseNo="3.9.4" SeqNo="8320">
+  <Migration EntityType="D" Name="Add Test Queue Manager Implementation" ReleaseNo="3.9.4" SeqNo="8320">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54843" Action="I" Record_ID="50002" Table="AD_QueueType">
         <Data AD_Column_ID="98903" Column="AD_Client_ID">0</Data>

--- a/migration/393lts-394lts/08330_Queue_Add_Queue_Type_as_Parameter.xml
+++ b/migration/393lts-394lts/08330_Queue_Add_Queue_Type_as_Parameter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add Queue Type as Parameter" ReleaseNo="3.9.4" SeqNo="8330">
+  <Migration EntityType="D" Name="Add Queue Type as Parameter" ReleaseNo="3.9.4" SeqNo="8330">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="285" Action="I" Record_ID="58391" Table="AD_Process_Para">
         <Data AD_Column_ID="2820" Column="Updated">2021-06-01 15:58:50.828</Data>

--- a/migration/393lts-394lts/08340_Queue_Add_Setup_Definition.xml
+++ b/migration/393lts-394lts/08340_Queue_Add_Setup_Definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add Setup Definition" ReleaseNo="3.9.4" SeqNo="8340">
+  <Migration EntityType="D" Name="Add Setup Definition" ReleaseNo="3.9.4" SeqNo="8340">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54786" Action="I" Record_ID="50023" Table="AD_SetupDefinition">
         <Data AD_Column_ID="97366" Column="AD_SetupDefinition_ID">50023</Data>

--- a/migration/393lts-394lts/08770_Queue_Add_Notifier_Entity_Type.xml
+++ b/migration/393lts-394lts/08770_Queue_Add_Notifier_Entity_Type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add Notification Entity Type" ReleaseNo="3.9.4" SeqNo="8770">
+  <Migration EntityType="D" Name="Add Queue Notification Entity Type" ReleaseNo="3.9.4" SeqNo="8770">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="882" Action="I" Record_ID="50116" Table="AD_EntityType">
         <Data AD_Column_ID="15607" Column="Processing">false</Data>

--- a/migration/393lts-394lts/08790_Queue_Add_Notification_Entities.xml
+++ b/migration/393lts-394lts/08790_Queue_Add_Notification_Entities.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add Notification Entities" ReleaseNo="3.9.4" SeqNo="8790">
+  <Migration EntityType="D" Name="Add Queue Notification Entities" ReleaseNo="3.9.4" SeqNo="8790">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="100" Action="I" Record_ID="54845" Table="AD_Table">
         <Data AD_Column_ID="546" Column="Updated">2021-06-01 17:20:40.245</Data>

--- a/migration/393lts-394lts/08800_Queue_Add_Notifier_Implementation.xml
+++ b/migration/393lts-394lts/08800_Queue_Add_Notifier_Implementation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add Notifier Implementation" ReleaseNo="3.9.4" SeqNo="8800">
+  <Migration EntityType="D" Name="Add QueueNotifier Implementation" ReleaseNo="3.9.4" SeqNo="8800">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54843" Action="I" Record_ID="50003" Table="AD_QueueType">
         <Data AD_Column_ID="98902" Column="AD_QueueType_ID">50003</Data>

--- a/migration/393lts-394lts/08810_Queue_Add_Backward_Compatibility.xml
+++ b/migration/393lts-394lts/08810_Queue_Add_Backward_Compatibility.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Queue: Add Backward Compatibility" ReleaseNo="3.9.4" SeqNo="8810">
+  <Migration EntityType="D" Name="Add Queue Backward Compatibility" ReleaseNo="3.9.4" SeqNo="8810">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="104" Action="I" Record_ID="55614" Table="AD_Ref_List">
         <Data AD_Column_ID="563" Column="IsActive">true</Data>

--- a/migration/393lts-394lts/09230_Add_new_Currency_for_Venezuela_Bolivar_Digital.xml
+++ b/migration/393lts-394lts/09230_Add_new_Currency_for_Venezuela_Bolivar_Digital.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add new Currency for Venezuela Bolivar Digital" ReleaseNo="3.9.4" SeqNo="9230">
+  <Migration EntityType="D" Name="Add new Currency for Venezuela: Bolivar Digital" ReleaseNo="3.9.4" SeqNo="9230">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="141" Action="I" Record_ID="50003" Table="C_Currency">
         <Data AD_Column_ID="789" Column="AD_Client_ID">0</Data>

--- a/migration/393lts-394lts/09240_Enlarge_length_for_Description_on_Order_and_Invoice.xml
+++ b/migration/393lts-394lts/09240_Enlarge_length_for_Description_on_Order_and_Invoice.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Enlarge length for Description on Order and Invoice" ReleaseNo="3.9.4" SeqNo="9240">
+  <Migration EntityType="D" Name="Enlarge Description on Order and Invoice" ReleaseNo="3.9.4" SeqNo="9240">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="U" Record_ID="3782" Table="AD_Column">
         <Data AD_Column_ID="118" Column="FieldLength" oldValue="255">16000</Data>

--- a/migration/393lts-394lts/09270_Fix_TheSmartBrowserToGenerateShipment.xml
+++ b/migration/393lts-394lts/09270_Fix_TheSmartBrowserToGenerateShipment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Does not show the Outbound orders picked pending" ReleaseNo="3.9.4" SeqNo="9270">
+  <Migration EntityType="D" Name="Display Outbound  picked pending orders" ReleaseNo="3.9.4" SeqNo="9270">
     <Comments>https://github.com/adempiere/adempiere/issues/3647</Comments>
     <Step DBType="Postgres" Parse="Y" SeqNo="1" StepType="SQL">
       <SQLStatement>DROP VIEW RV_WM_InOutBoundLine;

--- a/migration/393lts-394lts/09300_Add_IsIncludeNotAvailable_parameter_for_generate_Invoice.xml
+++ b/migration/393lts-394lts/09300_Add_IsIncludeNotAvailable_parameter_for_generate_Invoice.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Add IsIncludeNotAvailable parameter for generate Invoice" ReleaseNo="3.9.4" SeqNo="9300">
+  <Migration EntityType="D" Name="Add IsIncludeNotAvailable parameter for generate Invoice" ReleaseNo="3.9.4" SeqNo="9300">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="285" Action="I" Record_ID="58471" Table="AD_Process_Para">
         <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>

--- a/migration/393lts-394lts/09360_Fixed_error_with_product_price_for_product.xml
+++ b/migration/393lts-394lts/09360_Fixed_error_with_product_price_for_product.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Fixed error with product price for product" ReleaseNo="3.9.4" SeqNo="9360">
+  <Migration EntityType="D" Name="Fix Product Price error" ReleaseNo="3.9.4" SeqNo="9360">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="107" Action="I" Record_ID="101444" Table="AD_Field">
         <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>

--- a/migration/393lts-394lts/09370_3737_Add_Tax_functionality_To_The_Requisition.xml
+++ b/migration/393lts-394lts/09370_3737_Add_Tax_functionality_To_The_Requisition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="#3737 Add tax functionality to the requisition" ReleaseNo="3.9.4" SeqNo="9370">
+  <Migration EntityType="D" Name="#3737 Add Requisition Tax Functionality" ReleaseNo="3.9.4" SeqNo="9370">
     <Comments>https://github.com/adempiere/adempiere/issues/3737</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="I" Record_ID="99750" Table="AD_Column">

--- a/migration/393lts-394lts/09375_Add_support_for_Outlook_email_configuration.xml
+++ b/migration/393lts-394lts/09375_Add_support_for_Outlook_email_configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Add support for Outllook email configuration" ReleaseNo="3.9.4" SeqNo="9375">
+  <Migration EntityType="D" Name="Outlook email configuration Support" ReleaseNo="3.9.4" SeqNo="9375">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="104" Action="I" Record_ID="1000000" Table="AD_Ref_List">
         <Data AD_Column_ID="371" Column="AD_Client_ID">0</Data>

--- a/migration/393lts-394lts/09390_3806_AddingNewFieldsLatitudeLongitudeAltitude.xml
+++ b/migration/393lts-394lts/09390_3806_AddingNewFieldsLatitudeLongitudeAltitude.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Adding new fields Latitude and Longitude" ReleaseNo="3.9.4" SeqNo="9390">
+  <Migration EntityType="D" Name="New Fields for Latitude and Longitude" ReleaseNo="3.9.4" SeqNo="9390">
     <Comments>https://github.com/adempiere/adempiere/issues/3806</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="276" Action="I" Record_ID="62023" Table="AD_Element">

--- a/migration/393lts-394lts/09395_3806_AddingLatitudeLongitudeAltitudeToWindow.xml
+++ b/migration/393lts-394lts/09395_3806_AddingLatitudeLongitudeAltitudeToWindow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Adding  Latitude, Longitude and Altitude to Window" ReleaseNo="3.9.4" SeqNo="9395">
+  <Migration EntityType="D" Name="Add  Latitude, Longitude and Altitude to Window" ReleaseNo="3.9.4" SeqNo="9395">
     <Comments>https://github.com/adempiere/adempiere/issues/3806</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="107" Action="I" Record_ID="102143" Table="AD_Field">

--- a/migration/393lts-394lts/09410_Set_default_report_view_to_manufacturing_reports.xml
+++ b/migration/393lts-394lts/09410_Set_default_report_view_to_manufacturing_reports.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Set default report view to manufacturing reports" ReleaseNo="3.9.4" SeqNo="9410">
+  <Migration EntityType="D" Name="Set Manufacturing Report Default Report View" ReleaseNo="3.9.4" SeqNo="9410">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="284" Action="U" Record_ID="53006" Table="AD_Process">
         <Data AD_Column_ID="4374" Column="AD_ReportView_ID" isOldNull="true">53007</Data>

--- a/migration/393lts-394lts/09500_Notification_Add_Message_Type.xml
+++ b/migration/393lts-394lts/09500_Notification_Add_Message_Type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA23" Name="Notification: Add Message Type" ReleaseNo="3.9.4" SeqNo="9500">
+  <Migration EntityType="D" Name="Notification: Add Message Type" ReleaseNo="3.9.4" SeqNo="9500">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="102" Action="I" Record_ID="54280" Table="AD_Reference">
         <Data AD_Column_ID="1180" Column="VFormat" isNewNull="true"/>

--- a/migration/393lts-394lts/09510_Notification_Add_Message_Type_for_WF.xml
+++ b/migration/393lts-394lts/09510_Notification_Add_Message_Type_for_WF.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA23" Name="Notification: Add Message Type for WF" ReleaseNo="3.9.4" SeqNo="9510">
+  <Migration EntityType="D" Name="Notification: Add Message Type for WF" ReleaseNo="3.9.4" SeqNo="9510">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="104" Action="I" Record_ID="55639" Table="AD_Ref_List">
         <Data AD_Column_ID="200" Column="Value">WAP</Data>

--- a/migration/393lts-394lts/09520_Notification_Add_Response_handler_for_Notification.xml
+++ b/migration/393lts-394lts/09520_Notification_Add_Response_handler_for_Notification.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA23" Name="Notification: Add Response handler for Notification" ReleaseNo="3.9.4" SeqNo="9520">
+  <Migration EntityType="D" Name="Notification: Add Response handler for Notification" ReleaseNo="3.9.4" SeqNo="9520">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="100" Action="I" Record_ID="54884" Table="AD_Table">
         <Data AD_Column_ID="84425" Column="UUID">c9509ba4-109a-4608-a91b-d6504304ba43</Data>

--- a/migration/393lts-394lts/09530_Notification_Add_Account_ID_for_Updates.xml
+++ b/migration/393lts-394lts/09530_Notification_Add_Account_ID_for_Updates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA23" Name="Notification: Add Account ID for Updates" ReleaseNo="3.9.4" SeqNo="9530">
+  <Migration EntityType="D" Name="Notification: Add Account ID for Updates" ReleaseNo="3.9.4" SeqNo="9530">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="276" Action="I" Record_ID="61952" Table="AD_Element">
         <Data AD_Column_ID="84316" Column="UUID">064696e5-173e-4391-905d-6120205e5088</Data>

--- a/migration/393lts-394lts/09550_Telegram_Add_Implementation_for_Telegram.xml
+++ b/migration/393lts-394lts/09550_Telegram_Add_Implementation_for_Telegram.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA34" Name="Telegram: Add Implementation for Telegram" ReleaseNo="3.9.4" SeqNo="9550">
+  <Migration EntityType="D" Name="Telegram: Add Implementation for Telegram" ReleaseNo="3.9.4" SeqNo="9550">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54542" Action="I" Record_ID="50020" Table="AD_AppSupport">
         <Data AD_Column_ID="91312" Column="Value">Telegram-Custom-Sender</Data>

--- a/migration/393lts-394lts/09560_Telegram_Add_Setup_for_Telegram_Notifier.xml
+++ b/migration/393lts-394lts/09560_Telegram_Add_Setup_for_Telegram_Notifier.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA34" Name="Telegram: Add Setup for Telegram Notifier" ReleaseNo="3.9.4" SeqNo="9560">
+  <Migration EntityType="D" Name="Telegram: Add Setup for Telegram Notifier" ReleaseNo="3.9.4" SeqNo="9560">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54786" Action="I" Record_ID="50044" Table="AD_SetupDefinition">
         <Data AD_Column_ID="97377" Column="UUID">a720457e-27cb-4dea-b64e-c6f0d5ae6c04</Data>

--- a/migration/393lts-394lts/09570_Telegram_Add_Chat_ID_as_Parameter_for_Registration.xml
+++ b/migration/393lts-394lts/09570_Telegram_Add_Chat_ID_as_Parameter_for_Registration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA34" Name="Telegram: Add Chat ID as Parameter for Registration" ReleaseNo="3.9.4" SeqNo="9570">
+  <Migration EntityType="D" Name="Telegram: Add Chat ID as Parameter for Registration" ReleaseNo="3.9.4" SeqNo="9570">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54544" Action="I" Record_ID="50024" Table="AD_AppSupport_Para">
         <Data AD_Column_ID="91386" Column="UUID">9deb6f5f-7236-4b23-9a1d-67b62b42eca5</Data>

--- a/migration/393lts-394lts/09620_Add_OpenID_Connect_Application_Type.xml
+++ b/migration/393lts-394lts/09620_Add_OpenID_Connect_Application_Type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Add OpenID Connect Application Type" ReleaseNo="3.9.4" SeqNo="9620">
+  <Migration EntityType="D" Name="Add OpenID Connect Application Type" ReleaseNo="3.9.4" SeqNo="9620">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="104" Action="I" Record_ID="55686" Table="AD_Ref_List">
         <Data AD_Column_ID="84390" Column="UUID">b4720f59-77cb-4053-9a28-250cb13f55d6</Data>

--- a/migration/393lts-394lts/09630_Add_User_Authentication_Entity.xml
+++ b/migration/393lts-394lts/09630_Add_User_Authentication_Entity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Add User Authentication Entity" ReleaseNo="3.9.4" SeqNo="9630">
+  <Migration EntityType="D" Name="Add User Authentication Entity" ReleaseNo="3.9.4" SeqNo="9630">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="100" Action="I" Record_ID="54897" Table="AD_Table">
         <Data AD_Column_ID="92544" Column="NameOldValue" isNewNull="true"/>

--- a/migration/393lts-394lts/09640_Add_Application_Support_for_Github_Autentication.xml
+++ b/migration/393lts-394lts/09640_Add_Application_Support_for_Github_Autentication.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Add Application Support for Github Authentication" ReleaseNo="3.9.4" SeqNo="9640">
+  <Migration EntityType="D" Name="Add Application Support for Github Authentication" ReleaseNo="3.9.4" SeqNo="9640">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54542" Action="I" Record_ID="50026" Table="AD_AppSupport">
         <Data AD_Column_ID="91311" Column="AD_AppSupport_ID">50026</Data>

--- a/migration/393lts-394lts/09650_Add_Application_Support_for_Google_Autentication.xml
+++ b/migration/393lts-394lts/09650_Add_Application_Support_for_Google_Autentication.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="ECA02" Name="Add Application Support for Google Authentication" ReleaseNo="3.9.4" SeqNo="9650">
+  <Migration EntityType="D" Name="Add Application Support for Google Authentication" ReleaseNo="3.9.4" SeqNo="9650">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="54542" Action="I" Record_ID="50027" Table="AD_AppSupport">
         <Data AD_Column_ID="91311" Column="AD_AppSupport_ID">50027</Data>

--- a/migration/393lts-394lts/09725_Update_System_Configurator_Dictionary_Centralized_ID.xml
+++ b/migration/393lts-394lts/09725_Update_System_Configurator_Dictionary_Centralized_ID.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Update System Configurator Dictionary Centralized ID" ReleaseNo="3.9.4" SeqNo="9720">
+  <Migration EntityType="D" Name="Update System Configurator Dictionary Centralized ID" ReleaseNo="3.9.4" SeqNo="9725">
     <Comments>See https://github.com/adempiere/adempiere/issues/3910</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="50009" Action="U" Record_ID="50002" Table="AD_SysConfig">

--- a/migration/393lts-394lts/09735_Configure_Centralized_ID_Management_Process.xml
+++ b/migration/393lts-394lts/09735_Configure_Centralized_ID_Management_Process.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Configure Centralized ID Management Process" ReleaseNo="3.9.4" SeqNo="9730">
+  <Migration EntityType="D" Name="Configure Centralized ID Management Process" ReleaseNo="3.9.4" SeqNo="9735">
     <Comments>Add process to Configure Centralized ID Management. See https://github.com/adempiere/adempiere/issues/3910</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="284" Action="I" Record_ID="54621" Table="AD_Process">

--- a/migration/393lts-394lts/09740_3894_Organization_Tax_Exempt.xml
+++ b/migration/393lts-394lts/09740_3894_Organization_Tax_Exempt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="09740_3894_Organization_Tax_Exempt" ReleaseNo="3.9.4" SeqNo="9700">
+  <Migration EntityType="D" Name="09740_3894_Organization_Tax_Exempt" ReleaseNo="3.9.4" SeqNo="9740">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="50009" Action="I" Record_ID="50162" Table="AD_SysConfig">
         <Data AD_Column_ID="50188" Column="AD_Client_ID">0</Data>

--- a/migration/393lts-394lts/09745_3925_Adding_Reconciled_To_Window_Payment.xml
+++ b/migration/393lts-394lts/09745_3925_Adding_Reconciled_To_Window_Payment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="[Feature Request] Adding Reconciled to Window Payment #3925 " ReleaseNo="3.9.4" SeqNo="9740">
+  <Migration EntityType="D" Name="Add Reconciled to Window Payment #3925 " ReleaseNo="3.9.4" SeqNo="9745">
     <Comments>https://github.com/adempiere/adempiere/issues/3925</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="107" Action="U" Record_ID="99663" Table="AD_Field">

--- a/migration/393lts-394lts/09750_Change_Entity_Type_for_Distribution_Process.xml
+++ b/migration/393lts-394lts/09750_Change_Entity_Type_for_Distribution_Process.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Change Entity Type for Distribution Process" ReleaseNo="3.9.4" SeqNo="9740">
+  <Migration EntityType="D" Name="Change Entity Type for Distribution Process" ReleaseNo="3.9.4" SeqNo="9750">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="284" Action="U" Record_ID="53735" Table="AD_Process">
         <Data AD_Column_ID="6485" Column="EntityType" oldValue="EE01">EE12</Data>

--- a/migration/393lts-394lts/09775_Change_model_package_for_WMS.xml
+++ b/migration/393lts-394lts/09775_Change_model_package_for_WMS.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="EE03" Name="Change model package for WMS" ReleaseNo="3.9.4" SeqNo="9770">
+  <Migration EntityType="D" Name="Change model package for WMS" ReleaseNo="3.9.4" SeqNo="9775">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="882" Action="U" Record_ID="50007" Table="AD_EntityType">
         <Data AD_Column_ID="15605" Column="ModelPackage" oldValue="org.eevolution.model">org.eevolution.wms.model</Data>

--- a/migration/393lts-394lts/09780_Rename_package_for_WMS_processes.xml
+++ b/migration/393lts-394lts/09780_Rename_package_for_WMS_processes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="EE03" Name="Rename package for WMS processes" ReleaseNo="3.9.4" SeqNo="9780">
+  <Migration EntityType="D" Name="Rename package for WMS processes" ReleaseNo="3.9.4" SeqNo="9780">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="284" Action="U" Record_ID="53186" Table="AD_Process">
         <Data AD_Column_ID="78843" Column="GenerateClass" isOldNull="true">N</Data>

--- a/migration/393lts-394lts/09800_Rename_Fixed_Asset_Packages.xml
+++ b/migration/393lts-394lts/09800_Rename_Fixed_Asset_Packages.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="FA" Name="Rename Fixed Asset Packages" ReleaseNo="3.9.4" SeqNo="9800">
+  <Migration EntityType="D" Name="Rename Fixed Asset Packages" ReleaseNo="3.9.4" SeqNo="9800">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="U" Record_ID="59255" Table="AD_Column">
         <Data AD_Column_ID="6482" Column="EntityType" oldValue="D">FA</Data>

--- a/migration/393lts-394lts/09805_Rename_Fixed_Asset_Packages.xml
+++ b/migration/393lts-394lts/09805_Rename_Fixed_Asset_Packages.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Rename Fixed Asset Packages" ReleaseNo="3.9.4" SeqNo="9805">
+  <Migration EntityType="D" Name="Rename Fixed Asset Packages 1" ReleaseNo="3.9.4" SeqNo="9805">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="U" Record_ID="55954" Table="AD_Column">
         <Data AD_Column_ID="1692" Column="Callout" oldValue="org.compiere.FA.model.CalloutAsset.asset">org.compiere.asset.controller.CalloutAsset.asset</Data>

--- a/migration/393lts-394lts/09806_Rename_Fixed_Asset_Packages.xml
+++ b/migration/393lts-394lts/09806_Rename_Fixed_Asset_Packages.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Rename Fixed Asset Packages" ReleaseNo="3.9.4" SeqNo="9806">
+  <Migration EntityType="D" Name="Rename Fixed Asset Packages 2" ReleaseNo="3.9.4" SeqNo="9806">
     <Step SeqNo="30" StepType="AD">
       <PO AD_Table_ID="284" Action="U" Record_ID="200000" Table="AD_Process">
         <Data AD_Column_ID="4656" Column="Classname" oldValue="org.compiere.FA.process.ProjectCreateAsset">org.compiere.asset.process.ProjectCreateAsset</Data>

--- a/migration/393lts-394lts/09820_Rename_package_name_of_Production.xml
+++ b/migration/393lts-394lts/09820_Rename_package_name_of_Production.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="PR" Name="Rename package name of Production" ReleaseNo="3.9.4" SeqNo="9820">
+  <Migration EntityType="D" Name="Rename package name of Production" ReleaseNo="3.9.4" SeqNo="9820">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="101" Action="U" Record_ID="76532" Table="AD_Column">
         <Data AD_Column_ID="6482" Column="EntityType" oldValue="D">PR</Data>

--- a/migration/393lts-394lts/09830_Change_package_name_for_distribution_and_entity_type.xml
+++ b/migration/393lts-394lts/09830_Change_package_name_for_distribution_and_entity_type.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Change package name for distribution and entity type" ReleaseNo="3.9.4" SeqNo="9830">
+  <Migration EntityType="D" Name="Change package name for Distribution and Entity Type" ReleaseNo="3.9.4" SeqNo="9830">
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="284" Action="U" Record_ID="53955" Table="AD_Process">
         <Data AD_Column_ID="6485" Column="EntityType" oldValue="EE03">EE12</Data>

--- a/migration/393lts-394lts/09855_3985_Adding_URL_Map_To_A_Location_ Map.xml
+++ b/migration/393lts-394lts/09855_3985_Adding_URL_Map_To_A_Location_ Map.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Adding URL Map to a location map" ReleaseNo="3.9.4" SeqNo="9855">
+  <Migration EntityType="D" Name="Add URL to a Location Map" ReleaseNo="3.9.4" SeqNo="9855">
     <Comments>https://github.com/adempiere/adempiere/issues/3985</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="276" Action="I" Record_ID="62075" Table="AD_Element">

--- a/migration/393lts-394lts/09855_3985_Adding_URL_Map_To_A_Location_ Map.xml
+++ b/migration/393lts-394lts/09855_3985_Adding_URL_Map_To_A_Location_ Map.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <Migrations>
-  <Migration EntityType="D" Name="Adding URL Map to a location map" ReleaseNo="3.9.4" SeqNo="9850">
+  <Migration EntityType="D" Name="Adding URL Map to a location map" ReleaseNo="3.9.4" SeqNo="9855">
     <Comments>https://github.com/adempiere/adempiere/issues/3985</Comments>
     <Step SeqNo="10" StepType="AD">
       <PO AD_Table_ID="276" Action="I" Record_ID="62075" Table="AD_Element">


### PR DESCRIPTION
Implements #4018 

Previous to the next 3.9.4 release, it is necessary that the XML migration files get individual sequence numbering.