### PR TITLE
Fixed error with commission run detail report

### DIFF
--- a/db/ddlutils/oracle/views/RV_COMMISSIONRUNDETAIL.sql
+++ b/db/ddlutils/oracle/views/RV_COMMISSIONRUNDETAIL.sql
@@ -34,8 +34,9 @@ SELECT cr.AD_Client_ID, cr.AD_Org_ID, cr.IsActive, cr.Created,cr.CreatedBy, cr.U
     COALESCE (i.AD_User_ID,o.AD_User_ID) AS AD_User_ID,
     COALESCE (i.C_DocType_ID,o.C_DocType_ID) AS C_DocType_ID
 FROM C_CommissionRun cr
-    INNER JOIN C_Commission c ON (cr.C_Commission_ID=c.C_Commission_ID)
     INNER JOIN C_CommissionAmt ca ON (cr.C_CommissionRun_ID=ca.C_CommissionRun_ID)
+    INNER JOIN C_CommissionLine cl ON (cl.C_CommissionLine_ID=ca.C_CommissionLine_ID)
+    INNER JOIN C_Commission c ON (c.C_Commission_ID=cl.C_Commission_ID)
     INNER JOIN C_CommissionDetail cd ON (ca.C_CommissionAmt_ID=cd.C_CommissionAmt_ID)
     LEFT OUTER JOIN C_OrderLine ol ON (cd.C_OrderLine_ID=ol.C_OrderLine_ID)
     LEFT OUTER JOIN C_InvoiceLine il ON (cd.C_InvoiceLine_ID=il.C_InvoiceLine_ID)

--- a/db/ddlutils/postgresql/views/RV_COMMISSIONRUNDETAIL.sql
+++ b/db/ddlutils/postgresql/views/RV_COMMISSIONRUNDETAIL.sql
@@ -34,8 +34,9 @@ SELECT cr.AD_Client_ID, cr.AD_Org_ID, cr.IsActive, cr.Created,cr.CreatedBy, cr.U
     COALESCE (i.AD_User_ID,o.AD_User_ID) AS AD_User_ID,
     COALESCE (i.C_DocType_ID,o.C_DocType_ID) AS C_DocType_ID
 FROM C_CommissionRun cr
-    INNER JOIN C_Commission c ON (cr.C_Commission_ID=c.C_Commission_ID)
     INNER JOIN C_CommissionAmt ca ON (cr.C_CommissionRun_ID=ca.C_CommissionRun_ID)
+    INNER JOIN C_CommissionLine cl ON (cl.C_CommissionLine_ID=ca.C_CommissionLine_ID)
+    INNER JOIN C_Commission c ON (c.C_Commission_ID=cl.C_Commission_ID)
     INNER JOIN C_CommissionDetail cd ON (ca.C_CommissionAmt_ID=cd.C_CommissionAmt_ID)
     LEFT OUTER JOIN C_OrderLine ol ON (cd.C_OrderLine_ID=ol.C_OrderLine_ID)
     LEFT OUTER JOIN C_InvoiceLine il ON (cd.C_InvoiceLine_ID=il.C_InvoiceLine_ID)

