### PR TITLE
fix: Display lookup is same id.

### DIFF
--- a/base/src/org/compiere/model/MLookupFactory.java
+++ b/base/src/org/compiere/model/MLookupFactory.java
@@ -910,7 +910,7 @@ public class MLookupFactory
 		//  Do we have columns ?
 		if (list.size() == 0)
 		{
-			s_log.log(Level.SEVERE, "No Identifier records found: " + BaseTable + "." + ColumnName);
+			s_log.log(Level.SEVERE, "No Identifier records found: " + TableName + "." + ColumnName);
 			return "CASE "
 					+ "WHEN " + BaseTable + "." + ColumnName + " IS NULL THEN NULL "
 					+ "ELSE CONCAT('<', " + BaseTable + "." + ColumnName + ", '>') "

--- a/base/src/org/compiere/model/MLookupFactory.java
+++ b/base/src/org/compiere/model/MLookupFactory.java
@@ -910,8 +910,12 @@ public class MLookupFactory
 		//  Do we have columns ?
 		if (list.size() == 0)
 		{
-			s_log.log(Level.SEVERE, "No Identifier records found: " + ColumnName);
-			return "CONCAT('<', COALESCE(" + BaseTable + "." + ColumnName + ", -1) ,'>')";
+			s_log.log(Level.SEVERE, "No Identifier records found: " + BaseTable + "." + ColumnName);
+			return "CASE "
+					+ "WHEN " + BaseTable + "." + ColumnName + " IS NULL THEN NULL "
+					+ "ELSE CONCAT('<', " + BaseTable + "." + ColumnName + ", '>') "
+				+ "END"
+			;
 		}
 
 		//

--- a/base/src/org/compiere/model/MLookupFactory.java
+++ b/base/src/org/compiere/model/MLookupFactory.java
@@ -206,8 +206,8 @@ public class MLookupFactory
 			needToAddSecurity = false;
 		}
 		//	Table or Search with Reference_Value
-		else if ((AD_Reference_ID == DisplayType.Table || AD_Reference_ID == DisplayType.Search)
-			&& AD_Reference_Value_ID != 0)
+		else if (AD_Reference_ID == DisplayType.Table || (AD_Reference_ID == DisplayType.Search
+			&& AD_Reference_Value_ID > 0))
 		{
 			info = getLookup_Table (ctx, language, WindowNo, AD_Reference_Value_ID);
 		}
@@ -454,15 +454,17 @@ public class MLookupFactory
 		}
 
 		StringBuffer realSQL = new StringBuffer("SELECT ");
