### PR TITLE
Fixed error with missing property file for apache ecs packages

### DIFF
--- a/tools/build.gradle
+++ b/tools/build.gradle
@@ -12,8 +12,12 @@ dependencies {
 sourceSets {
     main {
          java {
-            srcDirs = ['src']
+            srcDirs 'src'
          }
+         resources {
+    		srcDirs 'src'
+        	include 'org/adempiere/legacy/apache/ecs/ecs.properties'
+    	 }
     }
 }
 


### PR DESCRIPTION
Just add the file `ecs.properties` is missing after publish packages, this throw a error when you try run a report with html format

The error is showed in terminal like this:

```Shell
java.lang.NoClassDefFoundError: Could not initialize class
org.adempiere.legacy.apache.ecs.ECSDefaults

Cannot find org.adempiere.legacy.apache.ecs.ecs.properties.
```