### PR TITLE
Add Embedded objects for replication

### DIFF
--- a/base/src/org/adempiere/core/domains/models/I_EXP_FormatLine.java
+++ b/base/src/org/adempiere/core/domains/models/I_EXP_FormatLine.java
@@ -3,7 +3,7 @@
  * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
  * This program is free software, you can redistribute it and/or modify it    *
  * under the terms version 2 of the GNU General Public License as published   *
- * or (at your option) any later version.                                     *
+ * or (at your option) any later version.										*
  * by the Free Software Foundation. This program is distributed in the hope   *
  * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
@@ -12,19 +12,19 @@
  * with this program, if not, write to the Free Software Foundation, Inc.,    *
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
  * For the text or an alternative of this public license, you may reach us    *
- * or via info@adempiere.net                                                  *
- * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
  *****************************************************************************/
 package org.adempiere.core.domains.models;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+
 import org.compiere.model.MTable;
 import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for EXP_FormatLine
  *  @author Adempiere (generated) 
- *  @version Release 3.9.4
+ *  @version Release 3.9.3
  */
 public interface I_EXP_FormatLine 
 {
@@ -227,6 +227,19 @@ public interface I_EXP_FormatLine
 
 	/** Get Is Part Unique Index	  */
 	public boolean isPartUniqueIndex();
+
+    /** Column name IsSaveAfterProcess */
+    public static final String COLUMNNAME_IsSaveAfterProcess = "IsSaveAfterProcess";
+
+	/** Set Save After Process.
+	  * Allows to validate yes save after processing
+	  */
+	public void setIsSaveAfterProcess (boolean IsSaveAfterProcess);
+
+	/** Get Save After Process.
+	  * Allows to validate yes save after processing
+	  */
+	public boolean isSaveAfterProcess();
 
     /** Column name Name */
     public static final String COLUMNNAME_Name = "Name";

--- a/base/src/org/adempiere/core/domains/models/X_EXP_FormatLine.java
+++ b/base/src/org/adempiere/core/domains/models/X_EXP_FormatLine.java
@@ -3,7 +3,7 @@
  * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
  * This program is free software, you can redistribute it and/or modify it    *
  * under the terms version 2 of the GNU General Public License as published   *
- * or (at your option) any later version.                                     *
+ * or (at your option) any later version.										*
  * by the Free Software Foundation. This program is distributed in the hope   *
  * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
@@ -12,14 +12,14 @@
  * with this program, if not, write to the Free Software Foundation, Inc.,    *
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
  * For the text or an alternative of this public license, you may reach us    *
- * or via info@adempiere.net                                                  *
- * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
  *****************************************************************************/
 /** Generated Model - DO NOT CHANGE */
 package org.adempiere.core.domains.models;
 
 import java.sql.ResultSet;
 import java.util.Properties;
+
 import org.compiere.model.I_Persistent;
 import org.compiere.model.MTable;
 import org.compiere.model.PO;
@@ -27,14 +27,14 @@ import org.compiere.model.POInfo;
 
 /** Generated Model for EXP_FormatLine
  *  @author Adempiere (generated) 
- *  @version Release 3.9.4 - $Id$ */
+ *  @version Release 3.9.3 - $Id$ */
 public class X_EXP_FormatLine extends PO implements I_EXP_FormatLine, I_Persistent 
 {
 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20230102L;
+	private static final long serialVersionUID = 20210602L;
 
     /** Standard Constructor */
     public X_EXP_FormatLine (Properties ctx, int EXP_FormatLine_ID, String trxName)
@@ -312,6 +312,30 @@ public class X_EXP_FormatLine extends PO implements I_EXP_FormatLine, I_Persiste
 	public boolean isPartUniqueIndex () 
 	{
 		Object oo = get_Value(COLUMNNAME_IsPartUniqueIndex);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Save After Process.
+		@param IsSaveAfterProcess 
+		Allows to validate yes save after processing
+	  */
+	public void setIsSaveAfterProcess (boolean IsSaveAfterProcess)
+	{
+		set_Value (COLUMNNAME_IsSaveAfterProcess, Boolean.valueOf(IsSaveAfterProcess));
+	}
+
+	/** Get Save After Process.
+		@return Allows to validate yes save after processing
+	  */
+	public boolean isSaveAfterProcess () 
+	{
+		Object oo = get_Value(COLUMNNAME_IsSaveAfterProcess);
 		if (oo != null) 
 		{
 			 if (oo instanceof Boolean) 

--- a/migration/394lts-395lts/09910_Add_column_to_EXP_FormatLine.xml
+++ b/migration/394lts-395lts/09910_Add_column_to_EXP_FormatLine.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add column to EXP_FormatLine" ReleaseNo="" SeqNo="9910">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="276" Action="I" Record_ID="61751" Table="AD_Element">
+        <Data AD_Column_ID="2600" Column="Updated">2021-05-26 15:15:41.798</Data>
+        <Data AD_Column_ID="2597" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2603" Column="Name">Save After Process</Data>
+        <Data AD_Column_ID="2604" Column="Description">Allows to validate yes save after processing</Data>
+        <Data AD_Column_ID="2598" Column="Created">2021-05-26 15:15:41.798</Data>
+        <Data AD_Column_ID="2602" Column="ColumnName">IsSaveAfterProcess</Data>
+        <Data AD_Column_ID="2605" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="6284" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="6285" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="4299" Column="PrintName">Save After Process</Data>
+        <Data AD_Column_ID="6286" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="6283" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="58589" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="58588" Column="AD_Reference_ID">20</Data>
+        <Data AD_Column_ID="2594" Column="AD_Element_ID">61751</Data>
+        <Data AD_Column_ID="2596" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2595" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="6484" Column="EntityType">ECA01</Data>
+        <Data AD_Column_ID="2599" Column="CreatedBy">1000019</Data>
+        <Data AD_Column_ID="58590" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2601" Column="UpdatedBy">1000019</Data>
+        <Data AD_Column_ID="84316" Column="UUID">217bbd12-e10b-49df-859b-d576647b062b</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="277" Action="I" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2642" Column="Created">2021-05-26 15:32:21.567</Data>
+        <Data AD_Column_ID="6449" Column="PO_Help" isNewNull="true"/>
+        <Data AD_Column_ID="2641" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2644" Column="Updated">2021-05-26 15:32:21.567</Data>
+        <Data AD_Column_ID="2638" Column="AD_Language">es_VE</Data>
+        <Data AD_Column_ID="6450" Column="PO_Name" isNewNull="true"/>
+        <Data AD_Column_ID="2648" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="2646" Column="Name">Save After Process</Data>
+        <Data AD_Column_ID="6451" Column="PO_PrintName" isNewNull="true"/>
+        <Data AD_Column_ID="2647" Column="Description">Allows to validate yes save after processing</Data>
+        <Data AD_Column_ID="2649" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="4300" Column="PrintName">Save After Process</Data>
+        <Data AD_Column_ID="6448" Column="PO_Description" isNewNull="true"/>
+        <Data AD_Column_ID="2640" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2639" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="2645" Column="UpdatedBy">1000019</Data>
+        <Data AD_Column_ID="2643" Column="CreatedBy">1000019</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID">61751</Data>
+        <Data AD_Column_ID="84317" Column="UUID">889dd881-b59d-4813-a180-2ba84dfd47c1</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="277" Action="U" Record_ID="0" Table="AD_Element_Trl">
+        <Data AD_Column_ID="2638" Column="AD_Language" oldValue="es_VE">es_VE</Data>
+        <Data AD_Column_ID="2646" Column="Name" oldValue="Save After Process">Guardar Despues de Procesar</Data>
+        <Data AD_Column_ID="2647" Column="Description" isNewNull="true" oldValue="Allows to validate yes save after processing"/>
+        <Data AD_Column_ID="4300" Column="PrintName" oldValue="Save After Process">Guardar Despues de Procesar</Data>
+        <Data AD_Column_ID="2637" Column="AD_Element_ID" oldValue="61751">61751</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="101" Action="I" Record_ID="98901" Table="AD_Column">
+        <Data AD_Column_ID="112" Column="Description">Allows to validate yes save after processing</Data>
+        <Data AD_Column_ID="548" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90939" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="549" Column="Created">2021-05-27 10:27:15.3</Data>
+        <Data AD_Column_ID="3388" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="551" Column="Updated">2021-05-27 10:27:15.3</Data>
+        <Data AD_Column_ID="3389" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="109" Column="AD_Column_ID">98901</Data>
+        <Data AD_Column_ID="126" Column="IsIdentifier">false</Data>
+        <Data AD_Column_ID="111" Column="Name">Save After Process</Data>
+        <Data AD_Column_ID="124" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="125" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="117" Column="DefaultValue">N</Data>
+        <Data AD_Column_ID="1179" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="120" Column="IsParent">false</Data>
+        <Data AD_Column_ID="6244" Column="IsSelectionColumn">false</Data>
+        <Data AD_Column_ID="119" Column="IsKey">false</Data>
+        <Data AD_Column_ID="6483" Column="IsSyncDatabase">N</Data>
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="56352" Column="FormatPattern" isNewNull="true"/>
+        <Data AD_Column_ID="50218" Column="MandatoryLogic" isNewNull="true"/>
+        <Data AD_Column_ID="110" Column="Version">0</Data>
+        <Data AD_Column_ID="13448" Column="ColumnSQL" isNewNull="true"/>
+        <Data AD_Column_ID="116" Column="ColumnName">IsSaveAfterProcess</Data>
+        <Data AD_Column_ID="113" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="3360" Column="IsUpdateable">true</Data>
+        <Data AD_Column_ID="1692" Column="Callout" isNewNull="true"/>
+        <Data AD_Column_ID="11617" Column="IsAlwaysUpdateable">false</Data>
+        <Data AD_Column_ID="128" Column="IsEncrypted">N</Data>
+        <Data AD_Column_ID="54358" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="56187" Column="IsAllowLogging">true</Data>
+        <Data AD_Column_ID="56149" Column="IsAutocomplete">false</Data>
+        <Data AD_Column_ID="68024" Column="IsRange">false</Data>
+        <Data AD_Column_ID="62199" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="127" Column="SeqNo">0</Data>
+        <Data AD_Column_ID="6482" Column="EntityType">EE05</Data>
+        <Data AD_Column_ID="359" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="360" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="59702" Column="AD_Chart_ID" isNewNull="true"/>
+        <Data AD_Column_ID="114" Column="AD_Table_ID">53073</Data>
+        <Data AD_Column_ID="550" Column="CreatedBy">1000019</Data>
+        <Data AD_Column_ID="2608" Column="AD_Element_ID">61751</Data>
+        <Data AD_Column_ID="227" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="115" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="118" Column="FieldLength">1</Data>
+        <Data AD_Column_ID="226" Column="AD_Reference_ID">20</Data>
+        <Data AD_Column_ID="552" Column="UpdatedBy">1000019</Data>
+        <Data AD_Column_ID="84306" Column="UUID">9b3199fb-f3bf-4c14-88af-070b6faf44d2</Data>
+        <Data AD_Column_ID="3369" Column="AD_Process_ID" isNewNull="true"/>
+        <Data AD_Column_ID="92541" Column="RequiresSync">true</Data>
+        <Data AD_Column_ID="92542" Column="NameOldValue" isNewNull="true"/>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="752" Action="I" Record_ID="98901" Table="AD_Column_Trl">
+        <Data AD_Column_ID="12960" Column="Created">2021-05-27 10:27:23.456</Data>
+        <Data AD_Column_ID="12959" Column="IsActive">true</Data>
+        <Data AD_Column_ID="12952" Column="Updated">2021-05-27 10:27:23.456</Data>
+        <Data AD_Column_ID="12955" Column="AD_Column_ID">98901</Data>
+        <Data AD_Column_ID="12954" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="12957" Column="Name">Save After Process</Data>
+        <Data AD_Column_ID="12961" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="12951" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="12958" Column="UpdatedBy">1000019</Data>
+        <Data AD_Column_ID="12953" Column="AD_Language">es_VE</Data>
+        <Data AD_Column_ID="12956" Column="CreatedBy">1000019</Data>
+        <Data AD_Column_ID="84310" Column="UUID">a1bf5527-ed72-40e8-8fe5-34510c484bd5</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="107" Action="I" Record_ID="101203" Table="AD_Field">
+        <Data AD_Column_ID="168" Column="Name">Save After Process</Data>
+        <Data AD_Column_ID="2007" Column="IsReadOnly">false</Data>
+        <Data AD_Column_ID="579" Column="Created">2021-05-27 10:33:44.305</Data>
+        <Data AD_Column_ID="78493" Column="IsQuickEntry">false</Data>
+        <Data AD_Column_ID="88877" Column="AD_FieldDefinition_ID" isNewNull="true"/>
+        <Data AD_Column_ID="581" Column="Updated">2021-05-27 10:33:44.305</Data>
+        <Data AD_Column_ID="88918" Column="AD_ContextInfo_ID" isNewNull="true"/>
+        <Data AD_Column_ID="578" Column="IsActive">true</Data>
+        <Data AD_Column_ID="90940" Column="AD_Image_ID" isNewNull="true"/>
+        <Data AD_Column_ID="59703" Column="IsEmbedded">false</Data>
+        <Data AD_Column_ID="74868" Column="IsAllowCopy">true</Data>
+        <Data AD_Column_ID="169" Column="Description">Allows to validate yes save after processing</Data>
+        <Data AD_Column_ID="176" Column="IsDisplayed">true</Data>
+        <Data AD_Column_ID="185" Column="IsFieldOnly">false</Data>
+        <Data AD_Column_ID="182" Column="SortNo">0</Data>
+        <Data AD_Column_ID="2745" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="170" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="54359" Column="InfoFactoryClass" isNewNull="true"/>
+        <Data AD_Column_ID="177" Column="DisplayLogic">@EXP_EmbeddedFormat_ID@&gt;0</Data>
+        <Data AD_Column_ID="15011" Column="AD_Reference_ID" isNewNull="true"/>
+        <Data AD_Column_ID="15013" Column="IsMandatory" isNewNull="true"/>
+        <Data AD_Column_ID="59704" Column="PreferredWidth">0</Data>
+        <Data AD_Column_ID="62478" Column="IsDisplayedGrid">true</Data>
+        <Data AD_Column_ID="183" Column="IsSameLine">true</Data>
+        <Data AD_Column_ID="184" Column="IsHeading">false</Data>
+        <Data AD_Column_ID="9969" Column="ObscureType" isNewNull="true"/>
+        <Data AD_Column_ID="53265" Column="DefaultValue" isNewNull="true"/>
+        <Data AD_Column_ID="57957" Column="Included_Tab_ID" isNewNull="true"/>
+        <Data AD_Column_ID="186" Column="IsEncrypted">false</Data>
+        <Data AD_Column_ID="384" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="383" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="167" Column="AD_Field_ID">101203</Data>
+        <Data AD_Column_ID="7714" Column="EntityType">ECA01</Data>
+        <Data AD_Column_ID="582" Column="UpdatedBy">1000019</Data>
+        <Data AD_Column_ID="580" Column="CreatedBy">1000019</Data>
+        <Data AD_Column_ID="181" Column="SeqNo">180</Data>
+        <Data AD_Column_ID="5375" Column="AD_FieldGroup_ID" isNewNull="true"/>
+        <Data AD_Column_ID="174" Column="AD_Column_ID">98901</Data>
+        <Data AD_Column_ID="54356" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="62479" Column="SeqNoGrid">180</Data>
+        <Data AD_Column_ID="180" Column="DisplayLength">0</Data>
+        <Data AD_Column_ID="172" Column="AD_Tab_ID">53086</Data>
+        <Data AD_Column_ID="54357" Column="AD_Val_Rule_ID" isNewNull="true"/>
+        <Data AD_Column_ID="84320" Column="UUID">31dc3d83-c858-42dc-b29b-e76de789abb7</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="127" Action="I" Record_ID="101203" Table="AD_Field_Trl">
+        <Data AD_Column_ID="671" Column="IsActive">true</Data>
+        <Data AD_Column_ID="672" Column="Created">2021-05-27 10:33:52.052</Data>
+        <Data AD_Column_ID="674" Column="Updated">2021-05-27 10:33:52.052</Data>
+        <Data AD_Column_ID="1205" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="289" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="287" Column="Description">Allows to validate yes save after processing</Data>
+        <Data AD_Column_ID="286" Column="Name">Save After Process</Data>
+        <Data AD_Column_ID="288" Column="Help" isNewNull="true"/>
+        <Data AD_Column_ID="1204" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="284" Column="AD_Field_ID">101203</Data>
+        <Data AD_Column_ID="673" Column="CreatedBy">1000019</Data>
+        <Data AD_Column_ID="675" Column="UpdatedBy">1000019</Data>
+        <Data AD_Column_ID="285" Column="AD_Language">es_VE</Data>
+        <Data AD_Column_ID="84323" Column="UUID">99c4b4ad-d971-4cc5-a0b3-bf0eed8cb8d6</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
This pull request add support to embedded object insidereplication wrapper, the previous release was generated without this functionalidy.

With this pull request is supported objects like:

```Json

{
    "C_Order": {
        "uuid": "d39cdf60-69fc-4700-92c1-acd4f9d59950",
        "DocumentNo": "OV-001",
        "C_OrdderLine":[
            {
                "uuid": "d39cdf60-69fc-4700-92c1-acd4f9d59955",
                "Line": 10,
                "M_Product_ID": 1000002,
                "Description": "Only Test"
            },
            {
                "uuid": "d39cdf6s-69fc-4700-92c1-acd4f9d59955",
                "Line": 20,
                "M_Product_ID": 1000001,
                "Description": "Only Test 01"
            }
        ]
    }
}
```