### PR TITLE
fix: Remove deprecated warning with `new Double` constructor. 

### DIFF
--- a/base/src/org/compiere/model/MQuery.java
+++ b/base/src/org/compiere/model/MQuery.java
@@ -138,11 +138,11 @@ public class MQuery implements Serializable
 				Double P_Number = null;
 				double d = rs.getDouble(4);
 				if (!rs.wasNull())
-					P_Number = new Double(d);
+					P_Number = Double.valueOf(d);
 				Double P_Number_To = null;
 				d = rs.getDouble(5);
 				if (!rs.wasNull())
-					P_Number_To = new Double(d);
+					P_Number_To = Double.valueOf(d);
 				//
 				Timestamp P_Date = rs.getTimestamp(6);
 				Timestamp P_Date_To = rs.getTimestamp(7);

--- a/client/src/org/compiere/apps/search/Info.java
+++ b/client/src/org/compiere/apps/search/Info.java
@@ -1821,7 +1821,7 @@ public abstract class Info extends CDialog
 						else if (c == BigDecimal.class)
 							data = m_rs.getBigDecimal(colIndex);
 						else if (c == Double.class)
-							data = new Double(m_rs.getDouble(colIndex));
+							data = Double.valueOf(m_rs.getDouble(colIndex));
 						else if (c == Integer.class)
 							data = Integer.valueOf(m_rs.getInt(colIndex));
 						else if (c == KeyNamePair.class)

--- a/client/src/org/compiere/apps/search/InvoiceHistory.java
+++ b/client/src/org/compiere/apps/search/InvoiceHistory.java
@@ -315,7 +315,7 @@ public class InvoiceHistory extends CDialog
 				//	0-Name, 1-PriceActual, 2-QtyInvoiced, 3-Discount, 4-DocumentNo, 5-DateInvoiced
 				line.add(rs.getString(1));      //  Name
 				line.add(rs.getBigDecimal(2));  //	Price
-				line.add(new Double(rs.getDouble(4)));      //  Qty
+				line.add(rs.getDouble(4));      //  Qty
 				BigDecimal discountBD = rs.getBigDecimal(8);
 				if (discountBD == null) {
 					double priceList = rs.getDouble(3);
@@ -604,7 +604,7 @@ public class InvoiceHistory extends CDialog
 				Vector<Object> line = new Vector<Object>(6);
 				//	1-Name, 2-MovementQty, 3-MovementDate, 4-IsSOTrx, 5-DocumentNo
 				line.add(rs.getString(1));      		//  Name
-				line.add(new Double(rs.getDouble(2)));  //  Qty
+				line.add(Double.valueOf(rs.getDouble(2)));				//  Qty
 				line.add(rs.getTimestamp(3));   		//  Date
 				line.add(Boolean.valueOf("Y".equals(rs.getString(4))));	//  IsSOTrx
 				line.add(rs.getString(5));				//  DocNo

--- a/client/src/org/compiere/minigrid/MiniTable.java
+++ b/client/src/org/compiere/minigrid/MiniTable.java
@@ -992,7 +992,7 @@ public class MiniTable extends CTable implements IMiniTable
 					if (c == IDColumn.class)
 						data = new IDColumn(((Integer)data).intValue());
 					else if (c == Double.class)
-						data = new Double(((BigDecimal)data).doubleValue());
+						data = Double.valueOf(((BigDecimal) data).doubleValue());
 				}
 				//  store
 				setValueAt(data, row, col);
@@ -1285,19 +1285,18 @@ public class MiniTable extends CTable implements IMiniTable
 					}
 					else if (c == Double.class)
 					{
-						Double subtotal = new Double(0);
+						Double subtotal = Double.valueOf(0);
 						if(total[col] != null)
 							subtotal = (Double)(total[col]);
 						
 						Double amt =  (Double) data;
 						if(subtotal == null)
-							subtotal = new Double(0);
+							subtotal = Double.valueOf(0);
 						if(amt == null )
-							subtotal = new Double(0);
+							subtotal = Double.valueOf(0);
 						total[col] = subtotal + amt;
-						
-					}		
-				}	
+					}
+				}
 		}
 		
 		//adding total row

