### PR TITLE
Add Generic Logic Authentication support for KeyCloak and Okta

### DIFF
--- a/migration/394lts-395lts/10330_Add_App_Support_to_Keycloak_OpenID.xml
+++ b/migration/394lts-395lts/10330_Add_App_Support_to_Keycloak_OpenID.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add App Support to Keycloak Open ID" ReleaseNo="3.9.5" SeqNo="10330">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="54542" Action="I" Record_ID="50040" Table="AD_AppSupport">
+        <Data AD_Column_ID="91310" Column="UUID">fff42604-9889-4493-a638-227399cfdba8</Data>
+        <Data AD_Column_ID="91312" Column="Value">KeyCloak Authentication</Data>
+        <Data AD_Column_ID="91313" Column="Name">KeyCloak Authentication</Data>
+        <Data AD_Column_ID="91314" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91315" Column="Help">https://www.keycloak.org/documentation</Data>
+        <Data AD_Column_ID="91316" Column="Classname">org.spin.authentication.services.provider.GenericAuthentication</Data>
+        <Data AD_Column_ID="91306" Column="Created">2024-01-09 09:29:36.911</Data>
+        <Data AD_Column_ID="91307" Column="Updated">2024-01-09 09:29:36.911</Data>
+        <Data AD_Column_ID="91308" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91318" Column="IsDefault">true</Data>
+        <Data AD_Column_ID="91303" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91304" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91305" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91309" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91317" Column="ApplicationType">OIA</Data>
+        <Data AD_Column_ID="91311" Column="AD_AppSupport_ID">50040</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50083" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">b640990d-4ebc-4a90-81df-9edabdda1a4e</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:30:11.336</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:30:11.336</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50083</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">http://localhost/webui</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50040</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">REDIRECT_URL</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50084" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">e128578b-4847-4464-9971-e81268f4c363</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:30:23.516</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:30:23.516</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50084</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">&lt;Client identifier&gt;</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50040</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">CLIENT_ID</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50085" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">40a046c9-73da-4d6c-91de-00592ad1d640</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:30:42.13</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:30:42.13</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50085</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">&lt;Client Secret&gt;</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50040</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">CLIENT_SECRET</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50086" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">99720a45-addb-423a-87a8-f68bd40f85b7</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:33:05.241</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:33:05.241</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50086</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">https://localhost/realms/&lt;Realm Name&gt;/protocol/openid-connect/auth</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50040</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">AUTHORIZATION_ENDPOINT</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50087" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">220639ba-dd13-4be5-9020-f1b22c3506e3</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:33:37.259</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:33:37.259</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50087</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">https://localhost/realms/&lt;Realm Name&gt;/protocol/openid-connect/token</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50040</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">TOKEN_ENDPOINT</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50088" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">3477e6d4-7656-4964-ae06-da62882ecd69</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:33:48.495</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:33:48.495</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50088</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">https://localhost/realms/&lt;Realm Name&gt;/protocol/openid-connect/userinfo</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50040</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">USERINFO_ENDPOINT</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/migration/394lts-395lts/10340_Add_App_Support_to_Okta_OpenID.xml
+++ b/migration/394lts-395lts/10340_Add_App_Support_to_Okta_OpenID.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Add App Support to Okta Open ID" ReleaseNo="3.9.5" SeqNo="10340">
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="54542" Action="I" Record_ID="50039" Table="AD_AppSupport">
+        <Data AD_Column_ID="91310" Column="UUID">bd02f9ca-1d29-499d-9ca4-4a953f356261</Data>
+        <Data AD_Column_ID="91312" Column="Value">Okta Authentication</Data>
+        <Data AD_Column_ID="91313" Column="Name">Okta Authentication</Data>
+        <Data AD_Column_ID="91314" Column="Description">https://www.okta.com/</Data>
+        <Data AD_Column_ID="91315" Column="Help">https://help.okta.com/oie/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_OIDC.htm</Data>
+        <Data AD_Column_ID="91316" Column="Classname">org.spin.authentication.services.provider.GenericAuthentication</Data>
+        <Data AD_Column_ID="91306" Column="Created">2024-01-09 09:22:44.517</Data>
+        <Data AD_Column_ID="91307" Column="Updated">2024-01-09 09:22:44.517</Data>
+        <Data AD_Column_ID="91308" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91318" Column="IsDefault">false</Data>
+        <Data AD_Column_ID="91303" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91304" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91305" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91309" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91317" Column="ApplicationType">OIA</Data>
+        <Data AD_Column_ID="91311" Column="AD_AppSupport_ID">50039</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="20" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50077" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">9999a1fd-d196-4982-9055-66b1002efed5</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:23:05.672</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:23:05.672</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50077</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">http://localhost/webui</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50039</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">REDIRECT_URL</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="30" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50078" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">be6b6b6b-3e68-497f-a666-35c1dc4d0304</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:23:19.347</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:23:19.347</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50078</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">&lt;Client identifier&gt;</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50039</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">CLIENT_ID</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="40" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50079" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">24e2a4c0-8fe1-48d3-8b08-b51e17d11c34</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:23:36.523</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:23:36.523</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50079</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">&lt;Client Secret&gt;</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50039</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">CLIENT_SECRET</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="50" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50080" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">1140d439-36d0-4987-b311-e82d7f4ec31f</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:24:07.745</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:24:07.745</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50080</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">https://&lt; Organization &gt;.okta.com/oauth2/v1/authorize</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50039</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">AUTHORIZATION_ENDPOINT</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="60" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50081" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">3652e032-bc9e-4483-83dc-8336eb547b11</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:24:24.099</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:24:24.099</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50081</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">https://&lt; Organization &gt;.okta.com/oauth2/v1/token</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50039</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">TOKEN_ENDPOINT</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+    <Step SeqNo="70" StepType="AD">
+      <PO AD_Table_ID="54544" Action="I" Record_ID="50082" Table="AD_AppSupport_Para">
+        <Data AD_Column_ID="91386" Column="UUID">4fafff03-ac98-4c2c-bb35-d11c183e6bee</Data>
+        <Data AD_Column_ID="91390" Column="ParameterType">C</Data>
+        <Data AD_Column_ID="91379" Column="AD_Client_ID">0</Data>
+        <Data AD_Column_ID="91380" Column="AD_Org_ID">0</Data>
+        <Data AD_Column_ID="91381" Column="IsActive">true</Data>
+        <Data AD_Column_ID="91382" Column="Created">2024-01-09 09:24:46.273</Data>
+        <Data AD_Column_ID="91383" Column="Updated">2024-01-09 09:24:46.273</Data>
+        <Data AD_Column_ID="91384" Column="CreatedBy">100</Data>
+        <Data AD_Column_ID="91385" Column="UpdatedBy">100</Data>
+        <Data AD_Column_ID="91387" Column="AD_AppSupport_Para_ID">50082</Data>
+        <Data AD_Column_ID="91389" Column="ParameterDefault">https://&lt; Organization &gt;.okta.com/oauth2/v1/userinfo</Data>
+        <Data AD_Column_ID="91391" Column="IsMandatory">true</Data>
+        <Data AD_Column_ID="91393" Column="Description" isNewNull="true"/>
+        <Data AD_Column_ID="91394" Column="AD_AppSupport_ID">50039</Data>
+        <Data AD_Column_ID="91388" Column="ParameterName">USERINFO_ENDPOINT</Data>
+        <Data AD_Column_ID="91392" Column="AD_Reference_ID">10</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>

