### PR TITLE
Fixed error with bad constraint for `M_ProductionLine.ReversalLine_ID`

### DIFF
--- a/migration/394lts-3.9.4.001/09970_Fix_Production_Line_constraint.xml
+++ b/migration/394lts-3.9.4.001/09970_Fix_Production_Line_constraint.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Fix Production Line constraint" ReleaseNo="3.9.4.001" SeqNo="9970">
+    <Step DBType="Postgres" Parse="Y" SeqNo="10" StepType="SQL">
+      <Comments>PostgreSQL: Remove and recreate constraint</Comments>
+      <SQLStatement>ALTER TABLE M_ProductionLine DROP CONSTRAINT reversalline_mproductionline;
+ALTER TABLE M_ProductionLine ADD CONSTRAINT ReversalLine_MProductionLine FOREIGN KEY (ReversalLine_ID) REFERENCES M_ProductionLine DEFERRABLE INITIALLY DEFERRED;</SQLStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="Y" SeqNo="20" StepType="SQL">
+      <Comments>Oracle: Remove and recreate constraint</Comments>
+      <SQLStatement>ALTER TABLE M_ProductionLine DROP CONSTRAINT ReversalLine_MProductionLine;
+ALTER TABLE M_ProductionLine ADD CONSTRAINT ReversalLine_MProductionLine FOREIGN KEY (ReversalLine_ID) REFERENCES M_ProductionLine (M_ProductionLine_ID);</SQLStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
Currently if you want to reverse a production, this throw a error trying validate the production line with a in out.
![284030225-5fb26054-3ba1-4f7f-969a-a1fa836a7585](https://github.com/adempiere/adempiere/assets/2333092/1ce967a4-4c15-42c5-b92b-fd1ce912ed8d)


A previos report for this was posted [here](https://github.com/adempiere/adempiere/pull/4081#issuecomment-1817709361)

## Step by Step

- Create a new Production
- Complete this
- Try reverse it