### PR TITLE
RFQ Create PO Fixed error with unused parameter

### DIFF
--- a/base/src/org/compiere/process/RfQCreatePO.java
+++ b/base/src/org/compiere/process/RfQCreatePO.java
@@ -169,7 +169,10 @@ public class RfQCreatePO extends SvrProcess
 				{
 					order = new MOrder (getCtx(), 0, get_TrxName());
 					order.setIsSOTrx(false);
-					order.setC_DocTypeTarget_ID();
+					if (p_C_DocType_ID != 0)
+						order.setC_DocTypeTarget_ID(p_C_DocType_ID);
+					else
+						order.setC_DocTypeTarget_ID();
 					order.setBPartner(bp);
 					order.setC_BPartner_Location_ID(response.getC_BPartner_Location_ID());
 					order.setSalesRep_ID(rfq.getSalesRep_ID());

--- a/base/src/org/compiere/process/RfQCreatePO.java
+++ b/base/src/org/compiere/process/RfQCreatePO.java
@@ -17,7 +17,6 @@
 package org.compiere.process;
 
 import java.math.BigDecimal;
-import java.util.logging.Level;
 
 import org.compiere.model.MBPartner;
 import org.compiere.model.MOrder;
@@ -39,30 +38,7 @@ import org.compiere.model.MRfQResponseLineQty;
  *  	<li>BF [ 2892588 ] Create PO from RfQ is not setting correct the price fields
  *  		https://sourceforge.net/tracker/?func=detail&aid=2892588&group_id=176962&atid=879332
  */
-public class RfQCreatePO extends SvrProcess
-{
-	/**	RfQ 			*/
-	private int		p_C_RfQ_ID = 0;
-	private int		p_C_DocType_ID = 0;
-
-	/**
-	 * 	Prepare
-	 */
-	protected void prepare ()
-	{
-		ProcessInfoParameter[] para = getParameter();
-		for (int i = 0; i < para.length; i++)
-		{
-			String name = para[i].getParameterName();
-			if (para[i].getParameter() == null)
-				;
-			else if (name.equals("C_DocType_ID"))
-				p_C_DocType_ID = para[i].getParameterAsInt();
-			else
-				log.log(Level.SEVERE, "Unknown Parameter: " + name);
-		}
-		p_C_RfQ_ID = getRecord_ID();
-	}	//	prepare
+public class RfQCreatePO extends RfQCreatePOAbstract {
 
 	/**
 	 * 	Process.
@@ -73,9 +49,8 @@ public class RfQCreatePO extends SvrProcess
 	 * 	If there is no response marked as Selected Winner, the lines are used.
 	 *	@return message
 	 */
-	protected String doIt () throws Exception
-	{
-		MRfQ rfq = new MRfQ (getCtx(), p_C_RfQ_ID, get_TrxName());
+	protected String doIt () throws Exception {
+		MRfQ rfq = new MRfQ (getCtx(), getRecord_ID(), get_TrxName());
 		if (rfq.get_ID() == 0)
 			throw new IllegalArgumentException("No RfQ found");
 		log.info(rfq.toString());
@@ -97,8 +72,8 @@ public class RfQCreatePO extends SvrProcess
 			log.config("Winner=" + bp);
 			MOrder order = new MOrder (getCtx(), 0, get_TrxName());
 			order.setIsSOTrx(false);
-			if (p_C_DocType_ID != 0)
-				order.setC_DocTypeTarget_ID(p_C_DocType_ID);
+			if (getDocTypeId() != 0)
+				order.setC_DocTypeTarget_ID(getDocTypeId());
 			else
 				order.setC_DocTypeTarget_ID();
 			order.setBPartner(bp);
@@ -169,8 +144,8 @@ public class RfQCreatePO extends SvrProcess
 				{
 					order = new MOrder (getCtx(), 0, get_TrxName());
 					order.setIsSOTrx(false);
-					if (p_C_DocType_ID != 0)
-						order.setC_DocTypeTarget_ID(p_C_DocType_ID);
+					if (getDocTypeId() != 0)
+						order.setC_DocTypeTarget_ID(getDocTypeId());
 					else
 						order.setC_DocTypeTarget_ID();
 					order.setBPartner(bp);

--- a/base/src/org/compiere/process/RfQCreatePOAbstract.java
+++ b/base/src/org/compiere/process/RfQCreatePOAbstract.java
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * or (at your option) any later version.                                     *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
+ *****************************************************************************/
+
+package org.compiere.process;
+
+
+
+/** Generated Process for (Create Purchase Order)
+ *  @author ADempiere (generated) 
+ *  @version Release 3.9.4
+ */
+public abstract class RfQCreatePOAbstract extends SvrProcess {
+	/** Process Value 	*/
+	private static final String VALUE_FOR_PROCESS = "C_RfQ_CreatePO";
+	/** Process Name 	*/
+	private static final String NAME_FOR_PROCESS = "Create Purchase Order";
+	/** Process Id 	*/
+	private static final int ID_FOR_PROCESS = 266;
+	/**	Parameter Name for Document Type	*/
+	public static final String C_DOCTYPE_ID = "C_DocType_ID";
+	/**	Parameter Value for Document Type	*/
+	private int docTypeId;
+
+	@Override
+	protected void prepare() {
+		docTypeId = getParameterAsInt(C_DOCTYPE_ID);
+	}
+
+	/**	 Getter Parameter Value for Document Type	*/
+	protected int getDocTypeId() {
+		return docTypeId;
+	}
+
+	/**	 Setter Parameter Value for Document Type	*/
+	protected void setDocTypeId(int docTypeId) {
+		this.docTypeId = docTypeId;
+	}
+
+	/**	 Getter Parameter Value for Process ID	*/
+	public static final int getProcessId() {
+		return ID_FOR_PROCESS;
+	}
+
+	/**	 Getter Parameter Value for Process Value	*/
+	public static final String getProcessValue() {
+		return VALUE_FOR_PROCESS;
+	}
+
+	/**	 Getter Parameter Value for Process Name	*/
+	public static final String getProcessName() {
+		return NAME_FOR_PROCESS;
+	}
+}


### PR DESCRIPTION
Currently exists a document type as parameter when a Purchase Order is
created from a Request for Quotation but it is unused inside process.
![image](https://user-images.githubusercontent.com/2333092/217959116-66edada1-7fc5-45dd-9b86-04fb954df531.png)
