### PR TITLE
Bugfix/#4188 badly formatted end of line in files

### DIFF
--- a/base/src/org/adempiere/model/ExportModelValidator.java
+++ b/base/src/org/adempiere/model/ExportModelValidator.java
@@ -61,6 +61,9 @@ import java.util.Properties;
  * <li> https://sourceforge.net/tracker/?func=detail&aid=3014094&group_id=176962&atid=879335
  *	@author Yamel Senih, ySenih@erpya.com, ERPCyA http://www.erpya.com
  *	<li> Add support to validate error fromreplication strategy
+ * @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  *	@version $Id$
  */
 public class ExportModelValidator implements ModelValidator {

--- a/base/src/org/adempiere/pipo/AbstractElementHandler.java
+++ b/base/src/org/adempiere/pipo/AbstractElementHandler.java
@@ -13,7 +13,12 @@
  *                                                                            *
  * Copyright (C) 2005 Robert Klein. robeklein@hotmail.com                     * 
  * Contributor(s): Low Heng Sin hengsin@avantz.com                            *
- *****************************************************************************/
+ * ****************************************************************************
+ *
+ * @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
+ */
 package org.adempiere.pipo;
 
 import java.io.FileInputStream;

--- a/base/src/org/compiere/acct/Doc_Order.java
+++ b/base/src/org/compiere/acct/Doc_Order.java
@@ -47,6 +47,9 @@ import org.compiere.util.Env;
  *  </pre>
  *  @author Jorg Janke
  *  @version  $Id: Doc_Order.java,v 1.3 2006/07/30 00:53:33 jjanke Exp $
+ * @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class Doc_Order extends Doc
 {

--- a/base/src/org/compiere/acct/Doc_Order.java
+++ b/base/src/org/compiere/acct/Doc_Order.java
@@ -47,7 +47,7 @@ import org.compiere.util.Env;
  *  </pre>
  *  @author Jorg Janke
  *  @version  $Id: Doc_Order.java,v 1.3 2006/07/30 00:53:33 jjanke Exp $
- * @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
  *		<a href="https://github.com/adempiere/adempiere/issues/4188">
  * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */

--- a/base/src/org/compiere/db/DBRes_hu.java
+++ b/base/src/org/compiere/db/DBRes_hu.java
@@ -23,6 +23,9 @@ import java.util.ListResourceBundle;
  *
  *  @author     Jorg Janke
  *  @version    $Id: DBRes.java,v 1.2 2006/07/30 00:55:13 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class DBRes_hu extends ListResourceBundle
 {

--- a/base/src/org/compiere/model/CalloutInvoice.java
+++ b/base/src/org/compiere/model/CalloutInvoice.java
@@ -35,6 +35,9 @@ import org.compiere.util.Env;
  *	
  *  @author Jorg Janke
  *  @version $Id: CalloutInvoice.java,v 1.4 2006/07/30 00:51:03 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class CalloutInvoice extends CalloutEngine
 {

--- a/base/src/org/compiere/model/CalloutOrder.java
+++ b/base/src/org/compiere/model/CalloutOrder.java
@@ -45,6 +45,9 @@ import java.util.logging.Level;
  *  @author Michael McKay (mjmckay)
  *  		<li> BF3468458 - Attribute Set Instance not filled on Orders when product lookup not used.
  *  			 See https://sourceforge.net/tracker/?func=detail&aid=3468458&group_id=176962&atid=879332
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class CalloutOrder extends CalloutEngine
 {

--- a/base/src/org/compiere/model/MAcctSchemaGL.java
+++ b/base/src/org/compiere/model/MAcctSchemaGL.java
@@ -34,6 +34,9 @@ import org.compiere.util.KeyNamePair;
  *  @version $Id: MAcctSchemaGL.java,v 1.3 2006/07/30 00:58:18 jjanke Exp $
  *  @author victor.perez@e-evolution.com, www.e-evolution.com
  *    			<li>RF [ 2214883 ] Remove SQL code and Replace for Query http://sourceforge.net/tracker/index.php?func=detail&aid=2214883&group_id=176962&atid=879335
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MAcctSchemaGL extends X_C_AcctSchema_GL
 {

--- a/base/src/org/compiere/model/MCash.java
+++ b/base/src/org/compiere/model/MCash.java
@@ -50,6 +50,9 @@ import org.compiere.util.TimeUtil;
  * 			<li>BF [ 1894524 ] Pay an reversed invoice
  * 			<li>BF [ 1899477 ] MCash.getLines should return only active lines
  * 			<li>BF [ 2588326 ] Cash Lines are not correctly updated on voiding
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MCash extends X_C_Cash implements DocAction
 {

--- a/base/src/org/compiere/model/MChat.java
+++ b/base/src/org/compiere/model/MChat.java
@@ -39,6 +39,9 @@ import org.compiere.util.Util;
  *	
  *  @author Jorg Janke
  *  @version $Id: MChat.java,v 1.4 2006/07/30 00:51:05 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MChat extends X_CM_Chat
 {

--- a/base/src/org/compiere/model/MChatEntry.java
+++ b/base/src/org/compiere/model/MChatEntry.java
@@ -26,6 +26,9 @@ import org.adempiere.core.domains.models.X_CM_ChatEntry;
  *	
  *  @author Jorg Janke
  *  @version $Id: MChatEntry.java,v 1.2 2006/07/30 00:51:03 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MChatEntry extends X_CM_ChatEntry
 {

--- a/base/src/org/compiere/model/MChatType.java
+++ b/base/src/org/compiere/model/MChatType.java
@@ -27,6 +27,9 @@ import org.compiere.util.CCache;
  *	
  *  @author Jorg Janke
  *  @version $Id: MChatType.java,v 1.2 2006/07/30 00:51:03 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MChatType extends X_CM_ChatType
 {

--- a/base/src/org/compiere/model/MContainer.java
+++ b/base/src/org/compiere/model/MContainer.java
@@ -37,6 +37,9 @@ import org.compiere.util.DB;
  * @author Yves Sandfort
  * @version $Id: MContainer.java,v 1.20 2006/09/05 23:22:53 comdivision Exp $
  * FR: [ 2214883 ] Remove SQL code and Replace for Query - red1/trifon
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MContainer extends X_CM_Container
 {

--- a/base/src/org/compiere/model/MContainerElement.java
+++ b/base/src/org/compiere/model/MContainerElement.java
@@ -27,6 +27,9 @@ import org.compiere.util.CLogger;
  * 
  * @author Yves Sandfort
  * @version $Id$
+ * @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MContainerElement extends X_CM_Container_Element
 {

--- a/base/src/org/compiere/model/MDunningLevel.java
+++ b/base/src/org/compiere/model/MDunningLevel.java
@@ -29,7 +29,9 @@ import org.adempiere.core.domains.models.X_C_DunningLevel;
  *	
  *  @author Jorg Janke
  *  @version $Id: MDunningLevel.java,v 1.3 2006/07/30 00:51:02 jjanke Exp $
- *  
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MDunningLevel extends X_C_DunningLevel {
 	/**

--- a/base/src/org/compiere/model/MDunningRunLine.java
+++ b/base/src/org/compiere/model/MDunningRunLine.java
@@ -30,6 +30,9 @@ import org.compiere.util.Env;
  *	
  *  @author Jorg Janke
  *  @version $Id: MDunningRunLine.java,v 1.3 2006/07/30 00:51:02 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MDunningRunLine extends X_C_DunningRunLine {
 	/**

--- a/base/src/org/compiere/model/MInterestArea.java
+++ b/base/src/org/compiere/model/MInterestArea.java
@@ -36,6 +36,9 @@ import org.compiere.util.DB;
  *
  *  @author Jorg Janke
  *  @version $Id: MInterestArea.java,v 1.3 2006/07/30 00:51:05 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MInterestArea extends X_R_InterestArea
 {

--- a/base/src/org/compiere/model/MNewsItem.java
+++ b/base/src/org/compiere/model/MNewsItem.java
@@ -26,6 +26,9 @@ import org.adempiere.core.domains.models.X_CM_NewsItem;
  * 
  * @author Yves Sandfort
  * @version $Id$
+ * @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MNewsItem extends X_CM_NewsItem
 {

--- a/base/src/org/compiere/model/MPaymentValidate.java
+++ b/base/src/org/compiere/model/MPaymentValidate.java
@@ -28,6 +28,9 @@ import org.compiere.util.CLogger;
  *	
  *  @author Jorg Janke
  *  @version $Id: MPaymentValidate.java,v 1.2 2006/07/30 00:51:05 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MPaymentValidate
 {

--- a/base/src/org/compiere/model/MWebProjectDomain.java
+++ b/base/src/org/compiere/model/MWebProjectDomain.java
@@ -30,6 +30,9 @@ import org.compiere.util.DB;
  *	
  *  @author Jorg Janke
  *  @version $Id: MWebProjectDomain.java,v 1.2 2006/07/30 00:51:02 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MWebProjectDomain extends X_CM_WebProject_Domain
 {

--- a/base/src/org/compiere/model/TranslationTable.java
+++ b/base/src/org/compiere/model/TranslationTable.java
@@ -28,6 +28,9 @@ import org.compiere.util.Env;
  *	
  *  @author Jorg Janke
  *  @version $Id: TranslationTable.java,v 1.2 2006/07/30 00:54:54 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class TranslationTable
 {

--- a/base/src/org/compiere/process/BankStatementPayment.java
+++ b/base/src/org/compiere/process/BankStatementPayment.java
@@ -43,6 +43,9 @@ import org.compiere.util.Util;
  *  @author Victor Perez, victor.perez@e-evolution.com , http://e-evolution.com
  *  [Bug Report] Transaction blocking error when creating payment from the account statement and immediate posting #3429
  *  https://github.com/adempiere/adempiere/issues/3429
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class BankStatementPayment extends BankStatementPaymentAbstract {
 

--- a/base/src/org/compiere/process/PaySelectionCreateFrom.java
+++ b/base/src/org/compiere/process/PaySelectionCreateFrom.java
@@ -41,6 +41,9 @@ import org.compiere.util.Env;
  *		<li> FR [ 297 ] Payment Selection must be like ADempiere Document, this process is changed to 
  *			document workflow of Payment Selection
  *		@see https://github.com/adempiere/adempiere/issues/297
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 @Deprecated
 public class PaySelectionCreateFrom extends SvrProcess

--- a/base/src/org/compiere/util/AmtInWords_IN.java
+++ b/base/src/org/compiere/util/AmtInWords_IN.java
@@ -25,6 +25,9 @@ package org.compiere.util;
  *  
  *  @author Halim Englen
  *  @version $Id: AmtInWords_IN.java,v 1.3 2006/07/30 00:54:36 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class AmtInWords_IN implements AmtInWords
 {

--- a/base/src/org/compiere/util/AmtInWords_SR.java
+++ b/base/src/org/compiere/util/AmtInWords_SR.java
@@ -17,6 +17,9 @@ package org.compiere.util;
  *Amount in Words for Serbia.
  * @author Nikola Petkov -The class is based on the AmtInWords_EN.java written
  *         by jjanke
+ * @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class AmtInWords_SR
 	implements AmtInWords

--- a/base/src/org/compiere/util/IniRes_hu.java
+++ b/base/src/org/compiere/util/IniRes_hu.java
@@ -23,6 +23,9 @@ import java.util.ListResourceBundle;
  *
  *  @author     Jorg Janke
  *  @version    $Id: IniRes.java,v 1.2 2006/07/30 00:52:23 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class IniRes_hu extends ListResourceBundle
 {

--- a/base/src/org/compiere/util/Msg.java
+++ b/base/src/org/compiere/util/Msg.java
@@ -32,6 +32,9 @@ import org.compiere.Adempiere;
  *
  *  @author     Jorg Janke
  *  @version    $Id: Msg.java,v 1.2 2006/07/30 00:54:36 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public final class Msg
 {

--- a/base/test/src/org/compiere/model/IT_MBPartner.java
+++ b/base/test/src/org/compiere/model/IT_MBPartner.java
@@ -12,7 +12,12 @@
  * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
  * For the text or an alternative of this public license, you may reach us    *
  * or via info@adempiere.net or http://www.adempiere.net/license.html         *
- *****************************************************************************/
+ ******************************************************************************
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
+ * */
+
 package org.compiere.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/client/src/org/compiere/plaf/PlafRes_hu.java
+++ b/client/src/org/compiere/plaf/PlafRes_hu.java
@@ -23,6 +23,9 @@ import java.util.ListResourceBundle;
  *
  *  @author     Jorg Janke
  *  @version    $Id: PlafRes.java,v 1.2 2006/07/30 00:52:24 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class PlafRes_hu extends ListResourceBundle
 {

--- a/client/src/org/spin/apps/form/BankStatementMatchController.java
+++ b/client/src/org/spin/apps/form/BankStatementMatchController.java
@@ -51,6 +51,9 @@ import org.compiere.util.Msg;
  * @author Yamel Senih, ysenih@erpya.com , http://www.erpya.com
  * <li> FR [ 1699 ] Add support view for Bank Statement
  * @see https://github.com/adempiere/adempiere/issues/1699
+ * @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class BankStatementMatchController {
 	/**

--- a/serverRoot/src/main/server/org/compiere/ldap/LdapConnectionHandler.java
+++ b/serverRoot/src/main/server/org/compiere/ldap/LdapConnectionHandler.java
@@ -59,6 +59,9 @@ import org.compiere.util.CLogger;
  * 
  *  @author Jorg Janke
  *  @version $Id: LdapConnectionHandler.java,v 1.1 2006/10/09 00:23:16 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class LdapConnectionHandler extends Thread
 {

--- a/serverRoot/src/main/server/org/compiere/ldap/LdapMessage.java
+++ b/serverRoot/src/main/server/org/compiere/ldap/LdapMessage.java
@@ -26,6 +26,9 @@ import com.sun.jndi.ldap.BerDecoder;
  *	
  *  @author Jorg Janke
  *  @version $Id: LdapMessage.java,v 1.1 2006/10/09 00:23:16 jjanke Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class LdapMessage
 {

--- a/webCM/src/main/servlet/org/compiere/cm/AdRedirector.java
+++ b/webCM/src/main/servlet/org/compiere/cm/AdRedirector.java
@@ -28,6 +28,9 @@ import org.compiere.model.MAd;
  * AdRedirector will forward the Ad Request to the destination URL and log the request
  * @author Yves Sandfort
  * @version  $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class AdRedirector extends HttpServletCM
 {

--- a/webCM/src/main/servlet/org/compiere/cm/Broadcast.java
+++ b/webCM/src/main/servlet/org/compiere/cm/Broadcast.java
@@ -37,6 +37,9 @@ import org.compiere.util.WebEnv;
  * 
  * @author Yves Sandfort
  * @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class Broadcast extends HttpServletCM
 {

--- a/webCM/src/main/servlet/org/compiere/cm/Community.java
+++ b/webCM/src/main/servlet/org/compiere/cm/Community.java
@@ -36,6 +36,9 @@ import org.compiere.util.WebUtil;
  *	
  *  @author Yves Sandfort
  *  @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class Community extends HttpServletCM
 {

--- a/webCM/src/main/servlet/org/compiere/cm/Extend.java
+++ b/webCM/src/main/servlet/org/compiere/cm/Extend.java
@@ -28,6 +28,9 @@ import org.compiere.util.WebInfo;
  *	
  *  @author Yves Sandfort
  *  @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public abstract class Extend implements Serializable
 {

--- a/webCM/src/main/servlet/org/compiere/cm/HttpServletCM.java
+++ b/webCM/src/main/servlet/org/compiere/cm/HttpServletCM.java
@@ -42,6 +42,9 @@ import org.compiere.util.WebEnv;
  * 
  * @author Yves Sandfort
  * @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class HttpServletCM extends HttpServlet
 {

--- a/webCM/src/main/servlet/org/compiere/cm/MediaBroadcast.java
+++ b/webCM/src/main/servlet/org/compiere/cm/MediaBroadcast.java
@@ -35,6 +35,9 @@ import org.compiere.util.WebEnv;
  *
  *  @author $Author$
  *  @version  $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class MediaBroadcast extends HttpServletCM
 {

--- a/webCM/src/main/servlet/org/compiere/cm/RequestServlet.java
+++ b/webCM/src/main/servlet/org/compiere/cm/RequestServlet.java
@@ -33,6 +33,9 @@ import org.compiere.util.WebUtil;
  *	
  *  @author Kai Viiksaar
  *  @version $Id: RequestServlet.java,v 1.1 2006/10/11 06:30:11 comdivision Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class RequestServlet extends HttpServletCM {
 	/**	serialVersionUID	*/

--- a/webCM/src/main/servlet/org/compiere/cm/StageBroadcast.java
+++ b/webCM/src/main/servlet/org/compiere/cm/StageBroadcast.java
@@ -35,6 +35,9 @@ import org.compiere.util.WebEnv;
  * 
  * @author $Author$
  * @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class StageBroadcast extends HttpServletCM
 {

--- a/webCM/src/main/servlet/org/compiere/cm/XMLBroadcast.java
+++ b/webCM/src/main/servlet/org/compiere/cm/XMLBroadcast.java
@@ -29,6 +29,9 @@ import org.compiere.cm.xml.Generator;
 /**
  * @author YS
  * @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class XMLBroadcast extends HttpServletCM
 {

--- a/webCM/src/main/servlet/org/compiere/cm/cache/CO.java
+++ b/webCM/src/main/servlet/org/compiere/cm/cache/CO.java
@@ -13,7 +13,11 @@
  * For the text or an alternative of this public license, you may reach us    *
  * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
  * or via info@compiere.org or http://www.compiere.org/license.html           *
- *****************************************************************************/
+ ******************************************************************************
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
+ * */
 package org.compiere.cm.cache;
 
 import java.util.Collections;

--- a/webCM/src/main/servlet/org/compiere/cm/cache/Chat.java
+++ b/webCM/src/main/servlet/org/compiere/cm/cache/Chat.java
@@ -25,6 +25,9 @@ import org.compiere.model.MChat;
  *	
  *  @author Yves Sandfort
  *  @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class Chat extends CO {
 	

--- a/webCM/src/main/servlet/org/compiere/cm/cache/Container.java
+++ b/webCM/src/main/servlet/org/compiere/cm/cache/Container.java
@@ -25,6 +25,9 @@ import org.compiere.model.MContainer;
  * 
  * @author Yves Sandfort
  * @version $ID$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class Container extends CO {
 	

--- a/webCM/src/main/servlet/org/compiere/cm/cache/ContainerElement.java
+++ b/webCM/src/main/servlet/org/compiere/cm/cache/ContainerElement.java
@@ -23,6 +23,9 @@ import org.compiere.model.MContainerElement;
  *	
  *  @author Yves Sandfort
  *  @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class ContainerElement extends CO {
 	/**

--- a/webCM/src/main/servlet/org/compiere/cm/cache/ContainerTree.java
+++ b/webCM/src/main/servlet/org/compiere/cm/cache/ContainerTree.java
@@ -26,6 +26,9 @@ import org.compiere.model.MWebProject;
  *	
  *  @author Yves Sandfort
  *  @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class ContainerTree extends CO {
 	

--- a/webCM/src/main/servlet/org/compiere/cm/cache/Domain.java
+++ b/webCM/src/main/servlet/org/compiere/cm/cache/Domain.java
@@ -21,6 +21,9 @@ import org.compiere.model.MWebProjectDomain;
 /**
  * @author Yves Sandfort
  * @version $Id$
+ * @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class Domain extends CO
 {

--- a/webCM/src/main/servlet/org/compiere/cm/cache/Service.java
+++ b/webCM/src/main/servlet/org/compiere/cm/cache/Service.java
@@ -30,6 +30,9 @@ import org.compiere.cm.HttpServletCM;
  *	
  *  @author Yves Sandfort
  *  @version $Id$
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class Service extends HttpServletCM {
 	/**	serialVersionUID	*/

--- a/webCM/src/main/servlet/org/compiere/cm/request/Request.java
+++ b/webCM/src/main/servlet/org/compiere/cm/request/Request.java
@@ -33,6 +33,9 @@ import org.compiere.util.DB;
  *	
  *  @author Kai Viiksaar
  *  @version $Id: Request.java,v 1.3 2006/10/16 11:34:47 comdivision Exp $
+ *  @author Raul Capecce, raul.capecce@solopsoftware.com, Solop https://solopsoftware.com/
+ *		<a href="https://github.com/adempiere/adempiere/issues/4188">
+ * 		@see BF [ 4188 ] Badly formatted end of line in files</a>
  */
 public class Request {
 


### PR DESCRIPTION
Fixes #4188 

First you can validate that there are no more mixed java files with the command

`git ls-files --eol | grep java | grep mixed`

Second you can compare the PR with intellij and show only a signature in the header of class