### PR TITLE
fix: Remove warning `The constructor AWindow() is deprecated`.

### DIFF
--- a/client/src/de/schaeffer/compiere/tools/DocumentSearch.java
+++ b/client/src/de/schaeffer/compiere/tools/DocumentSearch.java
@@ -48,7 +48,7 @@ public class DocumentSearch extends AbstractDocumentSearch {
 	static CLogger log = CLogger.getCLogger(DocumentSearch.class);
 	@Override
 	protected boolean openWindow(int windowId, MQuery query) {
-		final AWindow frame = new AWindow();
+		final AWindow frame = new AWindow(null);
 		AEnv.addToWindowManager(frame);
 		if (frame.initWindow(windowId, query)) {
 			frame.pack();

--- a/client/src/org/compiere/apps/AEnv.java
+++ b/client/src/org/compiere/apps/AEnv.java
@@ -597,7 +597,7 @@ public final class AEnv
 		}
 		
 		log.config(TableName + " - Record_ID=" + Record_ID + " (IsSOTrx=" + isSOTrx + ")");
-		AWindow frame = new AWindow();
+		AWindow frame = new AWindow(null);
 		if (!frame.initWindow(AD_Window_ID, MQuery.getEqualQuery(TableName + "_ID", Record_ID)))
 			return;
 		addToWindowManager(frame);
@@ -655,7 +655,7 @@ public final class AEnv
 		}
 		
 		log.config(query + " (IsSOTrx=" + isSOTrx + ")");
-		AWindow frame = new AWindow();
+		AWindow frame = new AWindow(null);
 		if (!frame.initWindow(AD_Window_ID, query))
 			return;
 		addToWindowManager(frame);
@@ -806,7 +806,7 @@ public final class AEnv
 			query.addRestriction("Record_ID", MQuery.EQUAL, Record_ID);
 		}
 		//
-		AWindow frame = new AWindow();
+		AWindow frame = new AWindow(null);
 		if (!frame.initWindow(s_workflow_Window_ID, query))
 			return;
 		addToWindowManager(frame);

--- a/client/src/org/compiere/apps/AWindow.java
+++ b/client/src/org/compiere/apps/AWindow.java
@@ -48,15 +48,6 @@ public class AWindow extends CFrame
 	private static final long serialVersionUID = -1925388774073536474L;
 
 	/**
-	 *	@deprecated
-	 *	Standard Constructor - requires initWindow
-	 */
-	public AWindow ()
-	{
-		this(null);
-	}	//	AWindow
-	
-	/**
 	 *	Standard Constructor - requires initWindow
 	 *  @param gc
 	 */

--- a/client/src/org/compiere/apps/AZoomAcross.java
+++ b/client/src/org/compiere/apps/AZoomAcross.java
@@ -118,7 +118,7 @@ public class AZoomAcross
 		logger.info("AD_Window_ID=" + AD_Window_ID 
 			+ " - " + query); 
 		
-		AWindow frame = new AWindow();
+		AWindow frame = new AWindow(null);
 		if (!frame.initWindow(AD_Window_ID, query))
 			return;
 		AEnv.addToWindowManager(frame);

--- a/client/src/org/compiere/apps/form/VTrxMaterial.java
+++ b/client/src/org/compiere/apps/form/VTrxMaterial.java
@@ -286,7 +286,7 @@ public class VTrxMaterial extends TrxMaterial
 
 		//  Zoom
 		panel.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-		AWindow frame = new AWindow();
