### PR TITLE
fix: getProductPrice with where clause.

### DIFF
--- a/base/src/org/compiere/model/MPriceListVersion.java
+++ b/base/src/org/compiere/model/MPriceListVersion.java
@@ -24,6 +24,7 @@ import org.adempiere.core.domains.models.I_M_ProductPrice;
 import org.adempiere.core.domains.models.X_M_PriceList_Version;
 import org.compiere.util.DisplayType;
 import org.compiere.util.TimeUtil;
+import org.compiere.util.Util;
 
 /**
  *	Price List Version Model
@@ -115,9 +116,10 @@ public class MPriceListVersion extends X_M_PriceList_Version
 	 */
 	public MProductPrice[] getProductPrice (String whereClause)
 	{
-		String localWhereClause = I_M_ProductPrice.COLUMNNAME_M_PriceList_Version_ID+"=?"+whereClause;
-		if (whereClause != null)
+		String localWhereClause = I_M_ProductPrice.COLUMNNAME_M_PriceList_Version_ID + "=?";
+		if (!Util.isEmpty(whereClause, true)) {
 			localWhereClause += " " + whereClause;
+		}
 		List<MProductPrice> list = new Query(getCtx(),I_M_ProductPrice.Table_Name,localWhereClause,get_TrxName())
 			.setParameters(getM_PriceList_Version_ID())
 			.list();


### PR DESCRIPTION
When using the `getProductPrice` method of the `MPriceListVersion` class and passing a where clause that does not start with spaces, for example `AND 1=1` or any other filter:
```sql
AND EXISTS (
  SELECT 1 FROM C_OrderLine ol ol
  WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID
)
```

 it generates an error:

``` log
org.postgresql.util.PSQLException: ERROR: trailing junk after parameter at or near "$1A"
  Position: 215, SQL=SELECT AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive,M_PriceList_Version_ID,M_ProductPrice_ID,M_Product_ID,PriceLimit,PriceList,PriceStd,UUID,Updated,UpdatedBy FROM M_ProductPrice WHERE (M_PriceList_Version_ID=?AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID) AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID)) [38]
```

To prevent this error, you can send the parameter with the where clause with the string starting with a blank space, but this may be impractical, and it also duplicates the where clause sent as a parameter:


```sql
SELECT AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive,M_PriceList_Version_ID,M_ProductPrice_ID,M_Product_ID,PriceLimit,PriceList,PriceStd,UUID,Updated,UpdatedBy 
FROM M_ProductPrice WHERE (M_PriceList_Version_ID=?
AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID) 
AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID))
```



