### PR TITLE
fix: Remove deprecated warning with `new Character` constructor.

### DIFF
--- a/client/src/org/compiere/apps/AppsAction.java
+++ b/client/src/org/compiere/apps/AppsAction.java
@@ -97,7 +97,7 @@ public final class AppsAction extends AbstractAction
 		int pos = toolTipText.indexOf('&');
 		if (pos != -1  && toolTipText.length() > pos)	//	We have a nemonic - creates ALT-_
 		{
-			Character ch = new Character(toolTipText.toUpperCase().charAt(pos+1));
+			Character ch = Character.valueOf(toolTipText.toUpperCase().charAt(pos+1));
 			if (ch != ' ')
 			{
 				toolTipText = toolTipText.substring(0, pos) + toolTipText.substring(pos+1);

--- a/zkwebui/WEB-INF/src/org/adempiere/webui/component/WAppsAction.java
+++ b/zkwebui/WEB-INF/src/org/adempiere/webui/component/WAppsAction.java
@@ -78,7 +78,7 @@ public class WAppsAction
        int pos = newToolTipText.indexOf('&');
        if (pos != -1  && newToolTipText.length() > pos)   //  We have a nemonic - creates ALT-_
        {
-           Character ch = new Character(newToolTipText.toLowerCase().charAt(pos + 1));
+           Character ch = Character.valueOf(newToolTipText.toLowerCase().charAt(pos + 1));
            if (ch != ' ')
            {
                // remove ampersand


### PR DESCRIPTION
`The constructor Character(char) is deprecated since version 9`

![imagen](https://github.com/adempiere/adempiere/assets/20288327/3c4881f2-16be-4a9a-a58b-9a9423ebf8ed)