+		AWindow frame = new AWindow(null);
 		if (!frame.initWindow(AD_Window_ID, query))
 		{
 			panel.setCursor(Cursor.getDefaultCursor());

--- a/client/src/org/compiere/apps/search/Info.java
+++ b/client/src/org/compiere/apps/search/Info.java
@@ -1395,11 +1395,10 @@ public abstract class Info extends CDialog
 	 *  @param AD_Window_ID window id
 	 *  @param zoomQuery zoom query
 	 */
-	@SuppressWarnings("deprecation")
 	protected void zoom (int AD_Window_ID, MQuery zoomQuery)
 	{
 		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-		final AWindow frame = new AWindow();
+		final AWindow frame = new AWindow(null);
 		if (!frame.initWindow(AD_Window_ID, zoomQuery))
 			return;
 		AEnv.addToWindowManager(frame);

--- a/client/src/org/compiere/apps/wf/WFActivity.java
+++ b/client/src/org/compiere/apps/wf/WFActivity.java
@@ -680,7 +680,7 @@ public class WFActivity extends CPanel
 			//
 			log.info("Zoom to AD_Window_ID=" + AD_Window_ID 
 				+ " - " + query + " (IsSOTrx=" + IsSOTrx + ")");
-			AWindow frame = new AWindow();
+			AWindow frame = new AWindow(null);
 			if (!frame.initWindow(AD_Window_ID, query))
 				return;
 			AEnv.addToWindowManager(frame);

--- a/client/src/org/compiere/apps/wf/WFPanel.java
+++ b/client/src/org/compiere/apps/wf/WFPanel.java
@@ -501,7 +501,7 @@ public class WFPanel extends CPanel
 		MQuery query = null;
 		if (m_wf != null)
 			query = MQuery.getEqualQuery("AD_Workflow_ID", m_wf.getAD_Workflow_ID());
-		AWindow frame = new AWindow();
+		AWindow frame = new AWindow(null);
 		if (!frame.initWindow (m_WF_Window_ID, query))
 			return;
 		AEnv.addToWindowManager(frame);

--- a/client/src/org/compiere/grid/ed/VLocator.java
+++ b/client/src/org/compiere/grid/ed/VLocator.java
@@ -537,7 +537,7 @@ public class VLocator extends JComponent
 		log.info("");
 		//
 		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-		AWindow frame = new AWindow();
+		AWindow frame = new AWindow(null);
 		
 		MQuery zoomQuery = new MQuery();
 		zoomQuery.addRestriction(MLocator.COLUMNNAME_M_Locator_ID, MQuery.EQUAL, getValue());

--- a/client/src/org/compiere/grid/ed/VPAttributeDialog.java
+++ b/client/src/org/compiere/grid/ed/VPAttributeDialog.java
@@ -729,7 +729,7 @@ public class VPAttributeDialog extends CDialog
 		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 		//
 		int AD_Window_ID = MWindow.getWindow_ID("Lot");		//	Lot
-		AWindow frame = new AWindow();
+		AWindow frame = new AWindow(null);
 		if (frame.initWindow(AD_Window_ID, zoomQuery))
 		{
 			this.setVisible(false);

--- a/client/src/org/compiere/print/SwingViewerProvider.java
+++ b/client/src/org/compiere/print/SwingViewerProvider.java
@@ -31,7 +31,7 @@ import org.compiere.util.Env;
 public class SwingViewerProvider implements ReportViewerProvider {
 
 	public void openViewer(ReportEngine re) {
-		Viewer viewer = new Viewer(re);
+		Viewer viewer = new Viewer(null, re);
 		JFrame top = Env.getWindow(0);
 		if (top instanceof AMenu)
 			((AMenu)top).getWindowManager().add(viewer);

--- a/client/src/org/compiere/print/SwingViewerProvider.java
+++ b/client/src/org/compiere/print/SwingViewerProvider.java
@@ -31,7 +31,7 @@ import org.compiere.util.Env;
 public class SwingViewerProvider implements ReportViewerProvider {
 
 	public void openViewer(ReportEngine re) {
-		Viewer viewer = new Viewer(null, re);
+		Viewer viewer = new Viewer(re);
 		JFrame top = Env.getWindow(0);
 		if (top instanceof AMenu)
 			((AMenu)top).getWindowManager().add(viewer);

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VMRPDetailed.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VMRPDetailed.java
@@ -1231,7 +1231,7 @@ public class VMRPDetailed extends MRPDetailed implements FormPanel,
 	public void zoom(int AD_Window_ID, MQuery zoomQuery) {
 		panel.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 
-		final AWindow frame = new AWindow();
+		final AWindow frame = new AWindow(null);
 		if (!frame.initWindow(AD_Window_ID, zoomQuery))
 			return;
 

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/action/ZoomMenuAction.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/action/ZoomMenuAction.java
@@ -179,7 +179,7 @@ public class ZoomMenuAction extends PopupAction {
 		MQuery query = new MQuery();
 		query.setTableName(tablename);
 
-		AWindow window = new AWindow();
+		AWindow window = new AWindow(null);
 		if (window.initWindow(tableid, query)) {
 		
 			AEnv.showCenterScreen(window);


### PR DESCRIPTION
```
The constructor AWindow() is deprecated
```

![imagen](https://github.com/adempiere/adempiere/assets/20288327/d641e944-73f5-46aa-82f8-f465c05059d0)
