### PR TITLE
#4048 [Bug Report] Lock transaction when try complete a payment using…

### DIFF
--- a/base/src/org/compiere/model/MFactAcct.java
+++ b/base/src/org/compiere/model/MFactAcct.java
@@ -131,7 +131,7 @@ public class MFactAcct extends X_Fact_Acct
 			getC_LocFrom_ID(), getC_LocTo_ID(), getC_SalesRegion_ID(), 
 			getC_Project_ID(), getC_Campaign_ID(), getC_Activity_ID(),
 			getUser1_ID(), getUser2_ID(), getUser3_ID() , getUser4_ID(),
-			getUserElement1_ID(), getUserElement2_ID(), null);
+			getUserElement1_ID(), getUserElement2_ID(), get_TrxName());
 		if (acct != null && acct.get_ID() == 0)
 			acct.saveEx();
 		return acct;

--- a/base/src/org/compiere/process/DocumentEngine.java
+++ b/base/src/org/compiere/process/DocumentEngine.java
@@ -55,6 +55,7 @@ import org.compiere.model.MRequisition;
 import org.compiere.model.MRole;
 import org.compiere.model.MTable;
 import org.compiere.model.PO;
+import org.compiere.util.AdempiereUserError;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
@@ -1464,7 +1465,7 @@ public class DocumentEngine implements DocAction
         String error = null;
         if (MClient.isClientAccounting()) {
             getLogger().info ("Table=" + tableName + ", Record=" + recordId);
-            MAcctSchema[] ass = MAcctSchema.getClientAcctSchema(ctx, clientId);
+            MAcctSchema[] ass = MAcctSchema.getClientAcctSchema(ctx, clientId, trxName);
             Doc doc = getDoc(ass, tableName, recordId, trxName);
 			if (doc != null) {
 				error = doc.postImmediate(force);
@@ -1545,7 +1546,7 @@ public class DocumentEngine implements DocAction
      *  @param rs ResultSet
      *  @param trxName transaction name
      *  @return Document
-     * @throws AdempiereUserError 
+     * @throws AdempiereUserError
      */
     public Doc getDoc (MAcctSchema[] acctSchemas, String tableName, ResultSet rs, String trxName) {
         return Doc.get(acctSchemas, tableName, rs, trxName);


### PR DESCRIPTION
… Workflow https://github.com/adempiere/adempiere/issues/4048

fixed #4048

- The error was caused when a new accounting combination was created but a null transaction was used, when the document transaction should be used
- The method to bring the accounting schemes with the transaction of the document to be posted was changed
- A new function was created to make the code more readable and validate if a transaction was created by the Workflow machine or comes from a process