### PR TITLE
fix: #4174 NPE with preview Jasper Report on `Swing` UI.

### DIFF
--- a/JasperReports/src/org/compiere/jr/report/ReportStarter.java
+++ b/JasperReports/src/org/compiere/jr/report/ReportStarter.java
@@ -667,7 +667,6 @@ public class ReportStarter implements ProcessCall, ClientProcess
 						File PDF = File.createTempFile("mail", ".pdf");
 						JasperExportManager.exportReportToPdfFile(jasperPrint, PDF.getAbsolutePath());
 						processInfo.setPDFReport(PDF);
-						processInfo.setPrintPreview(true);
 						if (processInfo.isPrintPreview()) {
 							log.info("ReportStarter.startProcess run report -" + jasperPrint.getName());
 							JRViewerProvider viewerLauncher = getReportViewerProvider();

--- a/JasperReports/src/org/compiere/jr/report/ReportStarter.java
+++ b/JasperReports/src/org/compiere/jr/report/ReportStarter.java
@@ -667,6 +667,7 @@ public class ReportStarter implements ProcessCall, ClientProcess
 						File PDF = File.createTempFile("mail", ".pdf");
 						JasperExportManager.exportReportToPdfFile(jasperPrint, PDF.getAbsolutePath());
 						processInfo.setPDFReport(PDF);
+						processInfo.setPrintPreview(true);
 						if (processInfo.isPrintPreview()) {
 							log.info("ReportStarter.startProcess run report -" + jasperPrint.getName());
 							JRViewerProvider viewerLauncher = getReportViewerProvider();

--- a/base/src/org/adempiere/util/ProcessUtil.java
+++ b/base/src/org/adempiere/util/ProcessUtil.java
@@ -155,6 +155,10 @@ public final class ProcessUtil {
 		
 		//Get Process
 		ProcessCall process = null;
+		if (processClass == null) {
+			pi.setSummary("No Instance for " + pi.getClassName(), true);
+			return false;
+		}
 		try
 		{
 			process = (ProcessCall) processClass.getDeclaredConstructor().newInstance();

--- a/base/src/org/adempiere/util/ProcessUtil.java
+++ b/base/src/org/adempiere/util/ProcessUtil.java
@@ -31,6 +31,10 @@ import org.compiere.wf.MWorkflow;
  * 				<li>BF [ 2530847 ] Report is displayed even if java process fails
  * @author Victor Pérez, E Evolution Consulting,  wwww.e-evolution.com
  * 				<li>[Bug Report] The workflow engine is not correctly handling transactions when processing documents #3170
+ *
+ * 	@author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
+ * 		@see <a href="https://github.com/adempiere/adempiere/issues/4174">
+ * 		BR [ 4174 ] Swing client does not generate jasper reports.</a>
  */
 public final class ProcessUtil {
 
@@ -127,9 +131,11 @@ public final class ProcessUtil {
 		String className = pi.getClassName();
 		if (className == null) {
 			MProcess proc = new MProcess(ctx, pi.getAD_Process_ID(), trx.getTrxName());
-			if (proc.getJasperReport() != null)
+			if (proc.getJasperReport() != null) {
 				className = JASPER_STARTER_CLASS;
+			}
 		}
+
 		//Get Class
 		Class<?> processClass = null;
 		//use context classloader if available
@@ -151,17 +157,12 @@ public final class ProcessUtil {
 		ProcessCall process = null;
 		try
 		{
-			process = (ProcessCall)processClass.newInstance();
+			process = (ProcessCall) processClass.getDeclaredConstructor().newInstance();
 		}
 		catch (Exception ex)
 		{
 			log.log(Level.WARNING, "Instance for " + className, ex);
 			pi.setSummary ("InstanceError", true);
-			return false;
-		}
-		
-		if (processClass == null) {
-			pi.setSummary("No Instance for " + pi.getClassName(), true);
 			return false;
 		}
 		

--- a/base/src/org/compiere/print/ReportViewerProvider.java
+++ b/base/src/org/compiere/print/ReportViewerProvider.java
@@ -23,6 +23,10 @@ import java.io.FileInputStream;
  * 
  * @author Low Heng Sin
  *
+ * 	@author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
+ * 		@see <a href="https://github.com/adempiere/adempiere/issues/4174">
+ * 		BR [ 4174 ] Swing client does not generate jasper reports.</a>
+ *
  */
 public interface ReportViewerProvider {
 	public void openViewer(ReportEngine re);

--- a/client/src/org/adempiere/Adempiere.java
+++ b/client/src/org/adempiere/Adempiere.java
@@ -195,7 +195,8 @@ public final class Adempiere
 		if (s_ImplementationVendor != null)
 			return;
 
-		Package adempierePackage = Package.getPackage("org.adempiere");
+		Class<?> clazz = Adempiere.class;
+		Package adempierePackage = clazz.getPackage();
 		if (adempierePackage != null) {
 			s_ImplementationVendor = adempierePackage.getImplementationVendor();
 			s_ImplementationVersion = adempierePackage.getImplementationVersion();

--- a/client/src/org/adempiere/Adempiere.java
+++ b/client/src/org/adempiere/Adempiere.java
@@ -32,9 +32,13 @@ import javax.swing.ImageIcon;
 
 import org.compiere.db.CConnection;
 import org.compiere.db.CConnectionDialog;
+import org.compiere.jr.report.ReportStarter;
+import org.compiere.jr.report.SwingJRViewerProvider;
 import org.compiere.model.MClient;
 import org.compiere.model.MSystem;
 import org.compiere.model.ModelValidationEngine;
+import org.compiere.print.ReportCtl;
+import org.compiere.print.SwingViewerProvider;
 import org.compiere.util.CLogFile;
 import org.compiere.util.CLogMgt;
 import org.compiere.util.CLogger;
@@ -52,12 +56,16 @@ import org.compiere.util.Util;
  *
  *  @author Jorg Janke
  *  @version $Id: Adempiere.java,v 1.8 2006/08/11 02:58:14 jjanke Exp $
- *  @athor Yamel Senih, ysenih@erpcya.com, ERPCyA http://www.erpcya.com
+ *  @author Yamel Senih, ysenih@erpcya.com, ERPCyA http://www.erpcya.com
  *		<li> FR [ 379 ] Change URL in About
  *		@see https://github.com/adempiere/adempiere/issues/379
  *		<a href="https://github.com/adempiere/adempiere/issues/1208">
  * 		@see FR [ 1208 ] Look and Feel Correction - Print footer</a>
- *  
+ *
+ * 	@author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
+ * 		@see <a href="https://github.com/adempiere/adempiere/issues/4174">
+ * 		BR [ 4174 ] Swing client does not generate jasper reports.</a>
+ *
  */
 public final class Adempiere
 {
@@ -187,7 +195,8 @@ public final class Adempiere
 		if (s_ImplementationVendor != null)
 			return;
 
-		Package adempierePackage = Package.getPackage("org.adempiere");
+		Class<?> clazz = Adempiere.class;
+		Package adempierePackage = clazz.getPackage();
 		if (adempierePackage != null) {
 			s_ImplementationVendor = adempierePackage.getImplementationVendor();
 			s_ImplementationVersion = adempierePackage.getImplementationVersion();
@@ -516,6 +525,12 @@ public final class Adempiere
 		//	Set UI
 		if (isClient)
 		{
+			ReportCtl.setReportViewerProvider(
+				new SwingViewerProvider()
+			);
+			ReportStarter.setReportViewerProvider(
+				new SwingJRViewerProvider()
+			);
 			if (CLogMgt.isLevelAll())
 				log.log(Level.FINEST, System.getProperties().toString());			
 		}
@@ -648,7 +663,7 @@ public final class Adempiere
 		try
 		{
 			Class<?> startClass = Class.forName(className);
-			startClass.newInstance();
+			startClass.getDeclaredConstructor().newInstance();
 		}
 		catch (Exception e)
 		{

--- a/client/src/org/adempiere/Adempiere.java
+++ b/client/src/org/adempiere/Adempiere.java
@@ -195,8 +195,7 @@ public final class Adempiere
 		if (s_ImplementationVendor != null)
 			return;
 
-		Class<?> clazz = Adempiere.class;
-		Package adempierePackage = clazz.getPackage();
+		Package adempierePackage = Package.getPackage("org.adempiere");
 		if (adempierePackage != null) {
 			s_ImplementationVendor = adempierePackage.getImplementationVendor();
 			s_ImplementationVersion = adempierePackage.getImplementationVersion();

--- a/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportProcessor.java
+++ b/org.adempiere.webservice/WEB-INF/src/net/sf/compilo/report/ReportProcessor.java
@@ -49,6 +49,11 @@ import org.compiere.util.Language;
  * 	@author 	Peter Shen
  * 	@version 	$Id: ReportProcessor.java,v 1.7 2005/09/03 04:09:51 pshen Exp $
  *	@description:	report server
+ *
+ * 	@author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
+ * 		@see <a href="https://github.com/adempiere/adempiere/issues/4174">
+ * 		BR [ 4174 ] Swing client does not generate jasper reports.</a>
+ *
  */
 public class ReportProcessor
 {
@@ -138,9 +143,9 @@ public class ReportProcessor
 		
         return m_jasperPrint;
 	}// runReport   
- 
-    
-    private void addProcessParameters( int AD_PInstance_ID, Map params) 
+
+
+	private void addProcessParameters(int AD_PInstance_ID, Map<String, Object> params)
     {
         log.finest("ReportStarter.addProcessParameters");
         MPInstance pinstance = new MPInstance(m_ctx, AD_PInstance_ID, null);
@@ -260,7 +265,7 @@ public class ReportProcessor
     private int m_AD_PInstance_ID = 0;
     private int m_AD_Process_ID = 0;
     private int m_Record_ID = 0;
-    private boolean m_isPrint = false;
+	// private boolean m_isPrint = false;
     private HashMap<String, Object> m_Param = null;
     private Properties m_ctx = null;   
     private JasperPrint m_jasperPrint = null;


### PR DESCRIPTION
- Fix NPE Jasper Report.
- Remove deprecated `JRPrintServiceExporter.setParameter`.
- Change deprecated `class.newInstance()` to `class.getDeclaredConstructor().newInstance()`.
- Move `ReportViewerProvider` class from `client/src/org/compiere/print` to `base/src/org/compiere/print`


https://github.com/adempiere/adempiere/assets/20288327/c43cdbbc-223c-45be-a183-1a7e06c74262

#### Additional context
fixes https://github.com/adempiere/adempiere/issues/4174