### PR TITLE
Fixed error with NPE for missing rule

### DIFF
--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/hr/model/MHRProcess.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/hr/model/MHRProcess.java
@@ -789,12 +789,15 @@ public class MHRProcess extends X_HR_Process implements DocAction , DocumentReve
 		Object result = null;
 		description = null;
 		try {
-			if (rule == null) {
+			if (rule == null
+					|| rule.getAD_Rule_ID() <= 0) {
 				logger.log(Level.WARNING, " @AD_Rule_ID@ @NotFound@");
+				return null;
 			}
 			if (!(rule.getEventType().equals(MRule.EVENTTYPE_HumanResourcePayroll)
 					&& rule.getRuleType().equals(MRule.RULETYPE_JSR223ScriptingAPIs))) {
 				logger.log(Level.WARNING, " must be of type JSR 223 and event human resource");
+				return null;
 			}
 			boolean isRunned = false;
 			if(rule.isRuleClassGenerated()) {


### PR DESCRIPTION
## Bug Report
The problem is a NPE when I try run a HR Process.

## Step by Step
1. Create a Concept as `Rule Engine`
2. Add a attribute to concept without rule
3. Add the concept to payroll process definition
4. Create a new **Payroll Process**
5. Run It
6. See the `NPE`

## What is the error?
The problem it that the the rule is only validated with null but the method `MRule.get` return a new instance if the ID not exist