### PR TITLE
fix: `ImpFormat` load by identifier.

### DIFF
--- a/base/src/org/compiere/impexp/ImpFormat.java
+++ b/base/src/org/compiere/impexp/ImpFormat.java
@@ -518,8 +518,8 @@ public final class ImpFormat
 	 *  @param fieldNo number of field to be returned
 	 *  @return field in lime or ""
 	@throws IllegalArgumentException if format unknowns
-	 *   */
-	private String parseFlexFormat (String line, String formatType, int fieldNo)
+	 */
+	public String parseFlexFormat(String line, String formatType, int fieldNo)
 	{
 		final char QUOTE = '"';
 		//  check input

--- a/base/src/org/compiere/impexp/ImpFormat.java
+++ b/base/src/org/compiere/impexp/ImpFormat.java
@@ -327,6 +327,9 @@ public final class ImpFormat
 	 */
 	public static ImpFormat load (String name) {
 		log.config(name);
+		if (Util.isEmpty(name, true)) {
+			return null;
+		}
 		ImpFormat retValue = null;
 		String sql = "SELECT * FROM AD_ImpFormat WHERE Name=?";
 		int ID = 0;
@@ -358,8 +361,11 @@ public final class ImpFormat
 	 */
 	public static ImpFormat load(int impFormatId) {
 		log.config("AD_ImpFormat_ID = " + impFormatId);
+		if (impFormatId <= 0) {
+			return null;
+		}
 		ImpFormat retValue = null;
-		String sql = "SELECT * FROM AD_ImpFormat WHERE Name=?";
+		String sql = "SELECT * FROM AD_ImpFormat WHERE AD_ImpFormat_ID=?";
 		try {
 			PreparedStatement pstmt = DB.prepareStatement(sql, null);
 			pstmt.setInt(1, impFormatId);

--- a/base/src/org/compiere/impexp/ImpFormat.java
+++ b/base/src/org/compiere/impexp/ImpFormat.java
@@ -350,6 +350,10 @@ public final class ImpFormat
 			log.log(Level.SEVERE, sql, e);
 			return null;
 		}
+		if (retValue == null) {
+			return null;
+		}
+
 		loadRows (retValue, ID);
 		return retValue;
 	}	//	getFormat
@@ -382,6 +386,10 @@ public final class ImpFormat
 			log.log(Level.SEVERE, sql, e);
 			return null;
 		}
+		if (retValue == null) {
+			return null;
+		}
+
 		loadRows(retValue, impFormatId);
 		return retValue;
 	}	//	getFormat

--- a/base/test/src/org/compiere/impexp/UT_ImFormat.java
+++ b/base/test/src/org/compiere/impexp/UT_ImFormat.java
@@ -1,0 +1,91 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2023 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.compiere.impexp;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.compiere.impexp.ImpFormat;
+import org.compiere.impexp.MImpFormat;
+import org.compiere.model.MPriceListVersion;
+import org.compiere.util.Env;
+import org.adempiere.test.CommonGWSetup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
+ */
+@Tag("ImpExp")
+@Tag("ImpFormat")
+@Tag("MImpFormat")
+@Tag("MImpFormatRow")
+@Tag("UnitTest")
+class UT_ImpFormat extends CommonGWSetup {
+
+	static MImpFormat importFormat = null;
+
+
+	@BeforeEach
+	static void beforeEach() {
+		// Accounting - Accounts
+		importFormat = new MImpFormat(ctx, 102, trxName);
+	}
+
+
+
+	@Test
+	void loadImpFormatByID_fill() {
+		ImpFormat impFormat = ImpFormat.load(importFormat.getAD_ImpFormat_ID());
+		assertTrue(
+			impFormat != null,
+			"ImpFormat successfully loaded by ID."
+		);
+	}
+
+	@Test
+	void loadImpFormatByID_empty() {
+		ImpFormat impFormat = ImpFormat.load(0);
+
+		assertTrue(
+			impFormat == null,
+			"ImpFormat is null, invalid or non-existent ID."
+		);
+	}
+
+
+
+	@Test
+	void loadImpFormatByName_fill() {
+		ImpFormat impFormat = ImpFormat.load(importFormat.getName());
+		assertTrue(
+			impFormat != null,
+			"ImpFormat successfully loaded by Name"
+		);
+	}
+
+	@Test
+	void loadImpFormatByName_empty() {
+		ImpFormat impFormat = ImpFormat.load("");
+
+		assertTrue(
+			impFormat == null,
+			"ImpFormat is null, invalid or non-existent Name."
+		);
+	}
+
+}


### PR DESCRIPTION
When the `ImpFormat.load(int id)` method is used, it generates a sql exception, because the parameter receives an integer but in the SQL query it tries to compare with the column `Name` whose data type is string, when it should be compared to the `AD_ImpFormat_ID` column.

```log
===========> ImpFormat.load: SELECT * FROM AD_ImpFormat WHERE Name=? [20]
org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer
  Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
  Position: 38; State=42883; ErrorCode=0
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355)
        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490)
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408)
        at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:166)
        at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:118)
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
        at jdk.internal.reflect.GeneratedMethodAccessor1.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
        at com.sun.proxy.$Proxy4.executeQuery(Unknown Source)
        at org.compiere.impexp.ImpFormat.load(ImpFormat.java:366)
        at org.spin.form.import_file_loader.ImportFileLoaderServiceLogic.listFilePreview(ImportFileLoaderServiceLogic.java:352)
        at org.spin.grpc.service.ImportFileLoaderServiceImplementation.listFilePreview(ImportFileLoaderServiceImplementation.java:194)
        at org.spin.backend.grpc.form.import_file_loader.ImportFileLoaderGrpc$MethodHandlers.invoke(ImportFileLoaderGrpc.java:748)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
```

It should be noted that this class implements several ResultSets where it only closes the connection to the database only if it executes everything inside the try, however they should have finally closing the connection, so that regardless of whether everything is executed correctly or if an exception is thrown , at the end always close the connections to the database