### PR TITLE
fix: #4381 Filter product on `Located at` tab.

### DIFF
--- a/migration/394lts-3.9.4.002/10360_4381_Filter_Locatd_Product_Tab.xml
+++ b/migration/394lts-3.9.4.002/10360_4381_Filter_Locatd_Product_Tab.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="#4381 Filter Located Product Tab" ReleaseNo="3.9.4.002" SeqNo="10360">
+    <Comments>See https://github.com/adempiere/adempiere/issues/4381 By EdwinBetanc0urt.</Comments>
+    <Step SeqNo="10" StepType="AD">
+      <PO AD_Table_ID="106" Action="U" Record_ID="53244" Table="AD_Tab">
+        <Data AD_Column_ID="2740" Column="AD_Column_ID" isOldNull="true">1980</Data>
+      </PO>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION

### Before this changes

https://github.com/user-attachments/assets/1aa5c08c-3862-4764-9288-7e1c07475ac6



### After this changes

https://github.com/user-attachments/assets/92652e81-f3a3-4858-857a-ffca76de7569



### Additional context
The `M_Product_ID` column is added as a tab link.

![imagen](https://github.com/user-attachments/assets/146c0007-170a-4a76-9bd9-0750f0beafc8)

fixes https://github.com/adempiere/adempiere/issues/4381