### PR TITLE
fix: Remove deprecated warning with `new Long` constructor.

### DIFF
--- a/base/src/org/spin/model/MADContextInfo.java
+++ b/base/src/org/spin/model/MADContextInfo.java
@@ -261,7 +261,7 @@ public class MADContextInfo extends X_AD_ContextInfo {
 					if(value instanceof BigDecimal) {
 						value = ((BigDecimal) value).doubleValue();
 					} else if(value instanceof Timestamp) {
-						value = new Long(((Timestamp) value).getTime());
+						value = Long.valueOf(((Timestamp) value).getTime());
 					} else if(value instanceof Number) {
 						value = Integer.valueOf(((Number) value).intValue());
 					} else {

--- a/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSActionPanel.java
+++ b/org.adempiere.pos/src/main/java/ui/zk/org/adempiere/pos/WPOSActionPanel.java
@@ -210,7 +210,7 @@ public class WPOSActionPanel extends WPOSSubPanel
 		row = rows.newRow();
 		row.setSpans("12");
 		if (posPanel.isEnableProductLookup() && !posPanel.isVirtualKeyboard()) {
-			lookupProduct = new WPOSLookupProduct(this, fieldProductName, new Long("1"));
+			lookupProduct = new WPOSLookupProduct(this, fieldProductName, Long.valueOf("1"));
 			lookupProduct.setPriceListId(posPanel.getM_PriceList_ID());
 			lookupProduct.setPartnerId(posPanel.getC_BPartner_ID());
 			lookupProduct.setWarehouseId(posPanel.getM_Warehouse_ID());

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/DBDataSource.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/data/DBDataSource.java
@@ -164,7 +164,7 @@ public class DBDataSource extends compiereDataSource
 				}
 				else if (clazz.equals(java.lang.Long.class))
 				{
-					objValue = new Long(m_resultSet.getLong(field.getName()));
+					objValue = Long.valueOf(m_resultSet.getLong(field.getName()));
 					if(m_resultSet.wasNull())
 					{
 						objValue = null;

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/process/CRPSummary.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/process/CRPSummary.java
@@ -144,7 +144,7 @@ public class CRPSummary extends SvrProcess
                 			long factor = (hours * 3600) / 86400; // factor = second for a day / avlailable hour in sencond
                 			System.out.print("factor:" + factor);
                 			long totalseconds = (seconds / factor) ; // (total seconds * factor seconds avaialble) / a day in seconds                			
-                			Long day = new Long((totalseconds/(hours* 3600)));
+                			Long day = Long.valueOf((totalseconds/(hours* 3600)));
                 			Timestamp dateFinishSchedule = getDate(date, day.intValue() ,type);
                 			n.setDateStartSchedule(date);
                 			n.setDateFinishSchedule(dateFinishSchedule);	
@@ -182,7 +182,7 @@ public class CRPSummary extends SvrProcess
                 			long factor = (hours * 3600) / 86400; // factor = second for a day / avlailable hour in sencond
                 			System.out.print("factor:" + factor);
                 			long totalseconds = (seconds / factor) ; // (total seconds * factor seconds avaialble) / a day in seconds                			
-                			Long day = new Long((totalseconds/(hours* 3600)) * -1 );
+                			Long day = Long.valueOf((totalseconds/(hours* 3600)) * -1 );
                 			Timestamp dateStartSchedule = getDate(date, day.intValue() ,type);
                 			n.setDateFinishSchedule(date);
 							n.setDateStartSchedule(dateStartSchedule);
@@ -412,7 +412,7 @@ public class CRPSummary extends SvrProcess
  		 			 cols.setFrom(gc1.getTime().toString());
  		 			 cols.setTo(gc1.getTime().toString());
  		 			 cols.setDays(1);
- 		 			Long Hours = Long.valueOf(hours); 
+ 		 			Long Hours = Long.valueOf(hours);
  		 			 cols.setCapacity(Hours.intValue());
  		 			 int C_UOM_ID = DB.getSQLValue(null,"SELECT C_UOM_ID FROM M_Product WHERE S_Resource_ID = ? " , r.getS_Resource_ID());
  		 			 MUOM oum = MUOM.get(getCtx(),C_UOM_ID);

--- a/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/process/CRPSummary.java
+++ b/org.eevolution.manufacturing/src/main/java/base/org/eevolution/manufacturing/process/CRPSummary.java
@@ -218,7 +218,7 @@ public class CRPSummary extends SvrProcess
  		//
  		GregorianCalendar cal = new GregorianCalendar();
  		cal.setTime(dateTime);
- 		cal.add(Calendar.SECOND, new Long(offset).intValue());			//	may have a problem with negative
+		cal.add(Calendar.SECOND, Long.valueOf(offset).intValue());			//	may have a problem with negative
  		return new Timestamp (cal.getTimeInMillis());
  	}	//	addMinutes
      
@@ -412,7 +412,7 @@ public class CRPSummary extends SvrProcess
  		 			 cols.setFrom(gc1.getTime().toString());
  		 			 cols.setTo(gc1.getTime().toString());
  		 			 cols.setDays(1);
- 		 			 Long Hours = new Long(hours); 
+ 		 			Long Hours = Long.valueOf(hours); 
  		 			 cols.setCapacity(Hours.intValue());
  		 			 int C_UOM_ID = DB.getSQLValue(null,"SELECT C_UOM_ID FROM M_Product WHERE S_Resource_ID = ? " , r.getS_Resource_ID());
  		 			 MUOM oum = MUOM.get(getCtx(),C_UOM_ID);

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/CRP.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/CRP.java
@@ -111,7 +111,7 @@ public class CRP {
 	     long hours = t.getTimeSlotHours();
 		 
 		 DefaultCategoryDataset dataset = new DefaultCategoryDataset();	 
-		 //		Long Hours = new Long(hours); 			 		 			 
+		 //		Long Hours = Long.valueOf(hours);
 		 int C_UOM_ID = DB.getSQLValue(null,"SELECT C_UOM_ID FROM M_Product WHERE S_Resource_ID = ? " , resource.getS_Resource_ID());
 		 MUOM uom = MUOM.get(Env.getCtx(),C_UOM_ID);
 	     if (!uom.isHour())
@@ -124,7 +124,7 @@ public class CRP {
  		 {	
 			String day = new String(Integer.valueOf(date.getDate()).toString());
  		 		long HoursLoad = getLoad(resource,date).longValue();
- 		 		Long Hours = new Long(hours); 
+ 		 		Long Hours = Long.valueOf(hours);
  		 		
  		 		switch(gc1.get(Calendar.DAY_OF_WEEK))
 				{

--- a/serverRoot/src/main/servlet/org/compiere/web/AdempiereMonitorFilter.java
+++ b/serverRoot/src/main/servlet/org/compiere/web/AdempiereMonitorFilter.java
@@ -60,7 +60,7 @@ public class AdempiereMonitorFilter implements Filter
 	 */
 	public AdempiereMonitorFilter() {
 		super ();
-		m_authorization = new Long (System.currentTimeMillis());
+		m_authorization = Long.valueOf(System.currentTimeMillis());
 	}
 
 	/**

--- a/webCM/src/main/servlet/org/compiere/cm/cache/CO.java
+++ b/webCM/src/main/servlet/org/compiere/cm/cache/CO.java
@@ -71,7 +71,7 @@ public class CO {
 	 */
 	public void put(String ID, Object thisObject) {
 		cache.put(ID,thisObject);
-		Long thisLong = new Long(new Date().getTime());
+		Long thisLong = Long.valueOf(new Date().getTime());
 		cacheUsage.put(ID, thisLong);
 		if (cacheUsage.size()>cacheSize-1) {
 			cleanUp();
@@ -145,7 +145,7 @@ public class CO {
 	 *	@param ID
 	 */
 	public void use(int ID) {
-		Long thisLong = new Long(new java.util.Date().getTime());
+		Long thisLong = Long.valueOf(new java.util.Date().getTime());
 		cacheUsage.put("" + ID, thisLong);
 	}
 	
@@ -154,7 +154,7 @@ public class CO {
 	 *	@param ID
 	 */
 	public void use(String ID) {
-		Long thisLong = new Long(new java.util.Date().getTime());
+		Long thisLong = new java.util.Date().getTime();
 		cacheUsage.put(ID, thisLong);
 	}
 	

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/window/WMediaDialog.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/window/WMediaDialog.java
@@ -245,7 +245,7 @@ public class WMediaDialog extends Window implements EventListener
 		{
 			Clob clob = (Clob)m_data;
 			long length = clob.length() > 100 ? 100 : clob.length();
-			String data = ((Clob)m_data).getSubString(1, new Long(length).intValue());
+			String data = ((Clob)m_data).getSubString(1, Long.valueOf(length).intValue());
 			if (data.toUpperCase().indexOf("<html>") >= 0)
 			{
 				contentType = "text/html";


### PR DESCRIPTION
`The constructor Long(long) is deprecated since version 9`

`The constructor Long(String) is deprecated since version 9`

![imagen](https://github.com/adempiere/adempiere/assets/20288327/08a01ca7-3cba-49ae-bbd5-d26c7a330487)
