### PR TITLE
fix: SB Process with empty `Record_ID`.

### DIFF
--- a/base/src/org/adempiere/pipo/PackOut.java
+++ b/base/src/org/adempiere/pipo/PackOut.java
@@ -159,7 +159,7 @@ public class PackOut extends PackOutAbstract {
 		log.info("doIt - AD_PACKAGE_EXP_ID=" + getRecord_ID());
 		// Valid Record Identifier
 		if (getRecord_ID() <= 0) {
-			throw new AdempiereException("@AD_Package_Exp_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @AD_Package_Exp_ID@ (@Record_ID@)");
 		}
 		try {
 			MPackageExp exportPackage = new MPackageExp(getCtx(), getRecord_ID(), get_TrxName());

--- a/base/src/org/adempiere/pipo/PackOut.java
+++ b/base/src/org/adempiere/pipo/PackOut.java
@@ -157,8 +157,10 @@ public class PackOut extends PackOutAbstract {
 		OutputStream  packageDocStream = null;
 		OutputStream  packOutDocStream = null;
 		log.info("doIt - AD_PACKAGE_EXP_ID=" + getRecord_ID());
-		if (getRecord_ID() == 0)
-			throw new IllegalArgumentException("No Record");	//	
+		// Valid Record Identifier
+		if (getRecord_ID() <= 0) {
+			throw new AdempiereException("@AD_Package_Exp_ID@ (@Record_ID@) @NotFound@");
+		}
 		try {
 			MPackageExp exportPackage = new MPackageExp(getCtx(), getRecord_ID(), get_TrxName());
 			//Create the package documentation

--- a/base/src/org/adempiere/pipo/PackOut.java
+++ b/base/src/org/adempiere/pipo/PackOut.java
@@ -83,6 +83,7 @@ import org.compiere.model.PO;
 import org.compiere.model.Query;
 import org.compiere.process.ProcessInfo;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 import org.spin.model.MADPackageExpCustom;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
@@ -158,7 +159,7 @@ public class PackOut extends PackOutAbstract {
 		OutputStream  packOutDocStream = null;
 		log.info("doIt - AD_PACKAGE_EXP_ID=" + getRecord_ID());
 		// Valid Record Identifier
-		if (getRecord_ID() <= 0) {
+		if (getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @AD_Package_Exp_ID@ (@Record_ID@)");
 		}
 		try {

--- a/base/src/org/compiere/process/CopyFromDistribution.java
+++ b/base/src/org/compiere/process/CopyFromDistribution.java
@@ -20,6 +20,7 @@
 package org.compiere.process;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MDistribution;
+import org.compiere.util.Util;
 
 /**
  * Copy From Distribution
@@ -29,7 +30,7 @@ public class CopyFromDistribution extends CopyFromDistributionAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @GL_Distribution_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/compiere/process/CopyFromDistribution.java
+++ b/base/src/org/compiere/process/CopyFromDistribution.java
@@ -30,7 +30,7 @@ public class CopyFromDistribution extends CopyFromDistributionAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@GL_Distribution_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @GL_Distribution_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/compiere/process/CopyFromDistribution.java
+++ b/base/src/org/compiere/process/CopyFromDistribution.java
@@ -18,20 +18,24 @@
  * Created by victor.perez@e-evolution.com , www.e-evolution.com
  */
 package org.compiere.process;
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MDistribution;
 
 /**
  * Copy From Distribution
  */
 public class CopyFromDistribution extends CopyFromDistributionAbstract {
+	@Override
 	protected void prepare() {
 		super.prepare();
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@GL_Distribution_ID@ (@Record_ID@) @NotFound@");
+		}
 	}
 
 	@Override
 	protected String doIt() throws Exception {
-		if (getRecord_ID() == 0)
-			throw new IllegalArgumentException("@GL_Distribution_ID@ @NotFound@");
 		MDistribution from = new MDistribution (getCtx(), getDistributionId(), get_TrxName());
 		MDistribution to = new MDistribution (getCtx(), getRecord_ID(), get_TrxName());
 		int no = to.copyLinesFrom (from);

--- a/base/src/org/compiere/process/CopyReportProcess.java
+++ b/base/src/org/compiere/process/CopyReportProcess.java
@@ -25,6 +25,7 @@ import org.compiere.model.MProcessPara;
 import org.compiere.model.PO;
 import org.compiere.util.DB;
 import org.compiere.util.DisplayType;
+import org.compiere.util.Util;
 
 /**
  * 
@@ -129,8 +130,9 @@ public class CopyReportProcess extends CopyReportProcessAbstract {
 	protected void prepare() {
 		super.prepare();
 		//	Valid Record Identifier
-		if(getRecord_ID() <= 0)
-			throw new AdempiereException("@AD_Process_ID@ @NotFound@");
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
+			throw new AdempiereException("@FillMandatory@ @AD_Process_ID@ (@Record_ID@)");
+		}
 		//	Log
 		log.fine(sql.toString());
 	}

--- a/base/src/org/compiere/process/InOutCreateFrom.java
+++ b/base/src/org/compiere/process/InOutCreateFrom.java
@@ -54,6 +54,10 @@ public class InOutCreateFrom extends InOutCreateFromAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@M_InOut_ID@ (@Record_ID@) @NotFound@");
+		}
 	}
 	
 	/**
@@ -89,9 +93,6 @@ public class InOutCreateFrom extends InOutCreateFromAbstract {
 	
 	@Override
 	protected String doIt() throws Exception {
-		// Valid Record Identifier
-		if(getRecord_ID() == 0)
-			return "";
 		AtomicInteger referenceId = new AtomicInteger(0);
 		AtomicInteger 	created = new AtomicInteger(0);
 		//	Get Shipment

--- a/base/src/org/compiere/process/InOutCreateFrom.java
+++ b/base/src/org/compiere/process/InOutCreateFrom.java
@@ -33,6 +33,7 @@ import org.compiere.model.MProduct;
 import org.compiere.model.MRMA;
 import org.compiere.model.MRMALine;
 import org.compiere.model.MWarehouse;
+import org.compiere.util.Util;
 
 /** Generated Process for (In Out Create From)
  *  @author ADempiere (generated) 
@@ -55,7 +56,7 @@ public class InOutCreateFrom extends InOutCreateFromAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @M_InOut_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/compiere/process/InOutCreateFrom.java
+++ b/base/src/org/compiere/process/InOutCreateFrom.java
@@ -56,7 +56,7 @@ public class InOutCreateFrom extends InOutCreateFromAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@M_InOut_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @M_InOut_ID@ (@Record_ID@)");
 		}
 	}
 	

--- a/base/src/org/compiere/process/InOutCreateInvoice.java
+++ b/base/src/org/compiere/process/InOutCreateInvoice.java
@@ -41,6 +41,10 @@ public class InOutCreateInvoice extends InOutCreateInvoiceAbstract
 	 */
 	protected void prepare() {
 		super.prepare();
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@Shipment@ (@Record_ID@) @NotFound@");
+		}
 	}	//	prepare
 
 	/**
@@ -52,8 +56,6 @@ public class InOutCreateInvoice extends InOutCreateInvoiceAbstract
 		log.info("M_InOut_ID=" + getRecord_ID()
 			+ ", M_PriceList_ID=" + getPriceListId()
 			+ ", InvoiceDocumentNo=" + getInvoiceDocumentNo());
-		if (getRecord_ID() == 0)
-			throw new IllegalArgumentException("No Shipment");
 		//
 		MInOut materialReceipt = new MInOut (getCtx(), getRecord_ID(), get_TrxName());
 		if (materialReceipt.get_ID() == 0)

--- a/base/src/org/compiere/process/InOutCreateInvoice.java
+++ b/base/src/org/compiere/process/InOutCreateInvoice.java
@@ -21,7 +21,8 @@ import org.compiere.model.MInOut;
 import org.compiere.model.MInOutLine;
 import org.compiere.model.MInvoice;
 import org.compiere.model.MInvoiceLine;
- 
+import org.compiere.util.Util;
+
 import java.util.Optional;
 
 /**
@@ -42,7 +43,7 @@ public class InOutCreateInvoice extends InOutCreateInvoiceAbstract
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @Shipment@ (@Record_ID@)");
 		}
 	}	//	prepare
@@ -58,11 +59,13 @@ public class InOutCreateInvoice extends InOutCreateInvoiceAbstract
 			+ ", InvoiceDocumentNo=" + getInvoiceDocumentNo());
 		//
 		MInOut materialReceipt = new MInOut (getCtx(), getRecord_ID(), get_TrxName());
-		if (materialReceipt.get_ID() == 0)
-			throw new IllegalArgumentException("Shipment not found");
-		if (!MInOut.DOCSTATUS_Completed.equals(materialReceipt.getDocStatus()))
-			throw new IllegalArgumentException("Shipment not completed");
-		
+		if (materialReceipt.get_ID() == 0) {
+			throw new AdempiereException("@Shipment@ @NotFound@");
+		}
+		if (!MInOut.DOCSTATUS_Completed.equals(materialReceipt.getDocStatus())) {
+			throw new AdempiereException("@Shipment@ @NoCompleted@");
+		}
+
 		MInOutLine[] materialReceiptLines = materialReceipt.getLines(false);
 		for (MInOutLine materialReceiptLine : materialReceiptLines) {
 			Optional<MInvoiceLine> maybeInvoiceLine = Optional.ofNullable(MInvoiceLine.getOfInOutLine(materialReceiptLine));

--- a/base/src/org/compiere/process/InOutCreateInvoice.java
+++ b/base/src/org/compiere/process/InOutCreateInvoice.java
@@ -43,7 +43,7 @@ public class InOutCreateInvoice extends InOutCreateInvoiceAbstract
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@Shipment@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @Shipment@ (@Record_ID@)");
 		}
 	}	//	prepare
 

--- a/base/src/org/compiere/process/InvoiceCreateFrom.java
+++ b/base/src/org/compiere/process/InvoiceCreateFrom.java
@@ -56,7 +56,7 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_Invoice_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_Invoice_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/compiere/process/InvoiceCreateFrom.java
+++ b/base/src/org/compiere/process/InvoiceCreateFrom.java
@@ -54,14 +54,15 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_Invoice_ID@ (@Record_ID@) @NotFound@");
+		}
 	}
 
 	@Override
 	protected String doIt() throws Exception {
-		// Valid Record Identifier
-		if(getRecord_ID() == 0)
-			return "";
-		//	Get Shipment
+		//	Get Invoice
 		MInvoice invoice = new MInvoice(getCtx(), getRecord_ID(), get_TrxName());
 		AtomicInteger referenceId = new AtomicInteger(0);
 		AtomicInteger 	created = new AtomicInteger(0);

--- a/base/src/org/compiere/process/InvoiceCreateFrom.java
+++ b/base/src/org/compiere/process/InvoiceCreateFrom.java
@@ -34,6 +34,7 @@ import org.compiere.model.MRMALine;
 import org.compiere.model.MUOMConversion;
 import org.compiere.model.PO;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 /** Generated Process for (Invoice Create From)
  *  @author ADempiere (generated)
@@ -55,7 +56,7 @@ public class InvoiceCreateFrom extends InvoiceCreateFromAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_Invoice_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/compiere/process/InvoiceCreateInOut.java
+++ b/base/src/org/compiere/process/InvoiceCreateInOut.java
@@ -26,6 +26,7 @@ import org.compiere.model.MInvoiceLine;
 import org.compiere.model.MMatchPO;
 import org.compiere.model.MOrderLine;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 import java.math.BigDecimal;
  
@@ -50,6 +51,10 @@ public class InvoiceCreateInOut extends InvoiceCreateInOutAbstract
 	protected void prepare()
 	{
 		super.prepare();
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
+			throw new AdempiereException("@FillMandatory@ @C_Invoice_ID@ (@Record_ID@)");
+		}
 	}	//	prepare
 
 	
@@ -61,8 +66,6 @@ public class InvoiceCreateInOut extends InvoiceCreateInOutAbstract
 	protected String doIt () throws Exception
 	{
 		log.info("C_Invoice_ID=" + getRecord_ID() + ", M_Warehouse_ID=" + getWarehouseId());
-		if (getRecord_ID() <= 0)
-			throw new FillMandatoryException("C_Invoice_ID");
 		if (getWarehouseId() == 0)
 			throw new FillMandatoryException(PARAM_M_Warehouse_ID);
 		//

--- a/base/src/org/compiere/process/OrderLineCreateShipment.java
+++ b/base/src/org/compiere/process/OrderLineCreateShipment.java
@@ -42,7 +42,7 @@ public class OrderLineCreateShipment extends OrderLineCreateShipmentAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_OrderLine_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_OrderLine_ID@ (@Record_ID@)");
 		}
 		if(getMovementDate() == null) {
 			setMovementDate(Env.getContextAsDate(getCtx(), "#Date"));

--- a/base/src/org/compiere/process/OrderLineCreateShipment.java
+++ b/base/src/org/compiere/process/OrderLineCreateShipment.java
@@ -18,6 +18,7 @@ package org.compiere.process;
 
 import java.sql.Timestamp;
 
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MInOut;
 import org.compiere.model.MInOutLine;
 import org.compiere.model.MOrder;
@@ -39,6 +40,10 @@ public class OrderLineCreateShipment extends OrderLineCreateShipmentAbstract {
 	 */
 	protected void prepare() {
 		super.prepare();
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_OrderLine_ID@ (@Record_ID@) @NotFound@");
+		}
 		if(getMovementDate() == null) {
 			setMovementDate(Env.getContextAsDate(getCtx(), "#Date"));
 			if (getMovementDate() == null) {
@@ -60,9 +65,6 @@ public class OrderLineCreateShipment extends OrderLineCreateShipmentAbstract {
 	 */
 	protected String doIt () throws Exception {
 		log.info("C_OrderLine_ID=" + getRecord_ID());
-		if (getRecord_ID() == 0) {
-			throw new IllegalArgumentException("@C_OrderLine_ID@ @NotFound@");
-		}
 		//
 		MOrderLine line = new MOrderLine (getCtx(), getRecord_ID(), get_TrxName());
 		if (line.get_ID() == 0) {

--- a/base/src/org/compiere/process/OrderLineCreateShipment.java
+++ b/base/src/org/compiere/process/OrderLineCreateShipment.java
@@ -24,6 +24,7 @@ import org.compiere.model.MInOutLine;
 import org.compiere.model.MOrder;
 import org.compiere.model.MOrderLine;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
  
 /**
  *	Create (Generate) Invoice from Shipment
@@ -41,7 +42,7 @@ public class OrderLineCreateShipment extends OrderLineCreateShipmentAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_OrderLine_ID@ (@Record_ID@)");
 		}
 		if(getMovementDate() == null) {

--- a/base/src/org/compiere/process/PSCreateFromHRMovement.java
+++ b/base/src/org/compiere/process/PSCreateFromHRMovement.java
@@ -27,6 +27,7 @@ import org.adempiere.core.domains.models.X_HR_Process;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MPaySelection;
 import org.compiere.model.MPaySelectionLine;
+import org.compiere.util.Util;
 
 /**
  * 	Payment Selection Create From Invoice, used for Smart Browse (Create From Payroll Movement)
@@ -44,14 +45,18 @@ public class PSCreateFromHRMovement extends PSCreateFromHRMovementAbstract {
 	protected void prepare() {
 		super.prepare();
 		//	Valid Record Identifier
-		if(getRecord_ID() <= 0)
-			throw new AdempiereException("@C_PaySelection_ID@ @NotFound@");
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
+			throw new AdempiereException("@FillMandatory@ @C_PaySelection_ID@ (@Record_ID@)");
+		}
 	}
 
 	@Override
 	protected String doIt() throws Exception {
 		//	Instance current Payment Selection
 		MPaySelection paySelection = new MPaySelection(getCtx(), getRecord_ID(), get_TrxName());
+		if (paySelection.getC_PaySelection_ID() <= 0) {
+			throw new AdempiereException("@C_PaySelection_ID@ @NotFound@");
+		}
 		sequence.set(paySelection.getLastLineNo());
 		//	Loop for keys
 		getSelectionKeys().forEach(key -> {

--- a/base/src/org/compiere/process/PSCreateFromOrder.java
+++ b/base/src/org/compiere/process/PSCreateFromOrder.java
@@ -22,6 +22,7 @@ import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MPaySelection;
 import org.compiere.model.MPaySelectionLine;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 /**
  * 	Payment Selection Create From Invoice, used for Smart Browse (Create From Order)
@@ -38,14 +39,18 @@ public class PSCreateFromOrder extends PSCreateFromOrderAbstract {
 	protected void prepare() {
 		super.prepare();
 		//	Valid Record Identifier
-		if(getRecord_ID() <= 0)
-			throw new AdempiereException("@C_PaySelection_ID@ @NotFound@");
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
+			throw new AdempiereException("@FillMandatory@ @C_PaySelection_ID@ (@Record_ID@)");
+		}
 	}
 
 	@Override
 	protected String doIt() throws Exception {
 		//	Instance current Payment Selection
 		MPaySelection paySelection = new MPaySelection(getCtx(), getRecord_ID(), get_TrxName());
+		if (paySelection.getC_PaySelection_ID() <= 0) {
+			throw new AdempiereException("@C_PaySelection_ID@ @NotFound@");
+		}
 		m_SeqNo = paySelection.getLastLineNo();
 		//	Loop for keys
 		for(Integer key : getSelectionKeys()) {

--- a/base/src/org/compiere/process/PSCreateFromPaySelection.java
+++ b/base/src/org/compiere/process/PSCreateFromPaySelection.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MPaySelection;
 import org.compiere.model.MPaySelectionLine;
+import org.compiere.util.Util;
 
 /**
  * 	Payment Selection Create From Invoice, used for Smart Browse (Create From Payment Request)
@@ -37,14 +38,18 @@ public class PSCreateFromPaySelection extends PSCreateFromPaySelectionAbstract {
 	protected void prepare() {
 		super.prepare();
 		//	Valid Record Identifier
-		if(getRecord_ID() <= 0)
-			throw new AdempiereException("@C_PaySelection_ID@ @NotFound@");
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
+			throw new AdempiereException("@FillMandatory@ @C_PaySelection_ID@");
+		}
 	}
 
 	@Override
 	protected String doIt() throws Exception {
 		//	Instance current Payment Selection
 		MPaySelection paySelection = new MPaySelection(getCtx(), getRecord_ID(), get_TrxName());
+		if (paySelection.getC_PaySelection_ID() <= 0) {
+			throw new AdempiereException("@C_PaySelection_ID@ @NotFound@");
+		}
 		m_SeqNo = paySelection.getLastLineNo();
 		//	Loop for keys
 		for(Integer key : getSelectionKeys()) {

--- a/base/src/org/compiere/process/PaySelectionCreateFrom.java
+++ b/base/src/org/compiere/process/PaySelectionCreateFrom.java
@@ -31,6 +31,7 @@ import org.compiere.model.MPaySelection;
 import org.compiere.model.MPaySelectionLine;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 
 /**
@@ -101,7 +102,7 @@ public class PaySelectionCreateFrom extends SvrProcess
 		p_C_PaySelection_ID = getRecord_ID();
 
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_PaySelection_ID@ (@Record_ID@)");
 		}
 	}	//	prepare

--- a/base/src/org/compiere/process/PaySelectionCreateFrom.java
+++ b/base/src/org/compiere/process/PaySelectionCreateFrom.java
@@ -26,6 +26,7 @@ import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.util.logging.Level;
 
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MPaySelection;
 import org.compiere.model.MPaySelectionLine;
 import org.compiere.util.DB;
@@ -98,6 +99,11 @@ public class PaySelectionCreateFrom extends SvrProcess
 				log.log(Level.SEVERE, "Unknown Parameter: " + name);
 		}
 		p_C_PaySelection_ID = getRecord_ID();
+
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@FillMandatory@ @C_PaySelection_ID@ (@Record_ID@)");
+		}
 	}	//	prepare
 
 	/**

--- a/base/src/org/compiere/process/StatementCreateFrom.java
+++ b/base/src/org/compiere/process/StatementCreateFrom.java
@@ -29,6 +29,7 @@ import org.compiere.model.MConversionRate;
 import org.compiere.model.MPayment;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 
 /** Generated Process for (Create From Statement (Process))
@@ -41,16 +42,20 @@ public class StatementCreateFrom extends StatementCreateFromAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
+			throw new AdempiereException("@FillMandatory@ @C_BankStatement_ID@ (@Record_ID@)");
+		}
 	}
 
 	@Override
 	protected String doIt() throws Exception {
 		//	Copied from CreateFromStatement old class
-		//  fixed values
-		if (getRecord_ID() <= 0)
-			throw new AdempiereException("@C_BankStatement_ID@ @NotFound@");
-
 		MBankStatement bankStatement = new MBankStatement (Env.getCtx(), getRecord_ID(), get_TrxName());
+		//  fixed values
+		if (bankStatement.getC_BankStatement_ID() <= 0) {
+			throw new AdempiereException("@C_BankStatement_ID@ @NotFound@");
+		}
 		//	Get Bank Account
 		MBankAccount bankAccount = bankStatement.getBankAccount();
 		//	Created

--- a/base/src/org/compiere/util/Util.java
+++ b/base/src/org/compiere/util/Util.java
@@ -21,9 +21,11 @@ import java.awt.font.TextAttribute;
 import java.io.UnsupportedEncodingException;
 import java.text.AttributedCharacterIterator;
 import java.text.AttributedString;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -320,7 +322,17 @@ public class Util
 			return str.length() == 0;
 	}	//	isEmpty
 
-	
+
+	/**
+	 * Is Collection Empty or Null
+	 * @param collection
+	 * @return
+	 */
+	public static boolean isEmptyCollection(Collection<?> collection) {
+		return Objects.isNull(collection) || collection.isEmpty();
+	}
+
+
 	/**************************************************************************
 	 * Find index of search character in str.
 	 * This ignores content in () and 'texts'

--- a/base/src/org/eevolution/process/GenerateInvoiceFromPayment.java
+++ b/base/src/org/eevolution/process/GenerateInvoiceFromPayment.java
@@ -40,12 +40,14 @@ public class GenerateInvoiceFromPayment extends GenerateInvoiceFromPaymentAbstra
     @Override
     protected void prepare() {
         super.prepare();
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@FillMandatory@ @C_Payment_ID@ (@Record_ID@)");
+		}
     }
 
     @Override
     protected String doIt() throws Exception {
-        if (getRecord_ID() <= 0)
-            throw new AdempiereException("@Record_ID@ @NotFound@");
         MPayment payment = new MPayment(getCtx(), getRecord_ID(), get_TrxName());
         if (MPayment.DOCACTION_Complete.equals(payment.getDocStatus()) || MPayment.DOCACTION_Close.equals(payment.getDocStatus())) {
             if (getPayAmt() != null && getPayAmt().compareTo(payment.getPayAmt()) > 0)

--- a/base/src/org/eevolution/process/GenerateInvoiceFromPayment.java
+++ b/base/src/org/eevolution/process/GenerateInvoiceFromPayment.java
@@ -25,6 +25,7 @@ import org.compiere.model.MInvoiceLine;
 import org.compiere.model.MPayment;
 import org.compiere.model.MPriceList;
 import org.compiere.util.Msg;
+import org.compiere.util.Util;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -41,7 +42,7 @@ public class GenerateInvoiceFromPayment extends GenerateInvoiceFromPaymentAbstra
     protected void prepare() {
         super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_Payment_ID@ (@Record_ID@)");
 		}
     }

--- a/base/src/org/spin/process/ASPCopyBrowserFrom.java
+++ b/base/src/org/spin/process/ASPCopyBrowserFrom.java
@@ -40,7 +40,7 @@ public class ASPCopyBrowserFrom extends ASPCopyBrowserFromAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyBrowserFrom.java
+++ b/base/src/org/spin/process/ASPCopyBrowserFrom.java
@@ -38,8 +38,9 @@ public class ASPCopyBrowserFrom extends ASPCopyBrowserFromAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@Record_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyBrowserFrom.java
+++ b/base/src/org/spin/process/ASPCopyBrowserFrom.java
@@ -28,6 +28,7 @@ import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MBrowseCustom;
 import org.compiere.model.MBrowseFieldCustom;
 import org.compiere.model.PO;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Copy Browser from other ASP)
@@ -39,7 +40,7 @@ public class ASPCopyBrowserFrom extends ASPCopyBrowserFromAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/ASPCopyFromTab.java
+++ b/base/src/org/spin/process/ASPCopyFromTab.java
@@ -37,8 +37,9 @@ public class ASPCopyFromTab extends ASPCopyFromTabAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@AD_TabCustom_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@AD_TabCustom_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyFromTab.java
+++ b/base/src/org/spin/process/ASPCopyFromTab.java
@@ -27,6 +27,7 @@ import org.compiere.model.MTabCustom;
 import org.compiere.model.MTable;
 import org.compiere.model.PO;
 import org.compiere.model.Query;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Copy From Customized Tab)
@@ -38,7 +39,7 @@ public class ASPCopyFromTab extends ASPCopyFromTabAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @AD_TabCustom_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/ASPCopyFromTab.java
+++ b/base/src/org/spin/process/ASPCopyFromTab.java
@@ -39,7 +39,7 @@ public class ASPCopyFromTab extends ASPCopyFromTabAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@AD_TabCustom_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @AD_TabCustom_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyFromWindow.java
+++ b/base/src/org/spin/process/ASPCopyFromWindow.java
@@ -37,8 +37,9 @@ public class ASPCopyFromWindow extends ASPCopyFromWindowAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@AD_WindowCustom_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@AD_WindowCustom_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyFromWindow.java
+++ b/base/src/org/spin/process/ASPCopyFromWindow.java
@@ -26,6 +26,7 @@ import org.compiere.model.MTable;
 import org.compiere.model.MWindowCustom;
 import org.compiere.model.PO;
 import org.compiere.model.Query;
+import org.compiere.util.Util;
 import org.eevolution.services.dsl.ProcessBuilder;
 
 /** 
@@ -38,7 +39,7 @@ public class ASPCopyFromWindow extends ASPCopyFromWindowAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @AD_WindowCustom_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/ASPCopyFromWindow.java
+++ b/base/src/org/spin/process/ASPCopyFromWindow.java
@@ -39,7 +39,7 @@ public class ASPCopyFromWindow extends ASPCopyFromWindowAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@AD_WindowCustom_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @AD_WindowCustom_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyProcessFrom.java
+++ b/base/src/org/spin/process/ASPCopyProcessFrom.java
@@ -40,7 +40,7 @@ public class ASPCopyProcessFrom extends ASPCopyProcessFromAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyProcessFrom.java
+++ b/base/src/org/spin/process/ASPCopyProcessFrom.java
@@ -28,6 +28,7 @@ import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MProcessCustom;
 import org.compiere.model.MProcessParaCustom;
 import org.compiere.model.PO;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Copy Process from other ASP)
@@ -39,7 +40,7 @@ public class ASPCopyProcessFrom extends ASPCopyProcessFromAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/ASPCopyProcessFrom.java
+++ b/base/src/org/spin/process/ASPCopyProcessFrom.java
@@ -38,8 +38,9 @@ public class ASPCopyProcessFrom extends ASPCopyProcessFromAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@Record_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyWindowFrom.java
+++ b/base/src/org/spin/process/ASPCopyWindowFrom.java
@@ -41,7 +41,7 @@ public class ASPCopyWindowFrom extends ASPCopyWindowFromAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyWindowFrom.java
+++ b/base/src/org/spin/process/ASPCopyWindowFrom.java
@@ -39,8 +39,9 @@ public class ASPCopyWindowFrom extends ASPCopyWindowFromAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@Record_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 

--- a/base/src/org/spin/process/ASPCopyWindowFrom.java
+++ b/base/src/org/spin/process/ASPCopyWindowFrom.java
@@ -29,6 +29,7 @@ import org.compiere.model.MFieldCustom;
 import org.compiere.model.MTabCustom;
 import org.compiere.model.MWindowCustom;
 import org.compiere.model.PO;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Copy Window from other ASP)
@@ -40,7 +41,7 @@ public class ASPCopyWindowFrom extends ASPCopyWindowFromAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @ASP_Level_ID@ / @AD_Role_ID@ / @AD_User_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/CopyBrowserFromRole.java
+++ b/base/src/org/spin/process/CopyBrowserFromRole.java
@@ -40,7 +40,7 @@ public class CopyBrowserFromRole extends CopyBrowserFromRoleAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@AD_Role_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @AD_Role_ID@ (@Record_ID@)");
 		}
 	}
 	

--- a/base/src/org/spin/process/CopyBrowserFromRole.java
+++ b/base/src/org/spin/process/CopyBrowserFromRole.java
@@ -28,6 +28,7 @@ import org.adempiere.model.MBrowse;
 import org.compiere.model.MProcess;
 import org.compiere.model.MProcessAccess;
 import org.compiere.model.Query;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Copy Browser From Role)
@@ -39,7 +40,7 @@ public class CopyBrowserFromRole extends CopyBrowserFromRoleAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @AD_Role_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/CopyBrowserFromRole.java
+++ b/base/src/org/spin/process/CopyBrowserFromRole.java
@@ -38,8 +38,9 @@ public class CopyBrowserFromRole extends CopyBrowserFromRoleAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@AD_Role_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@AD_Role_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 	

--- a/base/src/org/spin/process/CopyFormFromRole.java
+++ b/base/src/org/spin/process/CopyFormFromRole.java
@@ -35,8 +35,9 @@ public class CopyFormFromRole extends CopyFormFromRoleAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@AD_Role_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@AD_Role_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 

--- a/base/src/org/spin/process/CopyFormFromRole.java
+++ b/base/src/org/spin/process/CopyFormFromRole.java
@@ -37,7 +37,7 @@ public class CopyFormFromRole extends CopyFormFromRoleAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@AD_Role_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @AD_Role_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/CopyFormFromRole.java
+++ b/base/src/org/spin/process/CopyFormFromRole.java
@@ -25,6 +25,7 @@ import org.adempiere.core.domains.models.X_AD_Form_Access;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MForm;
 import org.compiere.model.Query;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Copy Forms From Role)
@@ -36,7 +37,7 @@ public class CopyFormFromRole extends CopyFormFromRoleAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @AD_Role_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/CopyWindowFromRole.java
+++ b/base/src/org/spin/process/CopyWindowFromRole.java
@@ -44,7 +44,7 @@ public class CopyWindowFromRole extends CopyWindowFromRoleAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@AD_Role_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @AD_Role_ID@ (@Record_ID@)");
 		}
 	}
 	

--- a/base/src/org/spin/process/CopyWindowFromRole.java
+++ b/base/src/org/spin/process/CopyWindowFromRole.java
@@ -42,8 +42,9 @@ public class CopyWindowFromRole extends CopyWindowFromRoleAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@AD_Role_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@AD_Role_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 	

--- a/base/src/org/spin/process/CopyWindowFromRole.java
+++ b/base/src/org/spin/process/CopyWindowFromRole.java
@@ -32,6 +32,7 @@ import org.compiere.model.MTab;
 import org.compiere.model.MWindow;
 import org.compiere.model.MWindowAccess;
 import org.compiere.model.Query;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Copy Window From Role)
@@ -43,11 +44,11 @@ public class CopyWindowFromRole extends CopyWindowFromRoleAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @AD_Role_ID@ (@Record_ID@)");
 		}
 	}
-	
+
     @Override
     protected String doIt() throws Exception {
         AtomicInteger windowAdded = new AtomicInteger(0);

--- a/base/src/org/spin/process/CreateRoleFromDocumentAction.java
+++ b/base/src/org/spin/process/CreateRoleFromDocumentAction.java
@@ -39,7 +39,7 @@ public class CreateRoleFromDocumentAction extends CreateRoleFromDocumentActionAb
 		super.prepare();
 		// Valid Record Identifier
 		if (getRecord_ID() <= 0) {
-			throw new AdempiereException("@AD_Role_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @AD_Role_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/CreateRoleFromDocumentAction.java
+++ b/base/src/org/spin/process/CreateRoleFromDocumentAction.java
@@ -37,8 +37,9 @@ public class CreateRoleFromDocumentAction extends CreateRoleFromDocumentActionAb
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@AD_Role_ID@ @NotFound@");
+		// Valid Record Identifier
+		if (getRecord_ID() <= 0) {
+			throw new AdempiereException("@AD_Role_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 

--- a/base/src/org/spin/process/CreateRoleFromDocumentAction.java
+++ b/base/src/org/spin/process/CreateRoleFromDocumentAction.java
@@ -27,6 +27,7 @@ import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MRefList;
 import org.compiere.model.Query;
 import org.compiere.process.DocAction;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Create from Document Actions)
@@ -38,7 +39,7 @@ public class CreateRoleFromDocumentAction extends CreateRoleFromDocumentActionAb
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if (getRecord_ID() <= 0) {
+		if (getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @AD_Role_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/InOutRMACreateFrom.java
+++ b/base/src/org/spin/process/InOutRMACreateFrom.java
@@ -37,7 +37,16 @@ import org.compiere.model.MWarehouse;
  *  @version Release 3.9.2
  */
 public class InOutRMACreateFrom extends InOutRMACreateFromAbstract {
-	
+
+	@Override
+	protected void prepare() {
+		super.prepare();
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@M_InOut_ID@ (@Record_ID@) @NotFound@");
+		}
+	}
+
 	/**
 	 * Get a valid locator
 	 * @param locatorId
@@ -71,9 +80,6 @@ public class InOutRMACreateFrom extends InOutRMACreateFromAbstract {
 	
 	@Override
 	protected String doIt() throws Exception {
-		// Valid Record Identifier
-		if(getRecord_ID() == 0)
-			return "@M_InOut_ID@ @NotFound@";
 		//	Get Shipment
 		MInOut inout = new MInOut(getCtx(), getRecord_ID(), get_TrxName());
 		if(inout.isProcessed()) {

--- a/base/src/org/spin/process/InOutRMACreateFrom.java
+++ b/base/src/org/spin/process/InOutRMACreateFrom.java
@@ -43,7 +43,7 @@ public class InOutRMACreateFrom extends InOutRMACreateFromAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@M_InOut_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @M_InOut_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/InOutRMACreateFrom.java
+++ b/base/src/org/spin/process/InOutRMACreateFrom.java
@@ -30,6 +30,7 @@ import org.compiere.model.MOrder;
 import org.compiere.model.MOrderLine;
 import org.compiere.model.MProduct;
 import org.compiere.model.MWarehouse;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Order (RMA) Create From)
@@ -42,7 +43,7 @@ public class InOutRMACreateFrom extends InOutRMACreateFromAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @M_InOut_ID@ (@Record_ID@)");
 		}
 	}
@@ -82,6 +83,9 @@ public class InOutRMACreateFrom extends InOutRMACreateFromAbstract {
 	protected String doIt() throws Exception {
 		//	Get Shipment
 		MInOut inout = new MInOut(getCtx(), getRecord_ID(), get_TrxName());
+		if (inout.getM_InOut_ID() <= 0) {
+			throw new AdempiereException("@M_InOut_ID@ @NotFound@");
+		}
 		if(inout.isProcessed()) {
 			return "@M_InOut_ID@ @Processed@";
 		}

--- a/base/src/org/spin/process/OrderRMACreateFrom.java
+++ b/base/src/org/spin/process/OrderRMACreateFrom.java
@@ -43,7 +43,7 @@ public class OrderRMACreateFrom extends OrderRMACreateFromAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if (getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_Order_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_Order_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/OrderRMACreateFrom.java
+++ b/base/src/org/spin/process/OrderRMACreateFrom.java
@@ -30,6 +30,7 @@ import org.compiere.model.MOrderLine;
 import org.compiere.model.MProduct;
 import org.compiere.model.MUOMConversion;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Order (RMA) Create From)
@@ -42,7 +43,7 @@ public class OrderRMACreateFrom extends OrderRMACreateFromAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if (getRecord_ID() <= 0) {
+		if (getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_Order_ID@ (@Record_ID@)");
 		}
 	}
@@ -51,6 +52,9 @@ public class OrderRMACreateFrom extends OrderRMACreateFromAbstract {
 	protected String doIt() throws Exception {
 		//	Get Order
 		MOrder order = new MOrder(getCtx(), getRecord_ID(), get_TrxName());
+		if (order == null || order.getC_Order_ID() <= 0) {
+			throw new AdempiereException("@C_Order_ID@ @NotFound@");
+		}
 		if(order.isProcessed()) {
 			return "@C_Order_ID@ @Processed@";
 		}

--- a/base/src/org/spin/process/OrderRMACreateFrom.java
+++ b/base/src/org/spin/process/OrderRMACreateFrom.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MInOutLine;
 import org.compiere.model.MOrder;
 import org.compiere.model.MOrderLine;
@@ -36,13 +37,19 @@ import org.compiere.util.Env;
  *  @version Release 3.9.2
  */
 public class OrderRMACreateFrom extends OrderRMACreateFromAbstract {
-	
+
+	@Override
+	protected void prepare() {
+		super.prepare();
+		// Valid Record Identifier
+		if (getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_Order_ID@ (@Record_ID@) @NotFound@");
+		}
+	}
+
 	@Override
 	protected String doIt() throws Exception {
-		// Valid Record Identifier
-		if(getRecord_ID() == 0)
-			return "@C_Order_ID@ @NotFound@";
-		//	Get Shipment
+		//	Get Order
 		MOrder order = new MOrder(getCtx(), getRecord_ID(), get_TrxName());
 		if(order.isProcessed()) {
 			return "@C_Order_ID@ @Processed@";

--- a/base/src/org/spin/process/OrderRMACreateFromInvoice.java
+++ b/base/src/org/spin/process/OrderRMACreateFromInvoice.java
@@ -30,6 +30,7 @@ import org.compiere.model.MOrderLine;
 import org.compiere.model.MProduct;
 import org.compiere.model.MUOMConversion;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 /** 
  * 	Generated Process for (Order (RMA) Create From Invoice)
@@ -42,7 +43,7 @@ public class OrderRMACreateFromInvoice extends OrderRMACreateFromInvoiceAbstract
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if (getRecord_ID() <= 0) {
+		if (getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_Order_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/OrderRMACreateFromInvoice.java
+++ b/base/src/org/spin/process/OrderRMACreateFromInvoice.java
@@ -19,7 +19,6 @@ package org.spin.process;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/base/src/org/spin/process/OrderRMACreateFromInvoice.java
+++ b/base/src/org/spin/process/OrderRMACreateFromInvoice.java
@@ -44,7 +44,7 @@ public class OrderRMACreateFromInvoice extends OrderRMACreateFromInvoiceAbstract
 		super.prepare();
 		// Valid Record Identifier
 		if (getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_Order_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_Order_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/OrderRMACreateFromInvoice.java
+++ b/base/src/org/spin/process/OrderRMACreateFromInvoice.java
@@ -19,10 +19,12 @@ package org.spin.process;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MInvoiceLine;
 import org.compiere.model.MOrder;
 import org.compiere.model.MOrderLine;
@@ -36,12 +38,19 @@ import org.compiere.util.Env;
  *  @version Release 3.9.3
  */
 public class OrderRMACreateFromInvoice extends OrderRMACreateFromInvoiceAbstract {
+
+	@Override
+	protected void prepare() {
+		super.prepare();
+		// Valid Record Identifier
+		if (getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_Order_ID@ (@Record_ID@) @NotFound@");
+		}
+	}
+
 	@Override
 	protected String doIt() throws Exception {
-		// Valid Record Identifier
-		if(getRecord_ID() == 0)
-			return "@C_Order_ID@ @NotFound@";
-		//	Get Shipment
+		//	Get Order
 		MOrder order = new MOrder(getCtx(), getRecord_ID(), get_TrxName());
 		if(order.isProcessed()) {
 			return "@C_Order_ID@ @Processed@";

--- a/base/src/org/spin/process/PaySelectionReversePayment.java
+++ b/base/src/org/spin/process/PaySelectionReversePayment.java
@@ -23,6 +23,7 @@ import org.adempiere.core.domains.models.I_C_Payment;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MPayment;
 import org.compiere.model.Query;
+import org.compiere.util.Util;
 
 /** 
  * 	Reverse Payment
@@ -35,7 +36,7 @@ public class PaySelectionReversePayment extends PaySelectionReversePaymentAbstra
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_PaySelection_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/PaySelectionReversePayment.java
+++ b/base/src/org/spin/process/PaySelectionReversePayment.java
@@ -36,7 +36,7 @@ public class PaySelectionReversePayment extends PaySelectionReversePaymentAbstra
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_PaySelection_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_PaySelection_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/base/src/org/spin/process/PaySelectionReversePayment.java
+++ b/base/src/org/spin/process/PaySelectionReversePayment.java
@@ -34,8 +34,9 @@ public class PaySelectionReversePayment extends PaySelectionReversePaymentAbstra
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@C_PaySelection_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_PaySelection_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 

--- a/base/src/org/spin/process/PaySelectionSendRemittance.java
+++ b/base/src/org/spin/process/PaySelectionSendRemittance.java
@@ -55,7 +55,7 @@ public class PaySelectionSendRemittance extends PaySelectionSendRemittanceAbstra
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_PaySelection_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/PaySelectionSendRemittance.java
+++ b/base/src/org/spin/process/PaySelectionSendRemittance.java
@@ -54,8 +54,9 @@ public class PaySelectionSendRemittance extends PaySelectionSendRemittanceAbstra
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@C_PaySelection_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_PaySelection_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 	

--- a/base/src/org/spin/process/PaySelectionSendRemittance.java
+++ b/base/src/org/spin/process/PaySelectionSendRemittance.java
@@ -56,7 +56,7 @@ public class PaySelectionSendRemittance extends PaySelectionSendRemittanceAbstra
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_PaySelection_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_PaySelection_ID@ (@Record_ID@)");
 		}
 	}
 	

--- a/base/src/org/spin/process/PaymentIdentify.java
+++ b/base/src/org/spin/process/PaymentIdentify.java
@@ -43,8 +43,8 @@ public class PaymentIdentify extends PaymentIdentifyAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@Record_ID@ @NotFound@");
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_Payment_ID@ (@Record_ID@) @NotFound@");
 		}
 		//	Validate transaction date
 		if(getDateTrx() == null) {

--- a/base/src/org/spin/process/PaymentIdentify.java
+++ b/base/src/org/spin/process/PaymentIdentify.java
@@ -33,6 +33,7 @@ import org.compiere.model.Query;
 import org.compiere.process.DocAction;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
+import org.compiere.util.Util;
 
 /** Generated Process for (Identify Payment)
  *  @author ADempiere (generated) 
@@ -43,7 +44,7 @@ public class PaymentIdentify extends PaymentIdentifyAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_Payment_ID@ (@Record_ID@)");
 		}
 		//	Validate transaction date

--- a/base/src/org/spin/process/PaymentIdentify.java
+++ b/base/src/org/spin/process/PaymentIdentify.java
@@ -44,7 +44,7 @@ public class PaymentIdentify extends PaymentIdentifyAbstract {
 	protected void prepare() {
 		super.prepare();
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_Payment_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_Payment_ID@ (@Record_ID@)");
 		}
 		//	Validate transaction date
 		if(getDateTrx() == null) {

--- a/base/src/org/spin/process/RFQCreateFromRequisition.java
+++ b/base/src/org/spin/process/RFQCreateFromRequisition.java
@@ -39,7 +39,7 @@ public class RFQCreateFromRequisition extends RFQCreateFromRequisitionAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_RfQ_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_RfQ_ID@ (@Record_ID@)");
 		}
 	}
 	

--- a/base/src/org/spin/process/RFQCreateFromRequisition.java
+++ b/base/src/org/spin/process/RFQCreateFromRequisition.java
@@ -37,8 +37,9 @@ public class RFQCreateFromRequisition extends RFQCreateFromRequisitionAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
-			throw new AdempiereException("@Record_ID@ @NotFound@");
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_RfQ_ID@ (@Record_ID@) @NotFound@");
 		}
 	}
 	

--- a/base/src/org/spin/process/RFQCreateFromRequisition.java
+++ b/base/src/org/spin/process/RFQCreateFromRequisition.java
@@ -38,7 +38,7 @@ public class RFQCreateFromRequisition extends RFQCreateFromRequisitionAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_RfQ_ID@ (@Record_ID@)");
 		}
 	}

--- a/base/src/org/spin/process/TestAppRegistration.java
+++ b/base/src/org/spin/process/TestAppRegistration.java
@@ -18,6 +18,7 @@
 package org.spin.process;
 
 import org.adempiere.exceptions.AdempiereException;
+import org.compiere.util.Util;
 import org.spin.model.MADAppRegistration;
 import org.spin.util.support.AppSupportHandler;
 
@@ -31,7 +32,7 @@ public class TestAppRegistration extends TestAppRegistrationAbstract {
 	@Override
 	protected String doIt() throws Exception {
 		//	Validate Config
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @AD_AppRegistration_ID@ (@Record_ID@)");
 		}
 		//	

--- a/base/src/org/spin/process/TestAppRegistration.java
+++ b/base/src/org/spin/process/TestAppRegistration.java
@@ -32,7 +32,7 @@ public class TestAppRegistration extends TestAppRegistrationAbstract {
 	protected String doIt() throws Exception {
 		//	Validate Config
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@AD_AppRegistration_ID@ @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @AD_AppRegistration_ID@ (@Record_ID@)");
 		}
 		//	
 		IAppSupport supportedApi = AppSupportHandler.getInstance().getAppSupport(MADAppRegistration.getById(getCtx(), getRecord_ID(), get_TrxName()));

--- a/base/test/src/org/compiere/util/UT_Util.java
+++ b/base/test/src/org/compiere/util/UT_Util.java
@@ -1,0 +1,71 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2024 ADempiere Foundation, All Rights Reserved.         *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * or via info@adempiere.net or http://www.adempiere.net/license.html         *
+ *****************************************************************************/
+package org.compiere.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.adempiere.test.CommonGWSetup;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Edwin Betancourt, EdwinBetanc0urt@outlook.com, https://github.com/EdwinBetanc0urt
+ */
+@Tag("org.compiere.util")
+@Tag("Util")
+@Tag("UnitTest")
+class UT_Util extends CommonGWSetup {
+
+	private List<?> nullCollection = null;
+
+	private List<?> emptyCollection = new ArrayList<>();
+
+	private List<?> filledCollection = Arrays.asList("any element", 2, true, '4');
+
+
+	@Test
+	void testIsEmptyCollection_null() {
+		boolean resultValue = Util.isEmptyCollection(this.nullCollection);
+		assertTrue(
+			resultValue,
+			"The `Util.isEmptyCollection` test with a null collection failed."
+		);
+	}
+
+	@Test
+	void testIsEmptyCollection_empty() {
+		boolean resultValue = Util.isEmptyCollection(this.emptyCollection);
+		assertFalse(
+			resultValue,
+			"The `Util.isEmptyCollection` test with a empty collection failed."
+		);
+	}
+
+	@Test
+	void testIsEmptyCollection_filled() {
+		boolean resultValue = Util.isEmptyCollection(this.filledCollection);
+		assertTrue(
+			!resultValue,
+			"The `Util.isEmptyCollection` test with a filled collection failed."
+		);
+	}
+
+}

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/CopyFromProject.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/CopyFromProject.java
@@ -32,7 +32,7 @@ public class CopyFromProject extends CopyFromProjectAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if (getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_Project_ID@ (@Record_ID@) @IsMandatory@");
+			throw new AdempiereException("@FillMandatory@ @C_Project_ID@ (@Record_ID@)");
 		}
 		if (getProjectId() == 0)
 			throw new IllegalArgumentException("@C_Project_ID@ @IsMandatory@");

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/CopyFromProject.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/CopyFromProject.java
@@ -16,6 +16,7 @@
  *****************************************************************************/
 package org.compiere.project.process;
 
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MProject;
 
 /**
@@ -29,8 +30,10 @@ public class CopyFromProject extends CopyFromProjectAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if (getRecord_ID() == 0)
-			throw new IllegalArgumentException("@Record_ID@ @IsMandatory@");
+		// Valid Record Identifier
+		if (getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_Project_ID@ (@Record_ID@) @IsMandatory@");
+		}
 		if (getProjectId() == 0)
 			throw new IllegalArgumentException("@C_Project_ID@ @IsMandatory@");
 	}

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/CopyFromProject.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/CopyFromProject.java
@@ -18,6 +18,7 @@ package org.compiere.project.process;
 
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MProject;
+import org.compiere.util.Util;
 
 /**
  *  Copy Project Details
@@ -31,7 +32,7 @@ public class CopyFromProject extends CopyFromProjectAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if (getRecord_ID() <= 0) {
+		if (getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_Project_ID@ (@Record_ID@)");
 		}
 		if (getProjectId() == 0)

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectClose.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectClose.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MProject;
 import org.compiere.model.MProjectLine;
+import org.compiere.util.Util;
  
 /**
  *  Close Project.
@@ -39,7 +40,7 @@ public class ProjectClose extends ProjectCloseAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if(getRecord_ID() <= 0) {
+		if(getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_Project_ID@ (@Record_ID@)");
 		}
 	}

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectClose.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectClose.java
@@ -38,7 +38,8 @@ public class ProjectClose extends ProjectCloseAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if(getRecord_ID() == 0) {
+		// Valid Record Identifier
+		if(getRecord_ID() <= 0) {
 			throw new AdempiereException("@C_Project_ID@ @IsMandatory@");
 		}
 	}

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectClose.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectClose.java
@@ -40,7 +40,7 @@ public class ProjectClose extends ProjectCloseAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if(getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_Project_ID@ @IsMandatory@");
+			throw new AdempiereException("@FillMandatory@ @C_Project_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectGenOrder.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectGenOrder.java
@@ -27,6 +27,7 @@ import org.compiere.model.MOrderLine;
 import org.compiere.model.MProject;
 import org.compiere.model.MProjectLine;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 /**
  *  Generate Sales Order from Project.
@@ -43,7 +44,7 @@ public class ProjectGenOrder extends ProjectGenOrderAbstract
 	{
 		super.prepare();
 		// Valid Record Identifier
-		if (getRecord_ID() <= 0) {
+		if (getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_Project_ID@ (@Record_ID@)");
 		}
 	}	//	prepare

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectGenOrder.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectGenOrder.java
@@ -42,6 +42,10 @@ public class ProjectGenOrder extends ProjectGenOrderAbstract
 	protected void prepare()
 	{
 		super.prepare();
+		// Valid Record Identifier
+		if (getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_Project_ID@ @NotFound@");
+		}
 	}	//	prepare
 
 	/**
@@ -52,8 +56,6 @@ public class ProjectGenOrder extends ProjectGenOrderAbstract
 	protected String doIt() throws Exception
 	{
 		log.info("C_Project_ID=" + getRecord_ID());
-		if (getRecord_ID() == 0)
-			throw new AdempiereException("@C_Project_ID@ @NotFound@");
 		MProject fromProject = getProject (getCtx(), getRecord_ID(), get_TrxName());
 		Env.setSOTrx(getCtx(), true);	//	Set SO context
 

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectGenOrder.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectGenOrder.java
@@ -44,7 +44,7 @@ public class ProjectGenOrder extends ProjectGenOrderAbstract
 		super.prepare();
 		// Valid Record Identifier
 		if (getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_Project_ID@ @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_Project_ID@ (@Record_ID@)");
 		}
 	}	//	prepare
 

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectLinePricing.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectLinePricing.java
@@ -17,6 +17,7 @@
 package org.compiere.project.process;
 
 
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MProductPricing;
 import org.compiere.model.MProject;
 import org.compiere.model.MProjectLine;
@@ -32,8 +33,10 @@ public class ProjectLinePricing extends ProjectLinePricingAbstract {
 	@Override
 	protected void prepare() {
 		super.prepare();
-		if (getRecord_ID() == 0)
-			throw new IllegalArgumentException("@C_ProjectLine_ID@ @IsMandatory@");
+		// Valid Record Identifier
+		if (getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_ProjectLine_ID@ @IsMandatory@");
+		}
 	}
 
 	/**

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectLinePricing.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectLinePricing.java
@@ -35,7 +35,7 @@ public class ProjectLinePricing extends ProjectLinePricingAbstract {
 		super.prepare();
 		// Valid Record Identifier
 		if (getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_ProjectLine_ID@ @IsMandatory@");
+			throw new AdempiereException("@FillMandatory@ @C_ProjectLine_ID@ (@Record_ID@)");
 		}
 	}
 

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectLinePricing.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectLinePricing.java
@@ -22,6 +22,7 @@ import org.compiere.model.MProductPricing;
 import org.compiere.model.MProject;
 import org.compiere.model.MProjectLine;
 import org.compiere.util.Msg;
+import org.compiere.util.Util;
 
 /**
  *  Price Project Line.
@@ -34,7 +35,7 @@ public class ProjectLinePricing extends ProjectLinePricingAbstract {
 	protected void prepare() {
 		super.prepare();
 		// Valid Record Identifier
-		if (getRecord_ID() <= 0) {
+		if (getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_ProjectLine_ID@ (@Record_ID@)");
 		}
 	}

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectPhaseGenOrder.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectPhaseGenOrder.java
@@ -45,6 +45,10 @@ public class ProjectPhaseGenOrder  extends ProjectPhaseGenOrderAbstract
 	protected void prepare()
 	{
 		super.prepare();
+		// Valid Record Identifier
+		if (getRecord_ID() <= 0) {
+			throw new AdempiereException("@C_ProjectPhase_ID@ (@Record_ID@) @NotFound@");
+		}
 	}	//	prepare
 
 	/**
@@ -55,8 +59,6 @@ public class ProjectPhaseGenOrder  extends ProjectPhaseGenOrderAbstract
 	protected String doIt() throws Exception
 	{
 		log.info("doIt - C_ProjectPhase_ID=" + getRecord_ID());
-		if (getRecord_ID() == 0)
-			throw new IllegalArgumentException("C_ProjectPhase_ID == 0");
 		MProjectPhase fromPhase = new MProjectPhase (getCtx(), getRecord_ID(), get_TrxName());
 		MProject fromProject = ProjectGenOrder.getProject (getCtx(), fromPhase.getC_Project_ID(), get_TrxName());
 		if (fromProject.getC_PaymentTerm_ID() <= 0)

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectPhaseGenOrder.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectPhaseGenOrder.java
@@ -47,7 +47,7 @@ public class ProjectPhaseGenOrder  extends ProjectPhaseGenOrderAbstract
 		super.prepare();
 		// Valid Record Identifier
 		if (getRecord_ID() <= 0) {
-			throw new AdempiereException("@C_ProjectPhase_ID@ (@Record_ID@) @NotFound@");
+			throw new AdempiereException("@FillMandatory@ @C_ProjectPhase_ID@ (@Record_ID@)");
 		}
 	}	//	prepare
 

--- a/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectPhaseGenOrder.java
+++ b/org.adempiere.project/src/main/java/org/compiere/project/process/ProjectPhaseGenOrder.java
@@ -29,6 +29,7 @@ import org.compiere.model.MProjectLine;
 import org.compiere.model.MProjectPhase;
 import org.compiere.model.MProjectTask;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 
 
 /**
@@ -46,7 +47,7 @@ public class ProjectPhaseGenOrder  extends ProjectPhaseGenOrderAbstract
 	{
 		super.prepare();
 		// Valid Record Identifier
-		if (getRecord_ID() <= 0) {
+		if (getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @C_ProjectPhase_ID@ (@Record_ID@)");
 		}
 	}	//	prepare

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/hr/process/HRPaySelectionCreateFrom.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/hr/process/HRPaySelectionCreateFrom.java
@@ -18,6 +18,7 @@ package org.eevolution.hr.process;
 import org.adempiere.core.domains.models.I_C_BPartner;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.Query;
+import org.compiere.util.Util;
 import org.eevolution.hr.model.MHREmployee;
 import org.eevolution.hr.model.MHRMovement;
 import org.eevolution.hr.model.MHRPaySelection;
@@ -61,7 +62,7 @@ public class HRPaySelectionCreateFrom extends HRPaySelectionCreateFromAbstract {
 
         List<Object> parameters = new ArrayList<Object>();
 		// Valid Record Identifier
-		if (getRecord_ID() <= 0) {
+		if (getRecord_ID() <= 0 && Util.isEmptyCollection(getSelectionKeys())) {
 			throw new AdempiereException("@FillMandatory@ @HR_PaySelection_ID@ (@Record_ID@)");
 		}
         if (paySelection.isProcessed())

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/hr/process/HRPaySelectionCreateFrom.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/hr/process/HRPaySelectionCreateFrom.java
@@ -16,6 +16,7 @@
 package org.eevolution.hr.process;
 
 import org.adempiere.core.domains.models.I_C_BPartner;
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.Query;
 import org.eevolution.hr.model.MHREmployee;
 import org.eevolution.hr.model.MHRMovement;
@@ -59,8 +60,10 @@ public class HRPaySelectionCreateFrom extends HRPaySelectionCreateFromAbstract {
         paySelection.saveEx();
 
         List<Object> parameters = new ArrayList<Object>();
-        if (getRecord_ID() == 0)
-            throw new IllegalArgumentException("@HR_PaySelection_ID@ @Notfound@");
+		// Valid Record Identifier
+		if (getRecord_ID() <= 0) {
+			throw new AdempiereException("@HR_PaySelection_ID@ (@Record_ID@) @Notfound@");
+		}
         if (paySelection.isProcessed())
             throw new IllegalArgumentException("@HR_PaySelection_ID@ @Processed@");
 

--- a/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/hr/process/HRPaySelectionCreateFrom.java
+++ b/org.eevolution.hr_and_payroll/src/main/java/base/org/eevolution/hr/process/HRPaySelectionCreateFrom.java
@@ -62,7 +62,7 @@ public class HRPaySelectionCreateFrom extends HRPaySelectionCreateFromAbstract {
         List<Object> parameters = new ArrayList<Object>();
 		// Valid Record Identifier
 		if (getRecord_ID() <= 0) {
-			throw new AdempiereException("@HR_PaySelection_ID@ (@Record_ID@) @Notfound@");
+			throw new AdempiereException("@FillMandatory@ @HR_PaySelection_ID@ (@Record_ID@)");
 		}
         if (paySelection.isProcessed())
             throw new IllegalArgumentException("@HR_PaySelection_ID@ @Processed@");


### PR DESCRIPTION
When `Record_ID` is empty the process runs successfully without sending an exception message in some cases, for example:


https://github.com/adempiere/adempiere/blob/59557cc2ee85ac938cd4f31a246d891bc2b15b8f/base/src/org/compiere/process/InvoiceCreateFrom.java#L61-L63

Some are validated but if the value is -1 it is considered a valid identifier.

More detail is also added to the message to more correctly identify which id is missing.