--- a/org.spin.authentication/src/main/java/base/org/spin/authentication/services/provider/GenericAuthentication.java
+++ b/org.spin.authentication/src/main/java/base/org/spin/authentication/services/provider/GenericAuthentication.java
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Copyright (C) 2003-2015 E.R.P. Consultores y Asociados, C.A.               *
+ * All Rights Reserved.                                                       *
+ * Contributor(s): Carlos Parada www.erpya.com                                *
+ *****************************************************************************/
+package org.spin.authentication.services.provider;
+
+import java.util.Optional;
+import org.spin.authentication.services.OpenIDConnect;
+import org.spin.model.MADAppRegistration;
+import com.nimbusds.oauth2.sdk.ResponseType;
+
+/**
+ * @author Carlos Parada, cparada@erpya.com, ERPCyA http://www.erpya.com
+ * Add support to login with Generic Open ID service
+ */
+public class GenericAuthentication extends OpenIDConnect{
+	
+	/**Default Scope*/
+	private final static String defaultScope = "openid,email,profile";
+	/**Authorization End point Tag*/
+	private static final String AUTHORIZATION_ENDPOINT_TAG = "AUTHORIZATION_ENDPOINT";
+	/**Token End point Tag*/
+	private static final String TOKEN_ENDPOINT_TAG = "TOKEN_ENDPOINT";
+	/**User Info End point Tag*/
+	private static final String USERINFO_ENDPOINT_TAG = "USERINFO_ENDPOINT";
+	/**Scope Parameter*/
+	private static final String PARAMETER_SCOPE = "SCOPE";
+	/**
+	 * Constructor
+	 */
+	public GenericAuthentication() {
+		super();
+		setResponseType(new ResponseType(ResponseType.Value.CODE));
+	}
+	
+	/***
+	 * Set Default values from Application Registration 
+	 */
+	@Override
+	public void setAppRegistrationId(int registrationId) {
+		super.setAppRegistrationId(registrationId);
+		Optional<MADAppRegistration> maybeApRegistration =  Optional.ofNullable(getApplicationRegistration());
+		maybeApRegistration.ifPresent(appRegistration -> {
+			String authorizationEndPoint = Optional.ofNullable(appRegistration.getParameterValue(AUTHORIZATION_ENDPOINT_TAG)).orElse("");
+			String tokenEndPoint = Optional.ofNullable(appRegistration.getParameterValue(TOKEN_ENDPOINT_TAG)).orElse("");
+			String userInfoEndPoint = Optional.ofNullable(appRegistration.getParameterValue(USERINFO_ENDPOINT_TAG)).orElse("");
+			String scope = Optional.ofNullable(appRegistration.getParameterValue(PARAMETER_SCOPE)).orElse(defaultScope);
+			setAuthorizationEndPoint(authorizationEndPoint);
+			setTokenEndpoint(tokenEndPoint);
+			setUserInfoEndpoint(userInfoEndPoint);
+			setScope(scope.split(","));
+		});
+	}
+}


### PR DESCRIPTION
## Support for login with KeyCloak and Okta with generic logic OpenID

With this functionality it's possible login with [KeyCloak](https://www.keycloak.org/documentation) and [Okta](https://help.okta.com/oie/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_OIDC.htm), see this example:


## KeyCloak:

#### Setting:
![image](https://github.com/adempiere/adempiere/assets/1847863/3c23c209-30a9-4dfe-b7fa-6735cde2c447)
![Screenshot_20240109_103554](https://github.com/adempiere/adempiere/assets/1847863/976375c5-0fa1-4bb6-94f4-ef2dd7610e49)

#### Login Sample:
![Keycloak](https://github.com/adempiere/adempiere/assets/1847863/a40fb654-92ac-4823-b8b9-7280940995c8)

## Okta:

#### Setting:
![image](https://github.com/adempiere/adempiere/assets/1847863/ae62fbd7-6c72-4b4a-ab3f-7572012fdba7)
![Screenshot_20240109_103944](https://github.com/adempiere/adempiere/assets/1847863/96655be9-5a5b-4945-bca1-35cb0ab72949)

#### Login Sample:
![okta](https://github.com/adempiere/adempiere/assets/1847863/313412a0-2fd5-4cde-80a9-7d8a72873ba4)
