### PR TITLE
adempiere NPE completing a Warehouse Order, line without product #4288

### DIFF
--- a/org.adempiere.asset/src/main/java/base/org/compiere/asset/model/validator/FixedAsset.java
+++ b/org.adempiere.asset/src/main/java/base/org/compiere/asset/model/validator/FixedAsset.java
@@ -199,6 +199,8 @@ implements org.compiere.model.ModelValidator, org.compiere.model.FactsValidator
 				MInOut inOut = (MInOut) po;
 				for (MInOutLine inOutLine :  inOut.getLines())
 				{
+//					if (inOutLine.getM_Product_ID()<=0)
+//						continue;
 					MProduct product = inOutLine.getProduct();
 					MProductCategory productCategory = MProductCategory.get(product.getCtx(), product.getM_Product_Category_ID());
 					MAssetGroup assetGroup = MAssetGroup.get(product.getCtx(), productCategory.getA_Asset_Group_ID()); 


### PR DESCRIPTION
Issue https://github.com/adempiere/adempiere/issues/4288

When a warehouse Order includes lines without product the validator fixedassets.java generates a NPE.
Theese can be description lines or lines with a charge.

Solution:
capture of the case of lines without products. 
```

MInOut inOut = (MInOut) po;
for (MInOutLine inOutLine :  inOut.getLines())
{
if (inOutLine.getM_Product_ID()<=0)
continue;
MProduct product = inOutLine.getProduct();
MProductCategory productCategory = MProductCategory.get(product.getCtx(), product.getM_Product_Category_ID());
MAssetGroup assetGroup = MAssetGroup.get(product.getCtx(), productCategory.getA_Asset_Group_ID()); 
...
}
```