### PR TITLE
Fixed error with many executions for report flagged as `IsForm` inside

### DIFF
--- a/base/src/org/compiere/print/ReportEngine.java
+++ b/base/src/org/compiere/print/ReportEngine.java
@@ -869,10 +869,7 @@ queued-job-count = 0  (class javax.print.attribute.standard.QueuedJobCount)
 				columnKey = tableName + "_ID";
 
 			query = MQuery.getEqualQuery(columnKey, pi.getRecord_ID());
-		}
-		if(tableName.startsWith("T_")
-				|| (Optional.ofNullable(pi.getAD_PInstance_ID()).isPresent() 
-						&& Optional.ofNullable(table.getColumn("AD_PInstance_ID")).isPresent())) {	//	For Temporary tables
+		} else {	//	For all, the temp tables and other are validated inside method
 			query = MQuery.get (ctx, pi.getAD_PInstance_ID(), tableName);
 		}
 

--- a/base/src/org/compiere/print/ReportEngine.java
+++ b/base/src/org/compiere/print/ReportEngine.java
@@ -871,8 +871,8 @@ queued-job-count = 0  (class javax.print.attribute.standard.QueuedJobCount)
 			query = MQuery.getEqualQuery(columnKey, pi.getRecord_ID());
 		}
 		if(tableName.startsWith("T_")
-				|| Optional.ofNullable(pi.getAD_PInstance_ID()).isPresent()
-				|| Optional.ofNullable(table.getColumn("AD_PInstance_ID")).isPresent()) {	//	For Temporary tables
+				|| (Optional.ofNullable(pi.getAD_PInstance_ID()).isPresent() 
+						&& Optional.ofNullable(table.getColumn("AD_PInstance_ID")).isPresent())) {	//	For Temporary tables
 			query = MQuery.get (ctx, pi.getAD_PInstance_ID(), tableName);
 		}
 


### PR DESCRIPTION
## Bug
The problem only affect to reports inside windows using button **Print Preview** for non standard reports.

## Step by Step
- Go to **Open Items** -> **Payment Selection** window
- Print Report inside window
- Note that the report show all records

## Base setup
The Print format must be flagged as `Form` and must has **Header** and **Content** bands

## Some History
The problem is that a `OR` operator was add [here](https://github.com/EdwinBetanc0urt/adempiere/commit/5d58da08e190e7f4074dc9618f8bb4b32eb15561#diff-e6e4fea8b4088210a4e30432da4d3b4ebee36723ece363e4d96572d119ca5c7eR874) instead a compose `AND` operator.

Note: This behavior not apply for legacy formats like Invoice, Orders, Shipments and other old hardcoded formats

https://github.com/adempiere/adempiere/assets/2333092/4c03a5a1-0cde-4305-b00b-df8fbf5c3dfa

A example of multiple record:
![Screenshot from 2023-11-30 20-12-23](https://github.com/adempiere/adempiere/assets/2333092/9b91815d-499a-49aa-be3c-6e15aa3346ac)

![image](https://github.com/adempiere/adempiere/assets/2333092/dc0ec5ab-9a02-4d4b-b462-468785f1ebdd)



Related to: https://github.com/adempiere/adempiere/issues/3884