### PR TITLE
Add translation for Discussions in GitHub

### DIFF
--- a/.github/workflows/issue-and-pr-translator.yml
+++ b/.github/workflows/issue-and-pr-translator.yml
@@ -9,7 +9,11 @@ on:
     types: [opened]
   # Valid for issues and pull requests
   issue_comment: 
-    types: [created]  
+    types: [created]
+  discussion:
+    types: [created, edited, answered]
+  discussion_comment:
+    types: [created, deleted]
   
 jobs:
   build: 


### PR DESCRIPTION
Solves #4138

@e-Evolution  Victor, @yamelsenih Yamel: either of you can accept this PR.

Unluckily, being this Pull Request a GitHub Action, this Pull Request can only be tested **after** the Pull Request has been accepted by creating for example a comment to a Discussion in Spanish; it should be translated as it happens now to issues and pull requests.

So, the acceptance has to be done "blindly" and if everything goes well, OK.
Otherwise, the Pull Request has to be reverted; then find the reason for the PR not functioning, fixing it and creating a new PR.