### PR TITLE
Add validation for maximum 20 digits of account

### DIFF
--- a/base/src/org/compiere/model/MBankAccount.java
+++ b/base/src/org/compiere/model/MBankAccount.java
@@ -144,6 +144,14 @@ public class MBankAccount extends X_C_BankAccount
 				}
 			}
 		}
+		if(newRecord || is_ValueChanged(COLUMNNAME_AccountNo)) {
+			if(Optional.ofNullable(MBank.get(getCtx(), getC_Bank_ID()).getBankType()).orElse("").equals(MBank.BANKTYPE_Bank)
+					&& !Util.isEmpty(getAccountNo())) {
+				if(getAccountNo().trim().length() > 20) {
+					setAccountNo(getAccountNo().trim().substring(0, 20));
+				}
+			}
+		}
 		return true;
 	}	//	beforeSave
 	


### PR DESCRIPTION
Add validation for maximum 20 digits of account

Currently the bank account number has a size of 20 characters, this is
created by database.

This pull request prevent the maximum characters when a bank account is
created based on model class
