### PR TITLE
#4332 Windows Fix JAVA version detected properly, Service FIX tomcat pid when is detected tomcat was not starting

### DIFF
--- a/install/Adempiere/RUN_setup.bat
+++ b/install/Adempiere/RUN_setup.bat
@@ -1,7 +1,28 @@
 @Title Install ADempiere Server
 @Echo off
 
-@CALL utils\functions.bat
+@CALL %CD%\utils\functions.bat
+
+rem
+rem check for correct java version by parsing out put of java -version
+rem we expect first line to be in format "java version 11.0.1" and assert that minor version number will be 11 or higher
+rem
+
+set EXPECTED_JAVA_VERSION=11
+
+for /f "tokens=3" %%g in ('%JAVA_HOME%\bin\java -version 2^>^&1 ^| findstr /i "version"') do (
+    set JAVAVER=%%g
+)
+set JAVAVER=%JAVAVER:"=%
+
+for /f "delims=. tokens=1" %%v in ("%JAVAVER%") do (
+
+   set JAVA=%%v
+   goto loaded_version
+)
+
+:loaded_version
+IF "%JAVA%" LSS "%EXPECTED_JAVA_VERSION%" goto wrong_version
 
 @if not "%JAVA_HOME%" == "" goto JAVA_HOME_OK
 @Set JAVA=java
@@ -72,3 +93,15 @@ cd utils
 @Echo For problems, check log file in base directory
 @Rem Wait 10 second
 @PING 1.1.1.1 -n 1 -w 10000 > NUL
+
+goto:eof
+
+:wrong_version
+echo *******************************************************************************
+echo *******    JAVA_HOME set to %JAVA_HOME%
+echo *******    Wrong JVM version! ADEMPIERE requires at least %EXPECTED_JAVA_VERSION% to run.    *******
+echo *******************************************************************************
+
+timeout /T 10
+
+exit /b 1

--- a/utils/RUN_Server2.sh
+++ b/utils/RUN_Server2.sh
@@ -59,11 +59,14 @@ if [ $ADEMPIERE_APPS_TYPE = "tomcat" ]; then
       else      
         echo "CATALINA_BASE: ${CATALINA_BASE}"
         PID="${CATALINA_BASE}/tomcat.pid"
-        if [ -f $PID ] && pgrep -F $PID ; then
-         echo "ADempiere's Server is already running .."
-        else
-          echo "ADempiere Server $ADEMPIERE_APPS_TYPE starting ..."
-          $CATALINA_BASE/bin/startup.sh
+	if [ -f $PID ] && pgrep -F $PID ; then
+	  if [ "$(ps -p $( <${PID}) -o comm=)" == "java" ] ; then
+            echo "ADempiere's Server is already running .. with PID ${PID}"
+          else
+	    rm -f ${PID}
+            echo "ADempiere Server $ADEMPIERE_APPS_TYPE starting ..."
+            $CATALINA_BASE/bin/startup.sh
+          fi
         fi
     fi    
 fi

--- a/utils/functions.bat
+++ b/utils/functions.bat
@@ -1,4 +1,4 @@
-@echo on
+@Echo OFF
 @REM Identify if the script runs from cmd console
 @REM Modified by Horacio Miranda, hmiranda@prolinux.cl, 2021-10-30
 @REM Variable CALLED_WITH_CMD_C is set when the bat is called from cmd


### PR DESCRIPTION
FIXED: RUN_setup.bat failed to detect the Java Version.
FIXED: RUN_Server2.sh failed to start Adempiere when Tomcat is used and PID file exist.