### PR TITLE
Fixed error with sequence when a PO is generated from requisition

### DIFF
--- a/base/src/org/compiere/process/RequisitionPOCreate.java
+++ b/base/src/org/compiere/process/RequisitionPOCreate.java
@@ -298,7 +298,11 @@ public class RequisitionPOCreate extends RequisitionPOCreateAbstract
 			purchaseOrder.setM_Warehouse_ID(requisitionLine.getParent().getM_Warehouse_ID());
 			purchaseOrder.setDatePromised(dateRequired);
 			purchaseOrder.setIsSOTrx(false);
-			purchaseOrder.setC_DocTypeTarget_ID();
+			if(getDocTypeId() > 0) {
+				purchaseOrder.setC_DocTypeTarget_ID(getDocTypeId());
+			} else {
+				purchaseOrder.setC_DocTypeTarget_ID();
+			}
 			purchaseOrder.setBPartner(businessPartner);
 			purchaseOrder.setM_PriceList_ID(priceListId);
 			//	default po document type
@@ -415,7 +419,9 @@ public class RequisitionPOCreate extends RequisitionPOCreateAbstract
 			purcaseOrderLine.setPriceActual(requisitionLine.getPriceActual());
 		}
 		purcaseOrderLine.setAD_Org_ID(requisitionLine.getAD_Org_ID());
-				
+		if(requisitionLine.getC_Tax_ID() > 0) {
+			purcaseOrderLine.setC_Tax_ID(requisitionLine.getC_Tax_ID());
+		}
 		
 		//	Prepare Save
 		productId = requisitionLine.getM_Product_ID();

--- a/base/src/org/compiere/process/RequisitionPOCreateAbstract.java
+++ b/base/src/org/compiere/process/RequisitionPOCreateAbstract.java
@@ -3,7 +3,7 @@
  * Copyright (C) 2006-2017 ADempiere Foundation, All Rights Reserved.         *
  * This program is free software, you can redistribute it and/or modify it    *
  * under the terms version 2 of the GNU General Public License as published   *
- * or (at your option) any later version.										*
+ * or (at your option) any later version.                                     *
  * by the Free Software Foundation. This program is distributed in the hope   *
  * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
  * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
@@ -12,7 +12,8 @@
  * with this program, if not, write to the Free Software Foundation, Inc.,    *
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
  * For the text or an alternative of this public license, you may reach us    *
- * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ * or via info@adempiere.net                                                  *
+ * or https://github.com/adempiere/adempiere/blob/develop/license.html        *
  *****************************************************************************/
 
 package org.compiere.process;
