### PR TITLE
Fixed error with size of `HR_Employee.Code`

### DIFF
--- a/migration/394lts-395lts/09990_Fix_Lenght_for_Employee_Validation_Code.xml
+++ b/migration/394lts-395lts/09990_Fix_Lenght_for_Employee_Validation_Code.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Fix Lenght for Employee Validation Code" ReleaseNo="3.9.5" SeqNo="9990">
+    <Step DBType="Postgres" Parse="N" SeqNo="10" StepType="SQL">
+      <SQLStatement>INSERT INTO t_alter_column values('hr_employee','Code','VARCHAR(255)',null,'NULL')
+;</SQLStatement>
+      <RollbackStatement>INSERT INTO t_alter_column values('hr_employee','Code','VARCHAR(1)',null,'NULL')
+;</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="N" SeqNo="20" StepType="SQL">
+      <SQLStatement>ALTER TABLE HR_Employee MODIFY Code NVARCHAR2(255) DEFAULT NULL
+;</SQLStatement>
+      <RollbackStatement>ALTER TABLE HR_Employee MODIFY Code NVARCHAR2(1) DEFAULT NULL
+;</RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
The column `HR_Employee.Code` has a size of `255` but the real size from database is `1`. If you want save a record with a code like `E5454` he database throw a error.
![Screenshot from 2023-11-06 19-34-11](https://github.com/adempiere/adempiere/assets/2333092/ca8d8760-efca-40ca-a9c1-059ea1537065)
`\d+ HR_Employee`
                                                         Table "adempiere.hr_employee"

Column | Type | Collation | Nullable | Default | Storage | Stats target | Description
-- | -- | -- | -- | -- | -- | -- | --
code | character varying(1) |   |   |   | extended |   |  