### PR TITLE
fix: Read Only Logic in `AD_ClientInfo` table columns.

### DIFF
--- a/migration/394lts-395lts/09930_Fix_Read_Only_Logic_in_AD_ClientInfo_table_columns.xml
+++ b/migration/394lts-395lts/09930_Fix_Read_Only_Logic_in_AD_ClientInfo_table_columns.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Fix Read Only Logic in AD_ClientInfo table columns" ReleaseNo="3.9.5" SeqNo="9930">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="1983" Table="AD_Column">
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" oldValue="@AD_Client_ID=0">@AD_Client_ID@=0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="3883" Table="AD_Column">
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" oldValue="@AD_Client_ID=0">@AD_Client_ID@=0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="5956" Table="AD_Column">
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" oldValue="@AD_Client_ID=0">@AD_Client_ID@=0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="2349" Table="AD_Column">
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" oldValue="@AD_Client_ID=0">@AD_Client_ID@=0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="2350" Table="AD_Column">
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" oldValue="@AD_Client_ID=0">@AD_Client_ID@=0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="2347" Table="AD_Column">
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" oldValue="@AD_Client_ID=0">@AD_Client_ID@=0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="2348" Table="AD_Column">
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" oldValue="@AD_Client_ID=0">@AD_Client_ID@=0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="80" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="6735" Table="AD_Column">
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" oldValue="@AD_Client_ID=0">@AD_Client_ID@=0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="90" StepType="AD">
+      <PO AD_Table_ID="101" Action="U" Record_ID="3881" Table="AD_Column">
+        <Data AD_Column_ID="6245" Column="ReadOnlyLogic" oldValue="@AD_Client_ID=0">@AD_Client_ID@=0</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
There are several columns in the `AD_ClientInfo` table whose read-only logics have the `@` at the beginning of the column but not at the end, however the adempiere evaluator does not generate an error when evaluating the logics with this incorrect format, considering that only the `@SQL=` logics should have this format.

In all the logic the value is `@AD_Client_ID=0` when it should be `@AD_Client_ID@=0` (with opening and closing `@` in the column name)

The following query can be performed to search with regular expression (used with postgres):
```sql
SELECT
	AD_Column_ID, ColumnName, ReadOnlyLogic, MandatoryLogic, DefaultValue, AD_Table_ID

FROM AD_Column

WHERE 
	ReadOnlyLogic ~ '@(#|$){0,1}\w+(<>|<=|==|>=|!=|<|=|>|!|\^|~)'
	OR MandatoryLogic ~ '@(#|$){0,1}\w(<>|<=|==|>=|!=|<|=|>|!|\^|~)'
	OR DefaultValue ~ '@(#|$){0,1}((?<=SQL)\w+)(<>|<=|==|>=|!=|<|=|>|!|\^|~)'
```

Among the columns with this incorrect logic format are:
- `C_AcctSchema1_ID`.
- `C_BPartnerCashTrx_ID`.
- `C_Calendar_ID`.
- `C_UOM_Length_ID`.
- `C_UOM_Time_ID`.
- `C_UOM_Volume_ID`.
- `C_UOM_Weight_ID`.
- `IsDiscountLineAmt`.
- `M_ProductFreight_ID`.



closes https://github.com/adempiere/adempiere/pull/4121