### PR TITLE
fix: getProductPrice with where clause.

### DIFF
--- a/base/src/org/compiere/model/MPriceListVersion.java
+++ b/base/src/org/compiere/model/MPriceListVersion.java
@@ -24,6 +24,7 @@ import org.adempiere.core.domains.models.I_M_ProductPrice;
 import org.adempiere.core.domains.models.X_M_PriceList_Version;
 import org.compiere.util.DisplayType;
 import org.compiere.util.TimeUtil;
+import org.compiere.util.Util;
 
 /**
  *	Price List Version Model
@@ -115,9 +116,10 @@ public class MPriceListVersion extends X_M_PriceList_Version
 	 */
 	public MProductPrice[] getProductPrice (String whereClause)
 	{
-		String localWhereClause = I_M_ProductPrice.COLUMNNAME_M_PriceList_Version_ID+"=?"+whereClause;
-		if (whereClause != null)
+		String localWhereClause = I_M_ProductPrice.COLUMNNAME_M_PriceList_Version_ID + "=?";
+		if (!Util.isEmpty(whereClause, true)) {
 			localWhereClause += " " + whereClause;
+		}
 		List<MProductPrice> list = new Query(getCtx(),I_M_ProductPrice.Table_Name,localWhereClause,get_TrxName())
 			.setParameters(getM_PriceList_Version_ID())
 			.list();

--- a/base/src/org/compiere/model/MPriceListVersion.java
+++ b/base/src/org/compiere/model/MPriceListVersion.java
@@ -118,6 +118,9 @@ public class MPriceListVersion extends X_M_PriceList_Version
 	{
 		String localWhereClause = I_M_ProductPrice.COLUMNNAME_M_PriceList_Version_ID + "=?";
 		if (!Util.isEmpty(whereClause, true)) {
+			if (!whereClause.trim().startsWith("AND")) {
+				localWhereClause += " AND ";
+			}
 			localWhereClause += " " + whereClause;
 		}
 		List<MProductPrice> list = new Query(getCtx(),I_M_ProductPrice.Table_Name,localWhereClause,get_TrxName())

--- a/base/test/src/org/compiere/model/UT_MPriceListVersion.java
+++ b/base/test/src/org/compiere/model/UT_MPriceListVersion.java
@@ -1,0 +1,90 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2023 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.compiere.model;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.compiere.model.MPriceListVersion;
+import org.compiere.util.Env;
+import org.adempiere.test.CommonGWSetup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Edwin Betancourt, EdwinBetanc0urt@outlook.com
+ */
+@Tag("Model")
+@Tag("MPriceList")
+@Tag("MPriceListVersion")
+@Tag("UnitTest")
+class UT_MPriceListVersion extends CommonGWSetup {
+
+	static MPriceList priceList = null;
+
+
+	@BeforeEach
+	static void beforeEach() {
+		// Standard
+		priceList = new MPriceList(ctx, 102, trxName);
+	}
+
+
+
+	@Test
+	void constructor() {
+		MPriceListVersion priceListVersionTest = new MPriceListVersion(ctx, 0, trxName);
+		priceListVersionTest.setName("Price List Version Test");
+		priceListVersionTest.setM_PriceList_ID(priceList.getM_PriceList_ID());
+		priceListVersionTest.setM_DiscountSchema_ID(100); // Sales 2001
+		priceListVersionTest.saveEx();
+
+		assertTrue(
+			priceListVersionTest.getM_PriceList_Version_ID() > 0,
+			"Saved Price List Version does not have an ID"
+		);
+	}
+
+
+
+	@Test
+	void getProductPrice_fillArray() {
+		// Standard 2001
+		MPriceListVersion priceListVersionTest = new MPriceListVersion(ctx, 101, trxName);
+
+		// [ Standard ]
+		MProductPrice[] priceLists = priceListVersionTest.getProductPrice("");
+		assertTrue(
+			priceLists.length > 0,
+			"Should not have at least the new element, the size must be greater than zero."
+		);
+	}
+
+	@Test
+	void getProductPrice_emptyArray() {
+		// Standard 2001
+		MPriceListVersion priceListVersionTest = new MPriceListVersion(ctx, 101, trxName);
+
+		// [ ]
+		MProductPrice[] priceLists = priceListVersionTest.getProductPrice(" AND 1=2");
+		assertFalse(
+			priceLists.length > 0,
+			"It should not have any element, the size should be zero."
+		);
+	}
+
+}


### PR DESCRIPTION
When using the `getProductPrice` method of the `MPriceListVersion` class:

https://github.com/adempiere/adempiere/blob/0070473977179e538835f46b9b486084307a5d30/base/src/org/compiere/model/MPriceListVersion.java#L116-L127


And passing a where clause that does not start with spaces, for example `AND 1=1` or any other filter:

```sql
AND EXISTS (
  SELECT 1 FROM C_OrderLine ol ol
  WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID
)
```

 it generates an error:

``` log
org.postgresql.util.PSQLException: ERROR: trailing junk after parameter at or near "$1A"
  Position: 215, SQL=SELECT AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive,M_PriceList_Version_ID,M_ProductPrice_ID,M_Product_ID,PriceLimit,PriceList,PriceStd,UUID,Updated,UpdatedBy FROM M_ProductPrice WHERE (M_PriceList_Version_ID=?AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID) AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID)) [38]
```
```sql
WHERE M_PriceList_Version_ID=?AND 
```

To prevent this error, you can send the parameter with the where clause with the string starting with a blank space, but this may be impractical, and it also duplicates the where clause sent as a parameter:


```sql
SELECT AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive,M_PriceList_Version_ID,M_ProductPrice_ID,M_Product_ID,PriceLimit,PriceList,PriceStd,UUID,Updated,UpdatedBy 
FROM M_ProductPrice WHERE (M_PriceList_Version_ID=?
AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID) 
AND EXISTS(SELECT 1 FROM C_OrderLine ol WHERE ol.C_Order_ID = 1000035 AND ol.M_Product_ID = M_ProductPrice.M_Product_ID))
```



