### PR TITLE
set java-version: '17' to check the effect

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         with:
             # For available options: see https://github.com/actions/setup-java#supported-distributions
             distribution: 'temurin'
-            java-version: '11.0'
+            java-version: '17'
             
       # Deploy Tomcat-Server 
       - name: Deploy Tomcat ...


### PR DESCRIPTION
Hi @marcalwestf 

in my env: WIN10 + `temurin 17` I cannot build ADempiere with

`javac target="11"` in build.xml

This PR is a test what happens on ubuntu-latest with temurin 17

regards EUGen