--- a/migration/394lts-3.9.4.002/10330_Fixed_Commission_Run_Detail_View.xml
+++ b/migration/394lts-3.9.4.002/10330_Fixed_Commission_Run_Detail_View.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Fixed Commission Run Detail View" ReleaseNo="3.9.4.002" SeqNo="10330">
+    <Step DBType="Postgres" Parse="Y" SeqNo="10" StepType="SQL">
+      <SQLStatement>CREATE OR REPLACE VIEW RV_COMMISSIONRUNDETAIL
+(AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, CREATEDBY, 
+ UPDATED, UPDATEDBY, C_COMMISSIONRUN_ID, DOCUMENTNO, DESCRIPTION, 
+ STARTDATE, GRANDTOTAL, PROCESSED, C_COMMISSION_ID, COMMISSION_BPARTNER_ID, 
+ C_COMMISSIONAMT_ID, COMMISSIONCONVERTEDAMT, COMMISSIONQTY, COMMISSIONAMT, C_COMMISSIONDETAIL_ID, 
+ REFERENCE, C_ORDERLINE_ID, C_INVOICELINE_ID, INFO, C_CURRENCY_ID, 
+ ACTUALAMT, CONVERTEDAMT, ACTUALQTY, INVOICEDOCUMENTNO, DATEDOC, 
+ M_PRODUCT_ID, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, C_DOCTYPE_ID)
+AS 
+SELECT cr.AD_Client_ID, cr.AD_Org_ID, cr.IsActive, cr.Created,cr.CreatedBy, cr.Updated,cr.UpdatedBy,
+    -- Run
+    cr.C_CommissionRun_ID, cr.DocumentNo, cr.Description, 
+    cr.StartDate, cr.GrandTotal, cr.Processed,
+    -- Commission
+    c.C_Commission_ID, ca.C_BPartner_ID AS Commission_BPartner_ID,
+    --  Commission Amount
+    ca.C_CommissionAmt_ID, 
+    cd.ConvertedAmt AS CommissionConvertedAmt, cd.ActualQty AS CommissionQty, 
+    cd.CommissionAmt,
+    --  Commission Detail
+    cd.C_CommissionDetail_ID,
+    cd.Reference,
+    cd.C_OrderLine_ID,
+    cd.C_InvoiceLine_ID,
+    cd.Info,
+    cd.C_Currency_ID, cd.ActualAmt, cd.ConvertedAmt,
+    cd.ActualQty,
+    -- Invoice/Order
+    i.DocumentNo AS InvoiceDocumentNo,
+    COALESCE (i.DateInvoiced, o.DateOrdered) AS DateDoc,
+    COALESCE (il.M_Product_ID,ol.M_Product_ID) AS M_Product_ID,
+    COALESCE (i.C_BPartner_ID,o.C_BPartner_ID) AS C_BPartner_ID,
+    COALESCE (i.C_BPartner_Location_ID,o.C_BPartner_Location_ID) AS C_BPartner_Location_ID,
+    COALESCE (i.AD_User_ID,o.AD_User_ID) AS AD_User_ID,
+    COALESCE (i.C_DocType_ID,o.C_DocType_ID) AS C_DocType_ID
+FROM C_CommissionRun cr
+    INNER JOIN C_CommissionAmt ca ON (cr.C_CommissionRun_ID=ca.C_CommissionRun_ID)
+    INNER JOIN C_CommissionLine cl ON (cl.C_CommissionLine_ID=ca.C_CommissionLine_ID)
+    INNER JOIN C_Commission c ON (c.C_Commission_ID=cl.C_Commission_ID)
+    INNER JOIN C_CommissionDetail cd ON (ca.C_CommissionAmt_ID=cd.C_CommissionAmt_ID)
+    LEFT OUTER JOIN C_OrderLine ol ON (cd.C_OrderLine_ID=ol.C_OrderLine_ID)
+    LEFT OUTER JOIN C_InvoiceLine il ON (cd.C_InvoiceLine_ID=il.C_InvoiceLine_ID)
+    LEFT OUTER JOIN C_Order o ON (ol.C_Order_ID=o.C_Order_ID)
+    LEFT OUTER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID);</SQLStatement>
+      <RollbackStatement>CREATE OR REPLACE VIEW RV_COMMISSIONRUNDETAIL
+(AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, CREATEDBY, 
+ UPDATED, UPDATEDBY, C_COMMISSIONRUN_ID, DOCUMENTNO, DESCRIPTION, 
+ STARTDATE, GRANDTOTAL, PROCESSED, C_COMMISSION_ID, COMMISSION_BPARTNER_ID, 
+ C_COMMISSIONAMT_ID, COMMISSIONCONVERTEDAMT, COMMISSIONQTY, COMMISSIONAMT, C_COMMISSIONDETAIL_ID, 
+ REFERENCE, C_ORDERLINE_ID, C_INVOICELINE_ID, INFO, C_CURRENCY_ID, 
+ ACTUALAMT, CONVERTEDAMT, ACTUALQTY, INVOICEDOCUMENTNO, DATEDOC, 
+ M_PRODUCT_ID, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, C_DOCTYPE_ID)
+AS 
+SELECT cr.AD_Client_ID, cr.AD_Org_ID, cr.IsActive, cr.Created,cr.CreatedBy, cr.Updated,cr.UpdatedBy,
+    -- Run
+    cr.C_CommissionRun_ID, cr.DocumentNo, cr.Description, 
+    cr.StartDate, cr.GrandTotal, cr.Processed,
+    -- Commission
+    c.C_Commission_ID, ca.C_BPartner_ID AS Commission_BPartner_ID,
+    --  Commission Amount
+    ca.C_CommissionAmt_ID, 
+    cd.ConvertedAmt AS CommissionConvertedAmt, cd.ActualQty AS CommissionQty, 
+    cd.CommissionAmt,
+    --  Commission Detail
+    cd.C_CommissionDetail_ID,
+    cd.Reference,
+    cd.C_OrderLine_ID,
+    cd.C_InvoiceLine_ID,
+    cd.Info,
+    cd.C_Currency_ID, cd.ActualAmt, cd.ConvertedAmt,
+    cd.ActualQty,
+    -- Invoice/Order
+    i.DocumentNo AS InvoiceDocumentNo,
+    COALESCE (i.DateInvoiced, o.DateOrdered) AS DateDoc,
+    COALESCE (il.M_Product_ID,ol.M_Product_ID) AS M_Product_ID,
+    COALESCE (i.C_BPartner_ID,o.C_BPartner_ID) AS C_BPartner_ID,
+    COALESCE (i.C_BPartner_Location_ID,o.C_BPartner_Location_ID) AS C_BPartner_Location_ID,
+    COALESCE (i.AD_User_ID,o.AD_User_ID) AS AD_User_ID,
+    COALESCE (i.C_DocType_ID,o.C_DocType_ID) AS C_DocType_ID
+FROM C_CommissionRun cr
+    INNER JOIN C_Commission c ON (cr.C_Commission_ID=c.C_Commission_ID)
+    INNER JOIN C_CommissionAmt ca ON (cr.C_CommissionRun_ID=ca.C_CommissionRun_ID)
+    INNER JOIN C_CommissionDetail cd ON (ca.C_CommissionAmt_ID=cd.C_CommissionAmt_ID)
+    LEFT OUTER JOIN C_OrderLine ol ON (cd.C_OrderLine_ID=ol.C_OrderLine_ID)
+    LEFT OUTER JOIN C_InvoiceLine il ON (cd.C_InvoiceLine_ID=il.C_InvoiceLine_ID)
+    LEFT OUTER JOIN C_Order o ON (ol.C_Order_ID=o.C_Order_ID)
+    LEFT OUTER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID);</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="Y" SeqNo="20" StepType="SQL">
+      <SQLStatement>CREATE OR REPLACE VIEW RV_COMMISSIONRUNDETAIL
+(AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, CREATEDBY, 
+ UPDATED, UPDATEDBY, C_COMMISSIONRUN_ID, DOCUMENTNO, DESCRIPTION, 
+ STARTDATE, GRANDTOTAL, PROCESSED, C_COMMISSION_ID, COMMISSION_BPARTNER_ID, 
+ C_COMMISSIONAMT_ID, COMMISSIONCONVERTEDAMT, COMMISSIONQTY, COMMISSIONAMT, C_COMMISSIONDETAIL_ID, 
+ REFERENCE, C_ORDERLINE_ID, C_INVOICELINE_ID, INFO, C_CURRENCY_ID, 
+ ACTUALAMT, CONVERTEDAMT, ACTUALQTY, INVOICEDOCUMENTNO, DATEDOC, 
+ M_PRODUCT_ID, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, C_DOCTYPE_ID)
+AS 
+SELECT cr.AD_Client_ID, cr.AD_Org_ID, cr.IsActive, cr.Created,cr.CreatedBy, cr.Updated,cr.UpdatedBy,
+    -- Run
+    cr.C_CommissionRun_ID, cr.DocumentNo, cr.Description, 
+    cr.StartDate, cr.GrandTotal, cr.Processed,
+    -- Commission
+    c.C_Commission_ID, ca.C_BPartner_ID AS Commission_BPartner_ID,
+    --  Commission Amount
+    ca.C_CommissionAmt_ID, 
+    cd.ConvertedAmt AS CommissionConvertedAmt, cd.ActualQty AS CommissionQty, 
+    cd.CommissionAmt,
+    --  Commission Detail
+    cd.C_CommissionDetail_ID,
+    cd.Reference,
+    cd.C_OrderLine_ID,
+    cd.C_InvoiceLine_ID,
+    cd.Info,
+    cd.C_Currency_ID, cd.ActualAmt, cd.ConvertedAmt,
+    cd.ActualQty,
+    -- Invoice/Order
+    i.DocumentNo AS InvoiceDocumentNo,
+    COALESCE (i.DateInvoiced, o.DateOrdered) AS DateDoc,
+    COALESCE (il.M_Product_ID,ol.M_Product_ID) AS M_Product_ID,
+    COALESCE (i.C_BPartner_ID,o.C_BPartner_ID) AS C_BPartner_ID,
+    COALESCE (i.C_BPartner_Location_ID,o.C_BPartner_Location_ID) AS C_BPartner_Location_ID,
+    COALESCE (i.AD_User_ID,o.AD_User_ID) AS AD_User_ID,
+    COALESCE (i.C_DocType_ID,o.C_DocType_ID) AS C_DocType_ID
+FROM C_CommissionRun cr
+    INNER JOIN C_CommissionAmt ca ON (cr.C_CommissionRun_ID=ca.C_CommissionRun_ID)
+    INNER JOIN C_CommissionLine cl ON (cl.C_CommissionLine_ID=ca.C_CommissionLine_ID)
+    INNER JOIN C_Commission c ON (c.C_Commission_ID=cl.C_Commission_ID)
+    INNER JOIN C_CommissionDetail cd ON (ca.C_CommissionAmt_ID=cd.C_CommissionAmt_ID)
+    LEFT OUTER JOIN C_OrderLine ol ON (cd.C_OrderLine_ID=ol.C_OrderLine_ID)
+    LEFT OUTER JOIN C_InvoiceLine il ON (cd.C_InvoiceLine_ID=il.C_InvoiceLine_ID)
+    LEFT OUTER JOIN C_Order o ON (ol.C_Order_ID=o.C_Order_ID)
+    LEFT OUTER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID);</SQLStatement>
+      <RollbackStatement>CREATE OR REPLACE VIEW RV_COMMISSIONRUNDETAIL
+(AD_CLIENT_ID, AD_ORG_ID, ISACTIVE, CREATED, CREATEDBY, 
+ UPDATED, UPDATEDBY, C_COMMISSIONRUN_ID, DOCUMENTNO, DESCRIPTION, 
+ STARTDATE, GRANDTOTAL, PROCESSED, C_COMMISSION_ID, COMMISSION_BPARTNER_ID, 
+ C_COMMISSIONAMT_ID, COMMISSIONCONVERTEDAMT, COMMISSIONQTY, COMMISSIONAMT, C_COMMISSIONDETAIL_ID, 
+ REFERENCE, C_ORDERLINE_ID, C_INVOICELINE_ID, INFO, C_CURRENCY_ID, 
+ ACTUALAMT, CONVERTEDAMT, ACTUALQTY, INVOICEDOCUMENTNO, DATEDOC, 
+ M_PRODUCT_ID, C_BPARTNER_ID, C_BPARTNER_LOCATION_ID, AD_USER_ID, C_DOCTYPE_ID)
+AS 
+SELECT cr.AD_Client_ID, cr.AD_Org_ID, cr.IsActive, cr.Created,cr.CreatedBy, cr.Updated,cr.UpdatedBy,
+    -- Run
+    cr.C_CommissionRun_ID, cr.DocumentNo, cr.Description, 
+    cr.StartDate, cr.GrandTotal, cr.Processed,
+    -- Commission
+    c.C_Commission_ID, ca.C_BPartner_ID AS Commission_BPartner_ID,
+    --  Commission Amount
+    ca.C_CommissionAmt_ID, 
+    cd.ConvertedAmt AS CommissionConvertedAmt, cd.ActualQty AS CommissionQty, 
+    cd.CommissionAmt,
+    --  Commission Detail
+    cd.C_CommissionDetail_ID,
+    cd.Reference,
+    cd.C_OrderLine_ID,
+    cd.C_InvoiceLine_ID,
+    cd.Info,
+    cd.C_Currency_ID, cd.ActualAmt, cd.ConvertedAmt,
+    cd.ActualQty,
+    -- Invoice/Order
+    i.DocumentNo AS InvoiceDocumentNo,
+    COALESCE (i.DateInvoiced, o.DateOrdered) AS DateDoc,
+    COALESCE (il.M_Product_ID,ol.M_Product_ID) AS M_Product_ID,
+    COALESCE (i.C_BPartner_ID,o.C_BPartner_ID) AS C_BPartner_ID,
+    COALESCE (i.C_BPartner_Location_ID,o.C_BPartner_Location_ID) AS C_BPartner_Location_ID,
+    COALESCE (i.AD_User_ID,o.AD_User_ID) AS AD_User_ID,
+    COALESCE (i.C_DocType_ID,o.C_DocType_ID) AS C_DocType_ID
+FROM C_CommissionRun cr
+    INNER JOIN C_Commission c ON (cr.C_Commission_ID=c.C_Commission_ID)
+    INNER JOIN C_CommissionAmt ca ON (cr.C_CommissionRun_ID=ca.C_CommissionRun_ID)
+    INNER JOIN C_CommissionDetail cd ON (ca.C_CommissionAmt_ID=cd.C_CommissionAmt_ID)
+    LEFT OUTER JOIN C_OrderLine ol ON (cd.C_OrderLine_ID=ol.C_OrderLine_ID)
+    LEFT OUTER JOIN C_InvoiceLine il ON (cd.C_InvoiceLine_ID=il.C_InvoiceLine_ID)
+    LEFT OUTER JOIN C_Order o ON (ol.C_Order_ID=o.C_Order_ID)
+    LEFT OUTER JOIN C_Invoice i ON (il.C_Invoice_ID=i.C_Invoice_ID);</RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
## Setup
For this error you should create:
- Two commission definitions

