### PR TITLE
fix: Remove warning `The constructor FormFrame() is deprecated`.

### DIFF
--- a/client/src/org/compiere/apps/AArchive.java
+++ b/client/src/org/compiere/apps/AArchive.java
@@ -169,7 +169,7 @@ public class AArchive implements ActionListener
 	public void actionPerformed (ActionEvent e)
 	{
 		int AD_Form_ID = 118;	//	ArchiveViewer
-		FormFrame ff = new FormFrame(m_graphicsconfig);
+		FormFrame ff = new FormFrame(0);
 		ff.openForm(AD_Form_ID);
 		ArchiveViewer av = (ArchiveViewer)ff.getFormPanel();
 		//

--- a/client/src/org/compiere/apps/AMenuStartItem.java
+++ b/client/src/org/compiere/apps/AMenuStartItem.java
@@ -352,7 +352,7 @@ public class AMenuStartItem extends Thread implements ActionListener
 				return;
 			}
 		}
-		//ff = new FormFrame();
+		// ff = new FormFrame(0);
 		SwingUtilities.invokeLater(updateProgressBar);			//	1
 		ff 	= VBrowser.openBrowse(0 , AD_Browse_ID , "", isSOTrx);
 		ff.setVisible(true);

--- a/client/src/org/compiere/apps/form/FormFrame.java
+++ b/client/src/org/compiere/apps/form/FormFrame.java
@@ -71,16 +71,7 @@ import org.compiere.util.Trace;
 public class FormFrame
 	implements ActionListener 
 {
-	/**
-	 * @deprecated
-	 *	Create Form.
-	 *  Need to call openForm
-	 */
-	public FormFrame ()
-	{
-		this(0);
-	}	//	FormFrame
-	
+
 	/**
 	 *	Create Form.
 	 *  Need to call openForm
@@ -127,15 +118,6 @@ public class FormFrame
 	public FormFrame(CFrame frame) {
 		m_MainContent = frame;
 		p_AD_Form_ID = frame.getAD_Form_ID();
-	}
-	
-	/**
-	 * 
-	 * @param gc
-	 */
-	@Deprecated
-	public FormFrame(GraphicsConfiguration gc) {
-		this(0);
 	}
 
 	private ProcessInfo  m_pi;

--- a/client/src/org/compiere/apps/form/VAttributeGrid.java
+++ b/client/src/org/compiere/apps/form/VAttributeGrid.java
@@ -539,7 +539,7 @@ public class VAttributeGrid extends CPanel
 	{
 		Adempiere.startup(true);
 		Env.setContext(Env.getCtx(), "#AD_Client_ID", 11);
-		FormFrame ff = new FormFrame();
+		FormFrame ff = new FormFrame(0);
 		ff.openForm(1111, "org.compiere.apps.form.VAttributeGrid", "Attribute Table");
 		ff.pack();
 		AEnv.showCenterScreen(ff);

--- a/client/src/org/compiere/apps/form/VPaySelect.java
+++ b/client/src/org/compiere/apps/form/VPaySelect.java
@@ -570,7 +570,7 @@ public class VPaySelect extends PaySelect implements FormPanel, ActionListener, 
 
 		//  Start PayPrint
 		int AD_Form_ID = 106;	//	Payment Print/Export
-		FormFrame ff = new FormFrame();
+		FormFrame ff = new FormFrame(0);
 		ff.openForm (AD_Form_ID);
 		//	Set Parameter
 		if (m_ps != null)

--- a/client/src/org/compiere/apps/wf/WFActivity.java
+++ b/client/src/org/compiere/apps/wf/WFActivity.java
@@ -690,7 +690,7 @@ public class WFActivity extends CPanel
 		else if (MWFNode.ACTION_UserForm.equals(node.getAction()))
 		{
 			int AD_Form_ID = node.getAD_Form_ID();
-			FormFrame ff = new FormFrame();
+			FormFrame ff = new FormFrame(0);
 			ff.openForm(AD_Form_ID);
 			ff.pack();
 			AEnv.addToWindowManager(ff);

--- a/org.adempiere.pos/src/main/java/ui/swing/org/adempiere/pos/POSApplication.java
+++ b/org.adempiere.pos/src/main/java/ui/swing/org/adempiere/pos/POSApplication.java
@@ -49,7 +49,7 @@ public class POSApplication {
 	public POSApplication() {
 		Adempiere.startup(true);	//	needs to be here for UI
 		Splash splash = Splash.getSplash();
-		final FormFrame frame = new FormFrame(splash.getGraphicsConfiguration());
+		final FormFrame frame = new FormFrame(0);
 		//  Focus Traversal
 		KeyboardFocusManager.setCurrentKeyboardFocusManager(AKeyboardFocusManager.get());
 		


### PR DESCRIPTION
`The constructor FormFrame() is deprecated`

`The constructor FormFrame(GraphicsConfiguration) is deprecated`

![imagen](https://github.com/adempiere/adempiere/assets/20288327/c6b1670c-60b9-4f5c-8c2a-5bb53b5792bf)

