### PR TITLE
fix: Remove deprecated warning with `DB.prepareStatement` method.

### DIFF
--- a/base/src/org/compiere/util/DB.java
+++ b/base/src/org/compiere/util/DB.java
@@ -733,21 +733,6 @@ public final class DB
 	}	//	prepareCall
 
 
-	/**************************************************************************
-	 *	Prepare Statement
-	 *  @param sql
-	 *  @return Prepared Statement
-	 *  @deprecated
-	 */
-	public static CPreparedStatement prepareStatement (String sql)
-	{
-		int concurrency = ResultSet.CONCUR_READ_ONLY;
-		String upper = sql.toUpperCase();
-		if (upper.startsWith("UPDATE ") || upper.startsWith("DELETE "))
-			concurrency = ResultSet.CONCUR_UPDATABLE;
-		return prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, concurrency, null);
-	}	//	prepareStatement
-
 	/**
 	 *	Prepare Statement
 	 *  @param sql
@@ -761,20 +746,6 @@ public final class DB
 		if (upper.startsWith("UPDATE ") || upper.startsWith("DELETE "))
 			concurrency = ResultSet.CONCUR_UPDATABLE;
 		return prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, concurrency, trxName);
-	}	//	prepareStatement
-
-	/**
-	 *	Prepare Statement.
-	 *  @param sql sql statement
-	 *  @param resultSetType - ResultSet.TYPE_FORWARD_ONLY, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.TYPE_SCROLL_SENSITIVE
-	 *  @param resultSetConcurrency - ResultSet.CONCUR_READ_ONLY or ResultSet.CONCUR_UPDATABLE
-	 *  @return Prepared Statement r/o or r/w depending on concur
-	 *  @deprecated
-	 */
-	public static CPreparedStatement prepareStatement (String sql,
-		int resultSetType, int resultSetConcurrency)
-	{
-		return prepareStatement(sql, resultSetType, resultSetConcurrency, null);
 	}	//	prepareStatement
 
 	/**

--- a/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/ADLookup.java
+++ b/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/ADLookup.java
@@ -91,7 +91,7 @@ public class ADLookup {
 	 PreparedStatement pstmt = null;
 	 ResultSet rs = null;
 	 try  {
-		pstmt = DB.prepareStatement( info.getSQL() );
+			pstmt = DB.prepareStatement(info.getSQL(), null);
 		info.setParameters( pstmt, false );
 		rs = pstmt.executeQuery();
 		while (rs.next())
@@ -323,7 +323,7 @@ public class ADLookup {
 				ResultSet rs = null;
 				try
 				{
-					pstmt = DB.prepareStatement(query);
+					pstmt = DB.prepareStatement(query, null);
 					pstmt.setInt(1, AD_Reference_ID);
 					rs = pstmt.executeQuery();
 					if (rs.next())
@@ -386,7 +386,7 @@ public class ADLookup {
 		ResultSet rs = null;
 		try
 		{
-			pstmt = DB.prepareStatement(query);
+			pstmt = DB.prepareStatement(query, null);
 			pstmt.setString(1, m_keyColumnName);
 			rs = pstmt.executeQuery();
 			while (rs.next())

--- a/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/Process.java
+++ b/org.adempiere.webservice/WEB-INF/src/com/_3e/ADInterface/Process.java
@@ -510,7 +510,7 @@ public class Process {
 				+ " AND l.AD_Reference_ID=135 ORDER BY t.Name";
 		try
 		{
-			PreparedStatement pstmt = DB.prepareStatement(sql);
+			PreparedStatement pstmt = DB.prepareStatement(sql, null);
 			ResultSet rs = pstmt.executeQuery();
 			while (rs.next())
 			{

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportInfo.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportInfo.java
@@ -179,7 +179,7 @@ public class ReportInfo
         ResultSet rs = null;
         try
         {
-            pstmt = DB.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+			pstmt = DB.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY, null);
             pstmt.setInt(1, AD_Process_ID);
             rs = pstmt.executeQuery();
             String path = null;

--- a/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/WWorkflow.java
+++ b/org.compiere.mobile/WEB-INF/src/org/compiere/mobile/WWorkflow.java
@@ -855,7 +855,7 @@ private int getAD_Workflow_ID(int AD_Menu_ID){
 				+ "WHERE AD_Menu_ID=? AND Action='F'";
 			try
 			{
-				PreparedStatement pstmt = DB.prepareStatement(sql);
+			PreparedStatement pstmt = DB.prepareStatement(sql, null);
 				pstmt.setInt(1, AD_Menu_ID);
 				ResultSet rs = pstmt.executeQuery();
 				while (rs.next())

--- a/serverApps/src/main/servlet/org/compiere/www/WWorkflow.java
+++ b/serverApps/src/main/servlet/org/compiere/www/WWorkflow.java
@@ -859,7 +859,7 @@ private int getAD_Workflow_ID(int AD_Menu_ID){
 				+ "WHERE AD_Menu_ID=? AND Action='F'";
 			try
 			{
-				PreparedStatement pstmt = DB.prepareStatement(sql);
+			PreparedStatement pstmt = DB.prepareStatement(sql, null);
 				pstmt.setInt(1, AD_Menu_ID);
 				ResultSet rs = pstmt.executeQuery();
 				while (rs.next())


### PR DESCRIPTION
```log
The method prepareStatement(String, int, int) from the type DB is deprecated
```

```log
The method prepareStatement(String) from the type DB is deprecated
```
![prepareStatement deprecated](https://github.com/adempiere/adempiere/assets/20288327/ba07da0c-e84a-45ab-bbac-4a47245c260e)