Name | Commission Group | Calculation Basis | Frequency Type | Currency | List Details | Days due from Payment Term | Commission only specified Orders | Is Percentage | Multiplier Amount
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
Commission 1 | Test Commision Group | Invoice | Monthly | USD | Yes | No | Yes | Yes | 7
Commission 2 | Test Commision Group | Invoice | Monthly | USD | Yes | No | Yes | Yes | 3

- One commission group

Value | Name
-- | --
TCG | Test Commision Group

## Step to Reproduce

After it you should create two commision run:

Document No | Commission | Commission Group
-- | -- | --
TC-1 | Commission 1 |  
TC-2 |   | Test Commision Group

Now just run the **Quote-to-Invoice** -> **Sales and Marketing** -> **Commission Run Detail** report
![Screenshot from 2023-12-06 11-13-45](https://github.com/adempiere/adempiere/assets/2333092/918a85ef-29db-41f5-9a12-e0639aeb9a34)

You can run it without parameters
![Screenshot from 2023-12-06 11-13-57](https://github.com/adempiere/adempiere/assets/2333092/a5348cf8-44a1-4acf-bff6-809ab3a57df8)

Note that the result is that the commission `TC-01` has data but the `TC-2` is not showed even though it should be shown.

## What is the problem? 
Is very easy, the problem is that the view make a mandatory join with `C_Commission` using the `C_CommissionRun.C_Commission_ID` link column instead (`C_CommissionAmt.C_CommissionLine_ID` -> `C_CommissionLine.C_Commission_ID`)

This pull request just add these changes to:

- `db/ddlutils/postgresql/views/RV_COMMISSIONRUNDETAIL.sql`
- `db/ddlutils/oracle/views/RV_COMMISSIONRUNDETAIL.sql`


Also add a XML to apply inside ADempiere dictionary
- `migration/394lts-3.9.4.002/10330_Fixed_Commission_Run_Detail_View.xml`