### PR TITLE
fix: Resource leak: 'zipFile' is never closed.

### DIFF
--- a/base/src/org/adempiere/pipo/CreateZipFile.java
+++ b/base/src/org/adempiere/pipo/CreateZipFile.java
@@ -99,22 +99,29 @@ public class CreateZipFile {
             Unzipper.setOwningTarget(new Target());	
             Unzipper.execute();
      }
-	static public String getParentDir(File zipFilepath)
-    {
+
+	static public String getParentDir(File zipFilepath) throws IOException
+	{
+		String fileName = "";
+		ZipFile zipFile = null;
 		try {
-		ZipFile zipFile = new ZipFile(zipFilepath);
-		Enumeration<? extends ZipEntry> entries = zipFile.entries();
-		ZipEntry entry = entries.nextElement();
-		File tempfile = new File(entry.getName());
-		while (tempfile.getParent()!=null)
-			tempfile = tempfile.getParentFile();		
-		return tempfile.getName();
+			zipFile = new ZipFile(zipFilepath);
+			Enumeration<? extends ZipEntry> entries = zipFile.entries();
+			ZipEntry entry = entries.nextElement();
+			File tempfile = new File(entry.getName());
+			while (tempfile.getParent()!=null) {
+				tempfile = tempfile.getParentFile();
+			}
+			fileName = tempfile.getName();
 		} catch (IOException ioe) {
-		      System.err.println("Unhandled exception:");
-		      ioe.printStackTrace();
-		      return "";
-	    }		
-     }
-	}//	CreateZipFile
+			System.err.println("Unhandled exception:");
+			ioe.printStackTrace();
+		} finally {
+			if (zipFile != null) {
+				zipFile.close();
+			}
+		}
+		return fileName;
+	}
 
-
+} //	CreateZipFile

--- a/base/src/org/adempiere/pipo/CreateZipFile.java
+++ b/base/src/org/adempiere/pipo/CreateZipFile.java
@@ -19,7 +19,6 @@ package org.adempiere.pipo;
 
 import io.vavr.control.Try;
 import java.io.File;
-import java.io.IOException;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -103,7 +102,7 @@ public class CreateZipFile {
      }
 
 
-	static public String getParentDir(File zipFilepath) throws IOException
+	static public String getParentDir(File zipFilepath)
 	{
 		Try<String> result = Try.withResources(() -> {
 				return new ZipFile(zipFilepath);


### PR DESCRIPTION
The IDE generates the warning `Resource leak: 'zipFile' is never closed`.

![imagen](https://github.com/adempiere/adempiere/assets/20288327/6dfbd2db-770a-4247-b4c5-8e1a84ee3967)


#### Additional context
To test this method, a packing must be created.
