### PR TITLE
fix: Remove deprecated warning with `new Integer` constructor.

### DIFF
--- a/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/MobileSessionCtx.java
+++ b/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/MobileSessionCtx.java
@@ -272,7 +272,7 @@ public class MobileSessionCtx implements Serializable
 		if (wstore == null)
 			return new Properties();
 		//
-		Integer key = new Integer (wstore.getW_Store_ID());
+		Integer key = Integer.valueOf(wstore.getW_Store_ID());
 		Properties newCtx = (Properties)s_cacheCtx.get(key);
 		
 		/**	Create New Context		*/

--- a/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/WReport.java
+++ b/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/WReport.java
@@ -142,7 +142,7 @@ public class WReport extends HttpServlet
 			{
 				if (queryColumn.endsWith("_ID"))
 					query.addRestriction(queryColumn, MQuery.EQUAL,
-						new Integer(Env.getContextAsInt(wsc.ctx, m_curTab.getWindowNo(), queryColumn)),
+						Integer.valueOf(Env.getContextAsInt(wsc.ctx, m_curTab.getWindowNo(), queryColumn)),
 						infoName, infoDisplay);
 				else
 					query.addRestriction(queryColumn, MQuery.EQUAL,

--- a/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/WWindow.java
+++ b/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/WWindow.java
@@ -819,7 +819,7 @@ public class WWindow extends HttpServlet
 			Integer ii = null;
 			try
 			{
-				ii = new Integer (value);
+				ii = Integer.valueOf(value);
 			}
 			catch (Exception e)
 			{

--- a/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/WWorkflow.java
+++ b/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/WWorkflow.java
@@ -768,7 +768,7 @@ private void loadWorkflow(Properties ctx, int AD_Workflow_ID, HttpSession sess) 
 		for (int i = 0; i < nodes.length; i++)
 		{
 		wfn= nodes[i];
-		nodes_ID.add (new Integer(wfn.getAD_WF_Node_ID()));
+			nodes_ID.add(Integer.valueOf(wfn.getAD_WF_Node_ID()));
 						}//for
         int imageMap [][] = generateImageMap(nodes_ID);
  //printMap(imageMap);
@@ -777,7 +777,7 @@ sess.setAttribute( WORKFLOW,wf);
 sess.setAttribute( NODES,nodes);
 sess.setAttribute( NODES_ID,nodes_ID);
 sess.setAttribute( IMAGE_MAP,imageMap);
-sess.setAttribute( ACTIVE_NODE,new Integer(-999));
+		sess.setAttribute(ACTIVE_NODE, Integer.valueOf(-999));
 
 }//loadWorkflow
 
@@ -796,7 +796,7 @@ sess.setAttribute( ACTIVE_NODE,new Integer(-999));
 private void executeCommand(String m_command, int j_command , MWorkflow wf,int activeNode, MWFNode [] nodes,ArrayList nodes_ID, HttpSession sess){
 if (j_command != 0 )
 {
-sess.setAttribute(ACTIVE_NODE, new Integer(j_command));
+			sess.setAttribute(ACTIVE_NODE, Integer.valueOf(j_command));
 return;
 }
 
@@ -836,7 +836,7 @@ if(m_command.equals(LAST)) updatedActiveNode= wf.getLast(0,Env.getContextAsInt(c
 }//ready
 
 //update
-sess.setAttribute(ACTIVE_NODE,new Integer(updatedActiveNode));
+		sess.setAttribute(ACTIVE_NODE, Integer.valueOf(updatedActiveNode));
 }//executeCommand
 
 


### PR DESCRIPTION
`The constructor Integer(int) is deprecated since version 9`

![imagen](https://github.com/adempiere/adempiere/assets/20288327/4fe0ad17-1e0c-42d5-86c9-6d538ce117e0)