### PR TITLE
fix: #4183 Chartdatasource and table without keys.

### DIFF
--- a/base/src/org/compiere/model/MChartDatasource.java
+++ b/base/src/org/compiere/model/MChartDatasource.java
@@ -23,6 +23,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Level;
 
@@ -198,9 +199,10 @@ public class MChartDatasource extends X_AD_ChartDatasource {
 					else if ( parent.getTimeUnit().equals(MChart.TIMEUNIT_Year))
 						period = new Year(date);
 
-					if (period != null) {
-						tseries.add(period, rs.getBigDecimal(1));
-						key = period.toString();
+					Optional<RegularTimePeriod> maybePeriod = Optional.ofNullable(period);
+					if(maybePeriod.isPresent()) {
+						tseries.add(maybePeriod.get(), rs.getBigDecimal(1));
+						key = maybePeriod.get().toString();
 					}
 					queryWhere += DB.TO_DATE(new Timestamp(date.getTime()));
 				}
@@ -211,7 +213,7 @@ public class MChartDatasource extends X_AD_ChartDatasource {
 				MQuery query = new MQuery(getAD_Table_ID());
 				MTable table = MTable.get(getCtx(), getAD_Table_ID());
 				String[] keyColumns = table.getKeyColumns();
-				if (keyColumns != null && keyColumns.length > 0) {
+				if (Optional.ofNullable(keyColumns).isPresent() && keyColumns.length > 0) {
 					String keyCol = keyColumns[0];
 					String whereClause = keyCol  + " IN (SELECT " + getKeyColumn()
 						+ " FROM " + getFromClause()

--- a/base/src/org/compiere/model/MChartDatasource.java
+++ b/base/src/org/compiere/model/MChartDatasource.java
@@ -47,7 +47,7 @@ import org.jfree.data.time.Year;
  * Chart Datasource model.
  *
  * 	@author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
- * 		@see <a href="https://github.com/adempiere/adempiere/issues/4176">
+ * 		@see <a href="https://github.com/adempiere/adempiere/issues/4183">
  * 		BR [ 4183 ] Does not start the swing ui for a chart datasource if the table has no keys.</a>
  */
 public class MChartDatasource extends X_AD_ChartDatasource {

--- a/base/src/org/compiere/model/MChartDatasource.java
+++ b/base/src/org/compiere/model/MChartDatasource.java
@@ -275,7 +275,7 @@ public class MChartDatasource extends X_AD_ChartDatasource {
 		return cal.getTime();
 	}
 
-	public String formatDate(Date date, String timeUnit)
+	public static String formatDate(Date date, String timeUnit)
 	{
 		String key = null;
 		String unitFormat = "yyyy-MM-dd";
@@ -289,9 +289,9 @@ public class MChartDatasource extends X_AD_ChartDatasource {
 					unitFormat = "yyyy";
 		 SimpleDateFormat format = new SimpleDateFormat(unitFormat);
 		 key = format.format(date);
-		 if ( timeUnit.equals(MChart.TIMEUNIT_Quarter) )
-			 key = convertToQuarter(format.format(date));
-		 
+		if (timeUnit.equals(MChart.TIMEUNIT_Quarter)) {
+			key = convertToQuarter(format.format(date));
+		}
 		 return key;
 	}
 	
@@ -300,7 +300,7 @@ public class MChartDatasource extends X_AD_ChartDatasource {
 	 * @param month
 	 * @return
 	 */
-	private String convertToQuarter(String month) {
+	public static String convertToQuarter(String month) {
 		if ( month.length() != 7 )
 			return month;
 		


### PR DESCRIPTION
#### Before this changes:

https://github.com/adempiere/adempiere/assets/20288327/984b4d5e-3dce-4341-b195-67a722ab2edd

#### After this changes:

https://github.com/adempiere/adempiere/assets/20288327/4abb7ba5-93a5-4ed1-9a1d-d374893a6fa0


#### Additional context
fixes https://github.com/adempiere/adempiere/issues/4183


Additionally:
- `period` variable is evaluated by `NPE` potential.

![imagen](https://github.com/adempiere/adempiere/assets/20288327/303ad1a4-c229-47e6-915d-add80c468568)

- Changed the visibility of the `formatDate` and `convertToQuarter` methods to public and static since they are not used inside the class.
![imagen](https://github.com/adempiere/adempiere/assets/20288327/2dfdc7b7-936a-4d27-99f7-6c1199f163c0)