--- a/client/src/org/compiere/report/core/RModelData.java
+++ b/client/src/org/compiere/report/core/RModelData.java
@@ -149,7 +149,7 @@ class RModelData
 					else if (rc.getColClass() == BigDecimal.class)
 						row.add(rs.getBigDecimal(index++));
 					else if (rc.getColClass() == Double.class)
-						row.add(new Double(rs.getDouble(index++)));
+						row.add(Double.valueOf(rs.getDouble(index++)));
 					else if (rc.getColClass() == Integer.class)
 						row.add(Integer.valueOf(rs.getInt(index++)));
 					else if (rc.getColClass() == Timestamp.class)

--- a/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSTable.java
+++ b/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSTable.java
@@ -132,7 +132,7 @@ public class WPOSTable extends WListbox {
 					}
 					else if (columnClass == Double.class)
 					{
-						data = new Double(rs.getDouble(rsColIndex));
+						data = Double.valueOf(rs.getDouble(rsColIndex));
 					}
 					else if (columnClass == Integer.class)
 					{
@@ -235,7 +235,7 @@ public class WPOSTable extends WListbox {
 					}
 					else if (columnClass == Double.class)
 					{
-						data = new Double(((BigDecimal)data).doubleValue());
+						data = Double.valueOf(((BigDecimal) data).doubleValue());
 					}
 				}
 				//  store

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/DBDataSource.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/DBDataSource.java
@@ -140,7 +140,7 @@ public class DBDataSource extends compiereDataSource
 				}
 				else if (clazz.equals(java.lang.Double.class))
 				{
-					objValue = new Double(m_resultSet.getDouble(field.getName()));
+					objValue = Double.valueOf(m_resultSet.getDouble(field.getName()));
 					if(m_resultSet.wasNull())
 					{
 						objValue = null;

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/engine/forecast/MovingAverage.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/engine/forecast/MovingAverage.java
@@ -73,8 +73,9 @@ public class MovingAverage implements ForecastRule {
 		observedData.setTimeVariable(timeVariable);
 
 		// Try moving average model
-		ForecastingModel model = new MovingAverageModel(new Double(
-				getFactorUser()).intValue());
+		ForecastingModel model = new MovingAverageModel(
+			Double.valueOf(getFactorUser()).intValue()
+		);
 		model.init(observedData);
 		forecastData = model.forecast(observedData);
 	}

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VMRPDetailed.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VMRPDetailed.java
@@ -150,7 +150,7 @@ public class VMRPDetailed extends MRPDetailed implements FormPanel,
 						else if (c == BigDecimal.class)
 							data = rs.getBigDecimal(colIndex);
 						else if (c == Double.class)
-							data = new Double(rs.getDouble(colIndex));
+							data = Double.valueOf(rs.getDouble(colIndex));
 						else if (c == Integer.class)
 							data = Integer.valueOf(rs.getInt(colIndex));
 						else if (c == KeyNamePair.class) {

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VOrderPlanning.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VOrderPlanning.java
@@ -74,6 +74,8 @@ import org.eevolution.manufacturing.model.MPPOrder;
 public class VOrderPlanning extends CPanel
 implements FormPanel, ActionListener, VetoableChangeListener, ChangeListener, ListSelectionListener, TableModelListener, ASyncProcess
 {
+	private static final long serialVersionUID = -2027009461523708974L;
+
 	/** Creates new form VOrderPlanning */
 	public VOrderPlanning()
 	{
@@ -650,7 +652,7 @@ implements FormPanel, ActionListener, VetoableChangeListener, ChangeListener, Li
 						else if (c == BigDecimal.class)
 							data = rs.getBigDecimal(colIndex);
 						else if (c == Double.class)
-							data = new Double(rs.getDouble(colIndex));
+							data = Double.valueOf(rs.getDouble(colIndex));
 						else if (c == Integer.class)
 							data = Integer.valueOf(rs.getInt(colIndex));
 						else if (c == KeyNamePair.class)

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/component/WListbox.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/component/WListbox.java
@@ -648,7 +648,7 @@ public class WListbox extends Listbox implements IMiniTable, TableValueChangeLis
 					}
 					else if (columnClass == Double.class)
 					{
-						data = new Double(rs.getDouble(rsColIndex));
+						data = Double.valueOf(rs.getDouble(rsColIndex));
 					}
 					else if (columnClass == Integer.class)
 					{
@@ -756,7 +756,7 @@ public class WListbox extends Listbox implements IMiniTable, TableValueChangeLis
 					}
 					else if (columnClass == Double.class)
 					{
-						data = new Double(((BigDecimal)data).doubleValue());
+						data = Double.valueOf(((BigDecimal)data).doubleValue());
 					}
 				}
 				//  store
@@ -1066,15 +1066,15 @@ public class WListbox extends Listbox implements IMiniTable, TableValueChangeLis
 					}
 					else if (c == Double.class)
 					{
-						Double subtotal = new Double(0);
+						Double subtotal = Double.valueOf(0);
 						if(total[col] != null)
 							subtotal = (Double)(total[col]);
 						
 						Double amt =  (Double) data;
 						if(subtotal == null)
-							subtotal = new Double(0);
+							subtotal = Double.valueOf(0);
 						if(amt == null )
-							subtotal = new Double(0);
+							subtotal = Double.valueOf(0);
 						total[col] = subtotal + amt;
 						
 					}		

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
@@ -821,7 +821,7 @@ public abstract class InfoPanel extends Window implements EventListener, WTableM
 			else if (c == BigDecimal.class)
 		        value = rs.getBigDecimal(colIndex);
 			else if (c == Double.class)
-		        value = new Double(rs.getDouble(colIndex));
+		        value = Double.valueOf(rs.getDouble(colIndex));
 			else if (c == Integer.class)
 		        value = Integer.valueOf(rs.getInt(colIndex));
 			else if (c == KeyNamePair.class)

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/panel/InvoiceHistory.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/panel/InvoiceHistory.java
@@ -355,7 +355,7 @@ public class InvoiceHistory extends Window implements EventListener
 				//	0-Name, 1-PriceActual, 2-QtyInvoiced, 3-Discount, 4-DocumentNo, 5-DateInvoiced
 				line.add(rs.getString(1));      //  Name
 				line.add(rs.getBigDecimal(2));  //	Price
-				line.add(new Double(rs.getDouble(4)));      //  Qty
+				line.add(Double.valueOf(rs.getDouble(4)));      //  Qty
 				BigDecimal discountBD = rs.getBigDecimal(8);
 				if (discountBD == null) {
 					double priceList = rs.getDouble(3);
@@ -644,7 +644,7 @@ public class InvoiceHistory extends Window implements EventListener
 				Vector<Object> line = new Vector<Object>(6);
 				//	1-Name, 2-MovementQty, 3-MovementDate, 4-IsSOTrx, 5-DocumentNo
 				line.add(rs.getString(1));      		//  Name
-				line.add(new Double(rs.getDouble(2)));  //  Qty
+				line.add(Double.valueOf(rs.getDouble(2)));  //  Qty
 				line.add(rs.getTimestamp(3));   		//  Date
 				line.add(Boolean.valueOf("Y".equals(rs.getString(4))));	//  IsSOTrx
 				line.add(rs.getString(5));				//  DocNo


### PR DESCRIPTION

```
The constructor Double(double) is deprecated since version 9
```

![Captura de pantalla de 2023-09-22 02-07-44](https://github.com/adempiere/adempiere/assets/20288327/6624a877-1b47-4379-9830-b070f69b2277)