@@ -21,7 +22,7 @@ import java.sql.Timestamp;
 
 /** Generated Process for (Create PO from Requisition)
  *  @author ADempiere (generated) 
- *  @version Release 3.9.0
+ *  @version Release 3.9.5
  */
 public abstract class RequisitionPOCreateAbstract extends SvrProcess {
 	/** Process Value 	*/
@@ -52,6 +53,8 @@ public abstract class RequisitionPOCreateAbstract extends SvrProcess {
 	public static final String C_BP_GROUP_ID = "C_BP_Group_ID";
 	/**	Parameter Name for Consolidate to one Document	*/
 	public static final String CONSOLIDATEDOCUMENT = "ConsolidateDocument";
+	/**	Parameter Name for Document Type	*/
+	public static final String C_DOCTYPE_ID = "C_DocType_ID";
 	/**	Parameter Value for Requisition	*/
 	private int requisitionId;
 	/**	Parameter Value for Organization	*/
@@ -78,6 +81,8 @@ public abstract class RequisitionPOCreateAbstract extends SvrProcess {
 	private int bPGroupId;
 	/**	Parameter Value for Consolidate to one Document	*/
 	private boolean isConsolidateDocument;
+	/**	Parameter Value for Document Type	*/
+	private int docTypeId;
 
 	@Override
 	protected void prepare() {
@@ -94,6 +99,7 @@ public abstract class RequisitionPOCreateAbstract extends SvrProcess {
 		productCategoryId = getParameterAsInt(M_PRODUCT_CATEGORY_ID);
 		bPGroupId = getParameterAsInt(C_BP_GROUP_ID);
 		isConsolidateDocument = getParameterAsBoolean(CONSOLIDATEDOCUMENT);
+		docTypeId = getParameterAsInt(C_DOCTYPE_ID);
 	}
 
 	/**	 Getter Parameter Value for Requisition	*/
@@ -224,6 +230,16 @@ public abstract class RequisitionPOCreateAbstract extends SvrProcess {
 	/**	 Setter Parameter Value for Consolidate to one Document	*/
 	protected void setConsolidateDocument(boolean isConsolidateDocument) {
 		this.isConsolidateDocument = isConsolidateDocument;
+	}
+
+	/**	 Getter Parameter Value for Document Type	*/
+	protected int getDocTypeId() {
+		return docTypeId;
+	}
+
+	/**	 Setter Parameter Value for Document Type	*/
+	protected void setDocTypeId(int docTypeId) {
+		this.docTypeId = docTypeId;
 	}
 
 	/**	 Getter Parameter Value for Process ID	*/

--- a/base/src/org/eevolution/process/CreatePOFromRequisitionLines.java
+++ b/base/src/org/eevolution/process/CreatePOFromRequisitionLines.java
@@ -62,6 +62,7 @@ public class CreatePOFromRequisitionLines extends CreatePOFromRequisitionLinesAb
                 .process(RequisitionPOCreate.getProcessId()).withTitle(RequisitionPOCreate.getProcessName())
                 .withSelectedRecordsIds(MRequisitionLine.Table_ID, getSelectionKeys())
                 .withParameter(RequisitionPOCreate.CONSOLIDATEDOCUMENT, isConsolidateDocument())
+                .withParameter(RequisitionPOCreate.C_DOCTYPE_ID, getDocTypeId())
                 .withoutTransactionClose()
                 .execute(get_TrxName());
 

--- a/migration/394lts-395lts/10320_Add_Document_Type_for_Requisition_PO_Create.xml
+++ b/migration/394lts-395lts/10320_Add_Document_Type_for_Requisition_PO_Create.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add Document Type for Requisition PO Create" ReleaseNo="3.9.5" SeqNo="10320">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="285" Action="I" Record_ID="59008" Table="AD_Process_Para">
+        <Data AD_Column_ID="3740" Column="VFormat" isNewNull="true"/>
+        <Data AD_Column_ID="3741" Column="ValueMin" isNewNull="true"/>
+        <Data AD_Column_ID="3742" Column="ValueMax" isNewNull="true"/>
+        <Data AD_Column_ID="84385" Column="UUID">6bd56b96-0dff-4b89-9581-3b82eb6d4836</Data>
+        <Data AD_Column_ID="2821" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2820" Column="Updated">2023-10-04 11:11:06.289</Data>
+        <Data AD_Column_ID="2826" Column="SeqNo">120</Data>
+        <Data AD_Column_ID="56299" Column="ReadOnlyLogic" isNewNull="true"/>
+        <Data AD_Column_ID="2822" Column="Name">Document Type</Data>
+        <Data AD_Column_ID="2830" Column="IsRange">false</Data>
+        <Data AD_Column_ID="3738" Column="IsMandatory">false</Data>
+        <Data AD_Column_ID="81287" Column="IsInfoOnly">false</Data>
+        <Data AD_Column_ID="5819" Column="IsCentrallyMaintained">true</Data>
+        <Data AD_Column_ID="2817" Column="IsActive">true</Data>
+        <Data AD_Column_ID="2824" Column="Help">The Document Type determines document sequence and processing rules</Data>
+        <Data AD_Column_ID="3737" Column="FieldLength">22</Data>
+        <Data AD_Column_ID="7728" Column="EntityType">D</Data>
+        <Data AD_Column_ID="56300" Column="DisplayLogic" isNewNull="true"/>
+        <Data AD_Column_ID="2823" Column="Description">Document type or rules</Data>
+        <Data AD_Column_ID="5593" Column="DefaultValue2" isNewNull="true"/>
+        <Data AD_Column_ID="3739" Column="DefaultValue">-1</Data>
+        <Data AD_Column_ID="2819" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2818" Column="Created">2023-10-04 11:11:06.288</Data>
+        <Data AD_Column_ID="4017" Column="ColumnName">C_DocType_ID</Data>
+        <Data AD_Column_ID="3736" Column="AD_Val_Rule_ID">206</Data>
+        <Data AD_Column_ID="2828" Column="AD_Reference_Value_ID" isNewNull="true"/>
+        <Data AD_Column_ID="2827" Column="AD_Reference_ID">19</Data>
+        <Data AD_Column_ID="2814" Column="AD_Process_Para_ID">59008</Data>
+        <Data AD_Column_ID="2825" Column="AD_Process_ID">337</Data>
+        <Data AD_Column_ID="2816" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="7729" Column="AD_Element_ID">196</Data>
+        <Data AD_Column_ID="2815" Column="AD_Client_ID">0</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="286" Action="I" Record_ID="0" Table="AD_Process_Para_Trl">
+        <Data AD_Column_ID="84386" Column="UUID">4191ae8e-4ee5-4939-bf6e-e244fa85a128</Data>
+        <Data AD_Column_ID="2839" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="2838" Column="Updated">2023-10-04 11:11:07.447</Data>
+        <Data AD_Column_ID="2840" Column="Name">Document Type</Data>
+        <Data AD_Column_ID="2842" Column="IsTranslated">false</Data>
+        <Data AD_Column_ID="2835" Column="IsActive">true</Data>
+        <Data AD_Column_ID="3743" Column="Help">The Document Type determines document sequence and processing rules</Data>
+        <Data AD_Column_ID="2841" Column="Description">Document type or rules</Data>
+        <Data AD_Column_ID="2837" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="2836" Column="Created">2023-10-04 11:11:07.447</Data>
+        <Data AD_Column_ID="2831" Column="AD_Process_Para_ID">59008</Data>
+        <Data AD_Column_ID="2834" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="2832" Column="AD_Language">es_MX</Data>
+        <Data AD_Column_ID="2833" Column="AD_Client_ID">0</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/tools/launchers/ModelClassGenerator.launch
+++ b/tools/launchers/ModelClassGenerator.launch
@@ -1,18 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/adempiere/base/src/org/adempiere/util/ModelClassGenerator.java"/>
-</listAttribute>
-<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-<listEntry value="1"/>
-</listAttribute>
-<booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
-<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
-<listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
-<listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
-</listAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.adempiere.util.ModelClassGenerator"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="${workspace_loc:base}/src/org/compiere/model/&#13;&#10;org.compiere.model&#13;&#10;&quot;'D', 'U', 'A', 'C'&quot;"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="adempiere"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-DPropertyFile=${workspace_loc}/adempiere/Adempiere/Adempiere.properties"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/adempiere/base/src/org/adempiere/util/GenerateModel.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
+    <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+        <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
+        <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.adempiere.util.GenerateModel"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="adempiere"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="/opt/Development/workspace-erpya/adempiere/base/src/org/adempiere/core/domains/models&#13;&#10;org.adempiere.core.domains.models&#13;&#10;&quot;'D', 'U', 'A', 'C'&quot;&#10;&quot;'I_Requisition'&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="adempiere"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-DPropertyFile=${workspace_loc}/adempiere/adempiere/Adempiere/Adempiere.properties"/>
 </launchConfiguration>


### PR DESCRIPTION
## What is the problem?
When a Purchase order is generated from a requisition using the smart browser `Requisition-to-Invoice` -> `Browser Requisition to Create PO from Requisition Lines`, the document type selected is setted but the sequence is wrong.

## What is the reason?
The smart browser never send the document type to process and the standard process for generate Purchases don't have support to document type.

## What is the change?
This pull request add a new parameter to process `Requisition-to-Invoice` -> `Create PO from Requisition` to add support to document type.

## Step for Step

- Create a new Requisition
- Go to Smart Browser `Requisition-to-Invoice` -> `Browser Requisition to Create PO from Requisition Lines`
- Select a Document Type distinct to default document type of PO
- Process it

Note that after process, the document type inside order is the selected but the **Document No** for Purchase Order is the sequence of default document type instead the sequence of selected document type