### PR TITLE
fix: Remove warning `The constructor Viewer(ReportEngine) is deprecated`.

### DIFF
--- a/client/src/org/compiere/print/SwingViewerProvider.java
+++ b/client/src/org/compiere/print/SwingViewerProvider.java
@@ -31,7 +31,7 @@ import org.compiere.util.Env;
 public class SwingViewerProvider implements ReportViewerProvider {
 
 	public void openViewer(ReportEngine re) {
-		Viewer viewer = new Viewer(re);
+		Viewer viewer = new Viewer(null, re);
 		JFrame top = Env.getWindow(0);
 		if (top instanceof AMenu)
 			((AMenu)top).getWindowManager().add(viewer);

--- a/client/src/org/compiere/print/Viewer.java
+++ b/client/src/org/compiere/print/Viewer.java
@@ -151,16 +151,6 @@ public class Viewer extends CFrame
 	private static final String HTML = "H";
 
 	/**
-	 * 	@deprecated
-	 *	Viewer Constructor
-	 *	@param re report engine
-	 */
-	public Viewer (ReportEngine re)
-	{
-		this(null, re);
-	}
-
-	/**
 	 *	Viewer Constructor
 	 *  @param gc
 	 *	@param re report engine

--- a/client/src/org/compiere/print/Viewer.java
+++ b/client/src/org/compiere/print/Viewer.java
@@ -1627,7 +1627,7 @@ public class Viewer extends CFrame
 	//	MPrintFormat f = new MPrintFormat(Env.getCtx(), 101);
 	//	ReportEngine re = new ReportEngine(f, null);
 
-		new Viewer(re);
+		new Viewer(null, re);
 	}	//	main
 
 }	//	Viewer

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VOrderDistributionReceipt.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VOrderDistributionReceipt.java
@@ -559,7 +559,7 @@ public class VOrderDistributionReceipt extends CPanel
 		             PrintInfo info = new PrintInfo(MMovement.Table_Name,MMovement.Table_ID, movement.getM_Movement_ID());               
 		             ReportEngine re = new ReportEngine(Env.getCtx(), format, query, info);
 		             re.print();
-                     new Viewer(re);
+					new Viewer(null, re);
 
              	//	Yamel Senih FR [ 114 ] 2015-11-23
 				ADialogDialog d = new ADialogDialog (m_frame.getCFrame(),

--- a/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VPrintDocument.java
+++ b/org.eevolution.manufacturing/src/main/java/ui/swing/org/eevolution/form/VPrintDocument.java
@@ -132,7 +132,7 @@ public class VPrintDocument implements IPrintDocument {
             PrintInfo info = new PrintInfo(document.get_TableName(), document.get_Table_ID(), document.get_ValueAsInt(keyColumnName));
             ReportEngine reportEngine = new ReportEngine(Env.getCtx(), format, query, info, document.get_TrxName());
             reportEngine.print();
-            new Viewer(reportEngine);
+			new Viewer(null, reportEngine);
         }
 	}
 }


### PR DESCRIPTION
```
The constructor Viewer(ReportEngine) is deprecated.
```

![imagen](https://github.com/adempiere/adempiere/assets/20288327/c715bce2-e56c-4815-b9b9-f1431bc55dc2)


