### PR TITLE
Allows overwrite overpayment amount a invoice from payment selection

### DIFF
--- a/base/src/org/compiere/model/MPaySelectionLine.java
+++ b/base/src/org/compiere/model/MPaySelectionLine.java
@@ -370,8 +370,8 @@ public class MPaySelectionLine extends X_C_PaySelectionLine
 		if(getC_BPartner_ID() == 0)
 			throw new AdempiereException("@C_BPartner_ID@ @NotFound@");
 
-		if (getC_Invoice_ID() > 0 && getOpenAmt().subtract(getPayAmt()).subtract(getDiscountAmt()).signum() < 0 )
-			throw new AdempiereException("@PayAmt@ > @C_Invoice_ID@ @Amount@ @OpenAmt@ ");
+		//	if (getC_Invoice_ID() > 0 && getOpenAmt().subtract(getPayAmt()).subtract(getDiscountAmt()).signum() < 0 )
+			//	throw new AdempiereException("@PayAmt@ > @C_Invoice_ID@ @Amount@ @OpenAmt@ ");
 
 		return true;
 	}	//	beforeSave


### PR DESCRIPTION
Currently a payment allows overwrite a invoice, but, a payment selection don't allow it.

This change just allows overwrite a invoice from payment selection like is allowed from payment