### PR TITLE
fix: Remove deprecated warning with `BigDecimal.ROUND`.

### DIFF
--- a/base/src/org/compiere/model/CalloutGLJournal.java
+++ b/base/src/org/compiere/model/CalloutGLJournal.java
@@ -163,7 +163,6 @@ public class CalloutGLJournal extends CalloutEngine
 	 */
 	public String amt (Properties ctx, int windowNo, GridTab gridTab, GridField gridField, Object value)
 	{
-		String colName = gridField.getColumnName();
 		if (value == null || isCalloutActive())
 			return "";
 

--- a/base/src/org/compiere/model/CalloutGLJournal.java
+++ b/base/src/org/compiere/model/CalloutGLJournal.java
@@ -26,6 +26,7 @@ import static org.adempiere.core.domains.models.X_C_Period.PERIODTYPE_Adjustment
 import static org.adempiere.core.domains.models.X_C_Period.PERIODTYPE_StandardCalendarPeriod;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.Timestamp;
 import java.util.Properties;
 
@@ -185,10 +186,10 @@ public class CalloutGLJournal extends CalloutEngine
 			amtSourceCr = Env.ZERO;
 
 		BigDecimal amtAcctDr = amtSourceDr.multiply(currencyRate);
-		amtAcctDr = amtAcctDr.setScale(precision, BigDecimal.ROUND_HALF_UP);
+		amtAcctDr = amtAcctDr.setScale(precision, RoundingMode.HALF_UP);
 		gridTab.setValue("AmtAcctDr", amtAcctDr);
 		BigDecimal amtAcctCr = amtSourceCr.multiply(currencyRate);
-		amtAcctCr = amtAcctCr.setScale(precision, BigDecimal.ROUND_HALF_UP);
+		amtAcctCr = amtAcctCr.setScale(precision, RoundingMode.HALF_UP);
 		gridTab.setValue("AmtAcctCr", amtAcctCr);
 
 		return "";


### PR DESCRIPTION
```
The field BigDecimal.ROUND_HALF_UP is deprecated since version 9
```


![imagen](https://github.com/adempiere/adempiere/assets/20288327/66764d23-8d2f-4bfa-8ae7-66abf337bd9a)