-		if (!KeyColumn.endsWith("_ID"))
+		if (KeyColumn != null && !KeyColumn.endsWith("_ID")) {
 			realSQL.append("NULL,");
+		}
 
 		//	Translated
 		if (IsTranslated && !Env.isBaseLanguage(language, TableName))
 		{
 			realSQL.append(TableName).append(".").append(KeyColumn).append(",");
-			if (KeyColumn.endsWith("_ID"))
+			if (KeyColumn != null && KeyColumn.endsWith("_ID")) {
 				realSQL.append("NULL,");
+			}
 			if ( !Util.isEmpty( displaySQL ))
 				realSQL.append("NVL(").append(displaySQL).append(",'-1')");
 			else 
@@ -486,8 +488,9 @@ public class MLookupFactory
 		else
 		{
 			realSQL.append(TableName).append(".").append(KeyColumn).append(",");
-			if (KeyColumn.endsWith("_ID"))
+			if (KeyColumn != null && KeyColumn.endsWith("_ID")) {
 				realSQL.append("NULL,");
+			}
 			if ( !Util.isEmpty( displaySQL ))
 				realSQL.append("NVL(").append(displaySQL).append(",'-1')");
 			else 
@@ -765,8 +768,8 @@ public class MLookupFactory
 			{
 				displayColumn.append(DB.TO_CHAR(columnSQL, ldc.DisplayType, language.getAD_Language()));
 			}
-			//  TableDir
-			else if ((ldc.DisplayType == DisplayType.TableDir || ldc.DisplayType == DisplayType.Search)
+			//  TableDir or Search
+			else if ((ldc.DisplayType == DisplayType.TableDir || (ldc.DisplayType == DisplayType.Search && ldc.AD_Reference_ID == 0))
 				&& ldc.ColumnName.endsWith("_ID"))
 			{
 				String embeddedSQL;
@@ -777,8 +780,8 @@ public class MLookupFactory
 				if (embeddedSQL != null)
 					displayColumn.append("(").append(embeddedSQL).append(")");
 			}
-			//	Table
-			else if (ldc.DisplayType == DisplayType.Table && ldc.AD_Reference_ID != 0)
+			//	Table or Search
+			else if (ldc.DisplayType == DisplayType.Table || (ldc.DisplayType == DisplayType.Search && ldc.AD_Reference_ID > 0))
 			{
 				String embeddedSQL;
 				if (ldc.IsVirtual)
@@ -908,7 +911,7 @@ public class MLookupFactory
 		if (list.size() == 0)
 		{
 			s_log.log(Level.SEVERE, "No Identifier records found: " + ColumnName);
-			return "";
+			return "CONCAT('<', COALESCE(" + BaseTable + "." + ColumnName + ", -1) ,'>')";
 		}
 
 		//
@@ -932,9 +935,9 @@ public class MLookupFactory
 			{
 				embedSQL.append("NVL(" + DB.TO_CHAR(columnSQL, ldc.DisplayType, language.getAD_Language()) + ",'')");
 			}
-			//  TableDir
-			else if ((ldc.DisplayType == DisplayType.TableDir || ldc.DisplayType == DisplayType.Search)
-			  && ldc.ColumnName.endsWith("_ID"))
+			//  TableDir or Search
+			else if ((ldc.DisplayType == DisplayType.TableDir || (ldc.DisplayType == DisplayType.Search && ldc.AD_Reference_ID == 0))
+				&& ldc.ColumnName.endsWith("_ID"))
 			{
 				String embeddedSQL;
 				if (ldc.IsVirtual)
@@ -943,8 +946,8 @@ public class MLookupFactory
 					embeddedSQL = getLookup_TableDirEmbed(language, ldc.ColumnName, TableName);
 				embedSQL.append("NVL((").append(embeddedSQL).append("),'')");
 			}
-			//	Table - teo_sarca [ 1714261 ]
-			else if (ldc.DisplayType == DisplayType.Table && ldc.AD_Reference_ID != 0)
+			//	Table or Search - teo_sarca [ 1714261 ]
+			else if ((ldc.DisplayType == DisplayType.Search || ldc.DisplayType == DisplayType.Table) && ldc.AD_Reference_ID > 0)
 			{
 				String embeddedSQL;
 				if (ldc.IsVirtual)
@@ -990,4 +993,3 @@ public class MLookupFactory
 	}	//  getLookup_TableDirEmbed
 
 }   //  MLookupFactory
-


### PR DESCRIPTION
When is refence Search with reference value and not identifiers generates error.

```log
adempiere-ui-gateway.zk                | org.postgresql.util.PSQLException: ERROR: syntax error at or near ")"
adempiere-ui-gateway.zk                |   Position: 91; State=42601; ErrorCode=0
adempiere-ui-gateway.zk                |        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)
adempiere-ui-gateway.zk                |        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365)
adempiere-ui-gateway.zk                |        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355)
adempiere-ui-gateway.zk                |        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490)
adempiere-ui-gateway.zk                |        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408)
adempiere-ui-gateway.zk                |        at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:166)
adempiere-ui-gateway.zk                |        at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:118)
adempiere-ui-gateway.zk                |        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
adempiere-ui-gateway.zk                |        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
adempiere-ui-gateway.zk                |        at jdk.internal.reflect.GeneratedMethodAccessor18.invoke(Unknown Source)
adempiere-ui-gateway.zk                |        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
adempiere-ui-gateway.zk                |        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
adempiere-ui-gateway.zk                |        at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
adempiere-ui-gateway.zk                |        at com.sun.proxy.$Proxy9.executeQuery(Unknown Source)
adempiere-ui-gateway.zk                |        at org.compiere.model.MLookup.getDirect(MLookup.java:473)
adempiere-ui-gateway.zk                |        at org.adempiere.webui.editor.WTableDirEditor.refreshList(WTableDirEditor.java:296)
adempiere-ui-gateway.zk                |        at org.adempiere.webui.editor.WTableDirEditor.setValue(WTableDirEditor.java:197)
adempiere-ui-gateway.zk                |        at org.adempiere.webui.editor.WTableDirEditor.propertyChange(WTableDirEditor.java:420)
adempiere-ui-gateway.zk                |        at java.desktop/java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:341)
adempiere-ui-gateway.zk                |        at java.desktop/java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:333)
adempiere-ui-gateway.zk                |        at java.desktop/java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:266)
adempiere-ui-gateway.zk                |        at org.compiere.model.GridField.setValue(GridField.java:1505)
adempiere-ui-gateway.zk                |        at org.compiere.model.GridTab.setCurrentRow(GridTab.java:2337)
adempiere-ui-gateway.zk                |        at org.compiere.model.GridTab.query(GridTab.java:749)
adempiere-ui-gateway.zk                |        at org.compiere.model.GridTab.query(GridTab.java:612)
```