### PR TITLE
fix: CI with `MPPProductBOMLine` import, and `com.amazonaws` package ant build. 

### DIFF
--- a/base/build.xml
+++ b/base/build.xml
@@ -43,9 +43,10 @@
     <pathelement path="../tools/lib/commons-io.jar"/>
   	<pathelement path="../tools/lib/poi-ooxml-3.17.jar" />
   	<pathelement path="../tools/lib/sardine-5.9-SNAPSHOT.jar" />
-  	<pathelement path="../tools/lib/aws-java-sdk-core-1.11.795.jar" />
-  	<pathelement path="../tools/lib/aws-java-sdk-kms-1.11.795.jar" />
-  	<pathelement path="../tools/lib/aws-java-sdk-s3-1.11.795.jar" />
+  	<pathelement path="../tools/lib/aws/joda-time-2.8.1.jar" />
+  	<pathelement path="../tools/lib/aws/aws-java-sdk-core-1.11.827.jar" />
+  	<pathelement path="../tools/lib/aws/aws-java-sdk-kms-1.11.827.jar" />
+  	<pathelement path="../tools/lib/aws/aws-java-sdk-s3-1.11.827.jar" />
   </path>
 		
   <target name="init" description="initialization target">

--- a/base/src/org/compiere/model/MProduction.java
+++ b/base/src/org/compiere/model/MProduction.java
@@ -44,7 +44,6 @@ import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
 import org.compiere.util.Util;
-import org.eevolution.manufacturing.model.MPPProductBOMLine;
 import org.eevolution.services.dsl.ProcessBuilder;
 
 /**


### PR DESCRIPTION
#### Error Continuous Integration with ant.

Import `MPPProductBOMLine` class on `MProduction`.

```log
    [javac] /home/runner/work/adempiere/adempiere/base/src/org/compiere/model/MProduction.java:47: error: package org.eevolution.manufacturing.model does not exist
    [javac] import org.eevolution.manufacturing.model.MPPProductBOMLine;
```

Package `com.amazonaws.auth` does not exist

```log
    [javac] /home/runner/work/adempiere/adempiere/base/src/org/spin/util/support/aws3/AmazonWS3.java:33: error: package com.amazonaws.auth does not exist
    [javac] import com.amazonaws.auth.AWSStaticCredentialsProvider;
```

After
https://github.com/EdwinBetanc0urt/adempiere/actions/runs/6981717832

#### Error Continuous Integration with gradle.

Import `MPPProductBOMLine` class on `MProduction`.

```log
/home/runner/work/adempiere/adempiere/base/src/org/compiere/model/MProduction.java:47: error: package org.eevolution.manufacturing.model does not exist
import org.eevolution.manufacturing.model.MPPProductBOMLine;
```

After
https://github.com/EdwinBetanc0urt/adempiere/actions/runs/6981717833


