### PR TITLE
Add auditable cost adjustment model for negative inventory, landed co…

### DIFF
--- a/base/src/org/adempiere/core/domains/models/I_C_CostAdjustmentEvent.java
+++ b/base/src/org/adempiere/core/domains/models/I_C_CostAdjustmentEvent.java
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2026 Adempiere Foundation. All Rights Reserved.          *
+ *****************************************************************************/
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+/** Generated Interface for C_CostAdjustmentEvent (manual stub, dictionary synced by migration) */
+public interface I_C_CostAdjustmentEvent {
+
+    String Table_Name = "C_CostAdjustmentEvent";
+
+    int Table_ID = 54001;
+
+    String COLUMNNAME_C_CostAdjustmentEvent_ID = "C_CostAdjustmentEvent_ID";
+    String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+    String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+    String COLUMNNAME_DocumentNo = "DocumentNo";
+    String COLUMNNAME_C_DocType_ID = "C_DocType_ID";
+    String COLUMNNAME_DateAcct = "DateAcct";
+    String COLUMNNAME_DateTrx = "DateTrx";
+    String COLUMNNAME_M_Product_ID = "M_Product_ID";
+    String COLUMNNAME_C_AcctSchema_ID = "C_AcctSchema_ID";
+    String COLUMNNAME_M_CostType_ID = "M_CostType_ID";
+    String COLUMNNAME_M_CostElement_ID = "M_CostElement_ID";
+    String COLUMNNAME_CostAdjustmentType = "CostAdjustmentType";
+    String COLUMNNAME_M_InOutLine_ID = "M_InOutLine_ID";
+    String COLUMNNAME_C_InvoiceLine_ID = "C_InvoiceLine_ID";
+    String COLUMNNAME_C_LandedCostAllocation_ID = "C_LandedCostAllocation_ID";
+    String COLUMNNAME_M_CostDetail_ID = "M_CostDetail_ID";
+    String COLUMNNAME_OldCostPrice = "OldCostPrice";
+    String COLUMNNAME_NewCostPrice = "NewCostPrice";
+    String COLUMNNAME_QtyOnHand = "QtyOnHand";
+    String COLUMNNAME_QtyAlreadySold = "QtyAlreadySold";
+    String COLUMNNAME_AdjustmentAmt = "AdjustmentAmt";
+    String COLUMNNAME_InventoryAmt = "InventoryAmt";
+    String COLUMNNAME_COGSAmt = "COGSAmt";
+    String COLUMNNAME_Description = "Description";
+    String COLUMNNAME_Processed = "Processed";
+    String COLUMNNAME_Posted = "Posted";
+    String COLUMNNAME_DocStatus = "DocStatus";
+    String COLUMNNAME_DocAction = "DocAction";
+    String COLUMNNAME_IsActive = "IsActive";
+
+    int getC_CostAdjustmentEvent_ID();
+
+    String getDocumentNo();
+
+    Timestamp getDateAcct();
+
+    Timestamp getDateTrx();
+
+    int getM_Product_ID();
+
+    int getC_AcctSchema_ID();
+
+    BigDecimal getAdjustmentAmt();
+
+    BigDecimal getInventoryAmt();
+
+    BigDecimal getCOGSAmt();
+
+    boolean isProcessed();
+
+    String getDocStatus();
+}

--- a/base/src/org/adempiere/core/domains/models/I_C_CostAdjustmentLine.java
+++ b/base/src/org/adempiere/core/domains/models/I_C_CostAdjustmentLine.java
@@ -1,0 +1,31 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ *****************************************************************************/
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+
+/** Generated Interface for C_CostAdjustmentLine (manual stub) */
+public interface I_C_CostAdjustmentLine {
+
+    String Table_Name = "C_CostAdjustmentLine";
+
+    int Table_ID = 54002;
+
+    String COLUMNNAME_C_CostAdjustmentLine_ID = "C_CostAdjustmentLine_ID";
+    String COLUMNNAME_C_CostAdjustmentEvent_ID = "C_CostAdjustmentEvent_ID";
+    String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+    String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+    String COLUMNNAME_Line = "Line";
+    String COLUMNNAME_AdjustmentLineType = "AdjustmentLineType";
+    String COLUMNNAME_Amt = "Amt";
+    String COLUMNNAME_Qty = "Qty";
+    String COLUMNNAME_Description = "Description";
+    String COLUMNNAME_IsActive = "IsActive";
+
+    int getC_CostAdjustmentLine_ID();
+
+    int getC_CostAdjustmentEvent_ID();
+
+    BigDecimal getAmt();
+}

--- a/base/src/org/adempiere/core/domains/models/X_C_CostAdjustmentEvent.java
+++ b/base/src/org/adempiere/core/domains/models/X_C_CostAdjustmentEvent.java
@@ -1,0 +1,355 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 2006-2026 ADempiere Foundation, All Rights Reserved.         *
+ * Generated Model - DO NOT CHANGE (manual stub for Cost Adjustment Event)    *
+ *****************************************************************************/
+/** Generated Model for C_CostAdjustmentEvent */
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.Properties;
+
+import org.compiere.model.I_Persistent;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.model.POInfo;
+import org.compiere.util.Env;
+
+/** Generated Model for C_CostAdjustmentEvent
+ *  @author Adempiere (generated)
+ *  @version Release 3.9.4 - $Id$ */
+public class X_C_CostAdjustmentEvent extends PO implements I_C_CostAdjustmentEvent, I_Persistent {
+
+    private static final long serialVersionUID = 20260908L;
+
+    public static final int Table_ID = I_C_CostAdjustmentEvent.Table_ID;
+    public static final String Table_Name = I_C_CostAdjustmentEvent.Table_Name;
+
+    /** DocStatus */
+    public static final String DOCSTATUS_Drafted = "DR";
+    public static final String DOCSTATUS_Completed = "CO";
+    public static final String DOCSTATUS_Approved = "AP";
+    public static final String DOCSTATUS_Invalid = "IN";
+    public static final String DOCSTATUS_NotApproved = "NA";
+    public static final String DOCSTATUS_Voided = "VO";
+    public static final String DOCSTATUS_Reversed = "RE";
+    public static final String DOCSTATUS_Closed = "CL";
+    public static final String DOCSTATUS_Unknown = "??";
+    public static final String DOCSTATUS_InProgress = "IP";
+    public static final String DOCSTATUS_WaitingPayment = "WP";
+    public static final String DOCSTATUS_WaitingConfirmation = "WC";
+    /** DocAction */
+    public static final String DOCACTION_Complete = "CO";
+    public static final String DOCACTION_WaitComplete = "WC";
+    public static final String DOCACTION_Approve = "AP";
+    public static final String DOCACTION_Reject = "RJ";
+    public static final String DOCACTION_Post = "PO";
+    public static final String DOCACTION_Void = "VO";
+    public static final String DOCACTION_Close = "CL";
+    public static final String DOCACTION_Reverse_Correct = "RC";
+    public static final String DOCACTION_Reverse_Accrual = "RA";
+    public static final String DOCACTION_ReActivate = "RE";
+    public static final String DOCACTION_None = "--";
+    public static final String DOCACTION_Prepare = "PR";
+    public static final String DOCACTION_Unlock = "XL";
+    public static final String DOCACTION_Invalidate = "IN";
+    public static final String DOCACTION_ReOpen = "OP";
+
+    public X_C_CostAdjustmentEvent(Properties ctx, int C_CostAdjustmentEvent_ID, String trxName) {
+        super(ctx, C_CostAdjustmentEvent_ID, trxName);
+    }
+
+    public X_C_CostAdjustmentEvent(Properties ctx, ResultSet rs, String trxName) {
+        super(ctx, rs, trxName);
+    }
+
+    protected int get_AccessLevel() {
+        return 3;
+    }
+
+    protected POInfo initPO(Properties ctx) {
+        POInfo poi = POInfo.getPOInfo(ctx, Table_ID, get_TrxName());
+        return poi;
+    }
+
+    public String toString() {
+        StringBuffer sb = new StringBuffer("X_C_CostAdjustmentEvent[").append(get_ID()).append("]");
+        return sb.toString();
+    }
+
+    public void setC_CostAdjustmentEvent_ID(int C_CostAdjustmentEvent_ID) {
+        if (C_CostAdjustmentEvent_ID < 1)
+            set_ValueNoCheck(COLUMNNAME_C_CostAdjustmentEvent_ID, null);
+        else
+            set_ValueNoCheck(COLUMNNAME_C_CostAdjustmentEvent_ID, Integer.valueOf(C_CostAdjustmentEvent_ID));
+    }
+
+    public int getC_CostAdjustmentEvent_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_C_CostAdjustmentEvent_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setDocumentNo(String DocumentNo) {
+        set_Value(COLUMNNAME_DocumentNo, DocumentNo);
+    }
+
+    public String getDocumentNo() {
+        return (String) get_Value(COLUMNNAME_DocumentNo);
+    }
+
+    public void setC_DocType_ID(int C_DocType_ID) {
+        set_Value(COLUMNNAME_C_DocType_ID, Integer.valueOf(C_DocType_ID));
+    }
+
+    public int getC_DocType_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_C_DocType_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setDateAcct(Timestamp DateAcct) {
+        set_Value(COLUMNNAME_DateAcct, DateAcct);
+    }
+
+    public Timestamp getDateAcct() {
+        return (Timestamp) get_Value(COLUMNNAME_DateAcct);
+    }
+
+    public void setDateTrx(Timestamp DateTrx) {
+        set_Value(COLUMNNAME_DateTrx, DateTrx);
+    }
+
+    public Timestamp getDateTrx() {
+        return (Timestamp) get_Value(COLUMNNAME_DateTrx);
+    }
+
+    public void setM_Product_ID(int M_Product_ID) {
+        set_Value(COLUMNNAME_M_Product_ID, Integer.valueOf(M_Product_ID));
+    }
+
+    public int getM_Product_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_M_Product_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setC_AcctSchema_ID(int C_AcctSchema_ID) {
+        set_Value(COLUMNNAME_C_AcctSchema_ID, Integer.valueOf(C_AcctSchema_ID));
+    }
+
+    public int getC_AcctSchema_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_C_AcctSchema_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setM_CostType_ID(int M_CostType_ID) {
+        set_Value(COLUMNNAME_M_CostType_ID, Integer.valueOf(M_CostType_ID));
+    }
+
+    public int getM_CostType_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_M_CostType_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setM_CostElement_ID(int M_CostElement_ID) {
+        set_Value(COLUMNNAME_M_CostElement_ID, Integer.valueOf(M_CostElement_ID));
+    }
+
+    public int getM_CostElement_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_M_CostElement_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setCostAdjustmentType(String CostAdjustmentType) {
+        set_Value(COLUMNNAME_CostAdjustmentType, CostAdjustmentType);
+    }
+
+    public String getCostAdjustmentType() {
+        return (String) get_Value(COLUMNNAME_CostAdjustmentType);
+    }
+
+    public void setM_InOutLine_ID(int M_InOutLine_ID) {
+        set_Value(COLUMNNAME_M_InOutLine_ID, Integer.valueOf(M_InOutLine_ID));
+    }
+
+    public int getM_InOutLine_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_M_InOutLine_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setC_InvoiceLine_ID(int C_InvoiceLine_ID) {
+        set_Value(COLUMNNAME_C_InvoiceLine_ID, Integer.valueOf(C_InvoiceLine_ID));
+    }
+
+    public int getC_InvoiceLine_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_C_InvoiceLine_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setC_LandedCostAllocation_ID(int C_LandedCostAllocation_ID) {
+        set_Value(COLUMNNAME_C_LandedCostAllocation_ID, Integer.valueOf(C_LandedCostAllocation_ID));
+    }
+
+    public int getC_LandedCostAllocation_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_C_LandedCostAllocation_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setM_CostDetail_ID(int M_CostDetail_ID) {
+        set_Value(COLUMNNAME_M_CostDetail_ID, Integer.valueOf(M_CostDetail_ID));
+    }
+
+    public int getM_CostDetail_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_M_CostDetail_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setOldCostPrice(BigDecimal OldCostPrice) {
+        set_Value(COLUMNNAME_OldCostPrice, OldCostPrice);
+    }
+
+    public BigDecimal getOldCostPrice() {
+        BigDecimal bd = (BigDecimal) get_Value(COLUMNNAME_OldCostPrice);
+        if (bd == null)
+            return Env.ZERO;
+        return bd;
+    }
+
+    public void setNewCostPrice(BigDecimal NewCostPrice) {
+        set_Value(COLUMNNAME_NewCostPrice, NewCostPrice);
+    }
+
+    public BigDecimal getNewCostPrice() {
+        BigDecimal bd = (BigDecimal) get_Value(COLUMNNAME_NewCostPrice);
+        if (bd == null)
+            return Env.ZERO;
+        return bd;
+    }
+
+    public void setQtyOnHand(BigDecimal QtyOnHand) {
+        set_Value(COLUMNNAME_QtyOnHand, QtyOnHand);
+    }
+
+    public BigDecimal getQtyOnHand() {
+        BigDecimal bd = (BigDecimal) get_Value(COLUMNNAME_QtyOnHand);
+        if (bd == null)
+            return Env.ZERO;
+        return bd;
+    }
+
+    public void setQtyAlreadySold(BigDecimal QtyAlreadySold) {
+        set_Value(COLUMNNAME_QtyAlreadySold, QtyAlreadySold);
+    }
+
+    public BigDecimal getQtyAlreadySold() {
+        BigDecimal bd = (BigDecimal) get_Value(COLUMNNAME_QtyAlreadySold);
+        if (bd == null)
+            return Env.ZERO;
+        return bd;
+    }
+
+    public void setAdjustmentAmt(BigDecimal AdjustmentAmt) {
+        set_Value(COLUMNNAME_AdjustmentAmt, AdjustmentAmt);
+    }
+
+    public BigDecimal getAdjustmentAmt() {
+        BigDecimal bd = (BigDecimal) get_Value(COLUMNNAME_AdjustmentAmt);
+        if (bd == null)
+            return Env.ZERO;
+        return bd;
+    }
+
+    public void setInventoryAmt(BigDecimal InventoryAmt) {
+        set_Value(COLUMNNAME_InventoryAmt, InventoryAmt);
+    }
+
+    public BigDecimal getInventoryAmt() {
+        BigDecimal bd = (BigDecimal) get_Value(COLUMNNAME_InventoryAmt);
+        if (bd == null)
+            return Env.ZERO;
+        return bd;
+    }
+
+    public void setCOGSAmt(BigDecimal COGSAmt) {
+        set_Value(COLUMNNAME_COGSAmt, COGSAmt);
+    }
+
+    public BigDecimal getCOGSAmt() {
+        BigDecimal bd = (BigDecimal) get_Value(COLUMNNAME_COGSAmt);
+        if (bd == null)
+            return Env.ZERO;
+        return bd;
+    }
+
+    public void setDescription(String Description) {
+        set_Value(COLUMNNAME_Description, Description);
+    }
+
+    public String getDescription() {
+        return (String) get_Value(COLUMNNAME_Description);
+    }
+
+    public void setProcessed(boolean Processed) {
+        set_Value(COLUMNNAME_Processed, Boolean.valueOf(Processed));
+    }
+
+    public boolean isProcessed() {
+        Object oo = get_Value(COLUMNNAME_Processed);
+        if (oo == null)
+            return false;
+        return ((Boolean) oo).booleanValue();
+    }
+
+    public void setPosted(boolean Posted) {
+        set_Value(COLUMNNAME_Posted, Boolean.valueOf(Posted));
+    }
+
+    public boolean isPosted() {
+        Object oo = get_Value(COLUMNNAME_Posted);
+        if (oo == null)
+            return false;
+        return ((Boolean) oo).booleanValue();
+    }
+
+    public void setDocStatus(String DocStatus) {
+        set_Value(COLUMNNAME_DocStatus, DocStatus);
+    }
+
+    public String getDocStatus() {
+        return (String) get_Value(COLUMNNAME_DocStatus);
+    }
+
+    public void setDocAction(String DocAction) {
+        set_Value(COLUMNNAME_DocAction, DocAction);
+    }
+
+    public String getDocAction() {
+        return (String) get_Value(COLUMNNAME_DocAction);
+    }
+
+    /** Dummy to satisfy MTable lookups when dictionary not yet synced */
+    public static int getTable_ID(String trxName) {
+        int id = MTable.getTable_ID(Table_Name);
+        return id > 0 ? id : Table_ID;
+    }
+}

--- a/base/src/org/adempiere/core/domains/models/X_C_CostAdjustmentLine.java
+++ b/base/src/org/adempiere/core/domains/models/X_C_CostAdjustmentLine.java
@@ -1,0 +1,124 @@
+/******************************************************************************
+ * Product: ADempiere ERP & CRM Smart Business Solution                       *
+ * Generated Model - DO NOT CHANGE (manual stub for Cost Adjustment Line)     *
+ *****************************************************************************/
+package org.adempiere.core.domains.models;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.util.Properties;
+
+import org.compiere.model.I_Persistent;
+import org.compiere.model.MTable;
+import org.compiere.model.PO;
+import org.compiere.model.POInfo;
+import org.compiere.util.Env;
+
+public class X_C_CostAdjustmentLine extends PO implements I_C_CostAdjustmentLine, I_Persistent {
+
+    private static final long serialVersionUID = 20260908L;
+
+    public static final int Table_ID = I_C_CostAdjustmentLine.Table_ID;
+    public static final String Table_Name = I_C_CostAdjustmentLine.Table_Name;
+
+    public X_C_CostAdjustmentLine(Properties ctx, int C_CostAdjustmentLine_ID, String trxName) {
+        super(ctx, C_CostAdjustmentLine_ID, trxName);
+    }
+
+    public X_C_CostAdjustmentLine(Properties ctx, ResultSet rs, String trxName) {
+        super(ctx, rs, trxName);
+    }
+
+    protected int get_AccessLevel() {
+        return 3;
+    }
+
+    protected POInfo initPO(Properties ctx) {
+        POInfo poi = POInfo.getPOInfo(ctx, Table_ID, get_TrxName());
+        return poi;
+    }
+
+    public String toString() {
+        StringBuffer sb = new StringBuffer("X_C_CostAdjustmentLine[").append(get_ID()).append("]");
+        return sb.toString();
+    }
+
+    public void setC_CostAdjustmentLine_ID(int C_CostAdjustmentLine_ID) {
+        if (C_CostAdjustmentLine_ID < 1)
+            set_ValueNoCheck(COLUMNNAME_C_CostAdjustmentLine_ID, null);
+        else
+            set_ValueNoCheck(COLUMNNAME_C_CostAdjustmentLine_ID, Integer.valueOf(C_CostAdjustmentLine_ID));
+    }
+
+    public int getC_CostAdjustmentLine_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_C_CostAdjustmentLine_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public int getC_CostAdjustmentEvent_ID() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_C_CostAdjustmentEvent_ID);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setC_CostAdjustmentEvent_ID(int C_CostAdjustmentEvent_ID) {
+        set_Value(COLUMNNAME_C_CostAdjustmentEvent_ID, Integer.valueOf(C_CostAdjustmentEvent_ID));
+    }
+
+    public void setLine(int Line) {
+        set_Value(COLUMNNAME_Line, Integer.valueOf(Line));
+    }
+
+    public int getLine() {
+        Integer ii = (Integer) get_Value(COLUMNNAME_Line);
+        if (ii == null)
+            return 0;
+        return ii.intValue();
+    }
+
+    public void setAdjustmentLineType(String AdjustmentLineType) {
+        set_Value(COLUMNNAME_AdjustmentLineType, AdjustmentLineType);
+    }
+
+    public String getAdjustmentLineType() {
+        return (String) get_Value(COLUMNNAME_AdjustmentLineType);
+    }
+
+    public void setAmt(BigDecimal Amt) {
+        set_Value(COLUMNNAME_Amt, Amt);
+    }
+
+    public BigDecimal getAmt() {
+        BigDecimal bd = (BigDecimal) get_Value(COLUMNNAME_Amt);
+        if (bd == null)
+            return Env.ZERO;
+        return bd;
+    }
+
+    public void setQty(BigDecimal Qty) {
+        set_Value(COLUMNNAME_Qty, Qty);
+    }
+
+    public BigDecimal getQty() {
+        BigDecimal bd = (BigDecimal) get_Value(COLUMNNAME_Qty);
+        if (bd == null)
+            return Env.ZERO;
+        return bd;
+    }
+
+    public void setDescription(String Description) {
+        set_Value(COLUMNNAME_Description, Description);
+    }
+
+    public String getDescription() {
+        return (String) get_Value(COLUMNNAME_Description);
+    }
+
+    public static int getTable_ID(String trxName) {
+        int id = MTable.getTable_ID(Table_Name);
+        return id > 0 ? id : Table_ID;
+    }
+}

--- a/base/src/org/adempiere/engine/AbstractCostingMethod.java
+++ b/base/src/org/adempiere/engine/AbstractCostingMethod.java
@@ -392,8 +392,11 @@ public abstract class AbstractCostingMethod implements ICostingMethod {
 		MDocType docType = MDocType.get(cost.getCtx(), documentLine.getC_DocType_ID());
 		Boolean openPeriod = MPeriod.isOpen(cost.getCtx(),  cost.getDateAcct() ,  docType .getDocBaseType(),  cost.getAD_Org_ID());
 		
-		if(!openPeriod)
+		if(!openPeriod) {
+			log.warning("clearAccounting blocked: period closed for M_CostDetail_ID="
+					+ cost.getM_CostDetail_ID() + ". Use CostAdjustmentEngine instead.");
 			return;
+		}
 
 		String sqldelete = "DELETE FROM Fact_Acct WHERE Record_ID =? AND AD_Table_ID=?";
 		int tableId = 0;

--- a/base/src/org/adempiere/engine/CostAdjustmentCalculator.java
+++ b/base/src/org/adempiere/engine/CostAdjustmentCalculator.java
@@ -1,0 +1,175 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2026 Adempiere Foundation. All Rights Reserved.          *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ *****************************************************************************/
+package org.adempiere.engine;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.compiere.util.Env;
+
+/**
+ * Pure (DB-free) calculator for auditable cost adjustments.
+ *
+ * <p>Core principle: a closed period must remain immutable. A late-known cost
+ * is recorded as a <b>new</b> economic event in an open period, split between
+ * remaining inventory and already-sold quantities (COGS).</p>
+ *
+ * <p>Reproducible scenario from the feature request:</p>
+ * <pre>
+ * March: 10 units @ 30 on hand, sell 20 units @ 50 (provisional COGS 600), close period.
+ * April: purchase 20 units @ 40.
+ * Final COGS = 700, adjustment = +100 in April, final inventory 10 units @ 40.
+ * </pre>
+ */
+public class CostAdjustmentCalculator {
+
+    /** Default precision when caller does not provide one. */
+    public static final int DEFAULT_PRECISION = 4;
+
+    private CostAdjustmentCalculator() {
+    }
+
+    /**
+     * Compute adjustment for a unit-cost change.
+     *
+     * @param unitCostBefore provisional unit cost used originally
+     * @param unitCostAfter final (true) unit cost
+     * @param qtyOnHand quantity still in stock affected by the change
+     * @param qtyAlreadySold quantity already shipped/invoiced with provisional cost
+     * @param precision costing precision
+     * @return split result
+     */
+    public static CostAdjustmentResult calculate(BigDecimal unitCostBefore, BigDecimal unitCostAfter,
+            BigDecimal qtyOnHand, BigDecimal qtyAlreadySold, int precision) {
+        if (unitCostBefore == null)
+            unitCostBefore = Env.ZERO;
+        if (unitCostAfter == null)
+            unitCostAfter = Env.ZERO;
+        if (qtyOnHand == null)
+            qtyOnHand = Env.ZERO;
+        if (qtyAlreadySold == null)
+            qtyAlreadySold = Env.ZERO;
+        if (precision < 0)
+            precision = DEFAULT_PRECISION;
+
+        BigDecimal unitDelta = unitCostAfter.subtract(unitCostBefore);
+        BigDecimal inventoryPortion = round(unitDelta.multiply(qtyOnHand), precision);
+        BigDecimal cogsPortion = round(unitDelta.multiply(qtyAlreadySold), precision);
+        return new CostAdjustmentResult(unitCostBefore, unitCostAfter,
+                qtyOnHand, qtyAlreadySold, inventoryPortion, cogsPortion);
+    }
+
+    public static CostAdjustmentResult calculate(BigDecimal unitCostBefore, BigDecimal unitCostAfter,
+            BigDecimal qtyOnHand, BigDecimal qtyAlreadySold) {
+        return calculate(unitCostBefore, unitCostAfter, qtyOnHand, qtyAlreadySold, DEFAULT_PRECISION);
+    }
+
+    /**
+     * Recompute average cost after a late receipt when negative inventory existed.
+     * average = (onHandValue + receiptQty * receiptCost) / (onHandQty + receiptQty)
+     * where onHandQty may be negative (sale before replenishment).
+     *
+     * @param onHandQty current накопительный quantity (may be negative)
+     * @param onHandValue current inventory value (qty * provisional average)
+     * @param receiptQty incoming quantity (&gt; 0)
+     * @param receiptUnitCost incoming unit cost
+     * @param precision costing precision
+     * @return new average unit cost (zero if resulting quantity is zero)
+     */
+    public static BigDecimal averageAfterReceipt(BigDecimal onHandQty, BigDecimal onHandValue,
+            BigDecimal receiptQty, BigDecimal receiptUnitCost, int precision) {
+        if (onHandQty == null)
+            onHandQty = Env.ZERO;
+        if (onHandValue == null)
+            onHandValue = Env.ZERO;
+        if (receiptQty == null)
+            receiptQty = Env.ZERO;
+        if (receiptUnitCost == null)
+            receiptUnitCost = Env.ZERO;
+        if (precision < 0)
+            precision = DEFAULT_PRECISION;
+        BigDecimal newQty = onHandQty.add(receiptQty);
+        if (newQty.signum() == 0)
+            return Env.ZERO;
+        BigDecimal newValue = onHandValue.add(receiptQty.multiply(receiptUnitCost));
+        return newValue.divide(newQty, precision, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Compute provisional COGS charged with a provisional average cost, and the
+     * final COGS once the true average is known. Difference = COGS adjustment.
+     */
+    public static BigDecimal cogsDelta(BigDecimal qtySold, BigDecimal provisionalUnitCost,
+            BigDecimal finalUnitCost, int precision) {
+        if (qtySold == null || provisionalUnitCost == null || finalUnitCost == null)
+            return Env.ZERO;
+        BigDecimal delta = finalUnitCost.subtract(provisionalUnitCost).multiply(qtySold);
+        return round(delta, precision);
+    }
+
+    /**
+     * Commission delta when commission is margin based:
+     * commission = margin * rate, margin = revenue - cogs.
+     * A COGS increase of X reduces commission by X * rate.
+     *
+     * @param cogsAdjustment positive when cost increased
+     * @param commissionRate e.g. 0.10 for 10%
+     * @param precision precision
+     * @return commission adjustment (negative when cost increased)
+     */
+    public static BigDecimal commissionDelta(BigDecimal cogsAdjustment, BigDecimal commissionRate, int precision) {
+        if (cogsAdjustment == null || commissionRate == null)
+            return Env.ZERO;
+        if (precision < 0)
+            precision = 2;
+        // margin delta = -cogsAdjustment ; commission delta = margin delta * rate
+        return round(cogsAdjustment.negate().multiply(commissionRate), precision);
+    }
+
+    /**
+     * Split a late landed cost between inventory and COGS proportionally.
+     *
+     * @param landedCostTotal total late landed cost
+     * @param qtyOnHand qty still on hand from the original receipt
+     * @param qtyOfReceipt original receipt quantity
+     * @param precision precision
+     * @return result where unit costs are zero and portions hold the split
+     */
+    public static CostAdjustmentResult splitLandedCost(BigDecimal landedCostTotal,
+            BigDecimal qtyOnHand, BigDecimal qtyOfReceipt, int precision) {
+        if (landedCostTotal == null)
+            landedCostTotal = Env.ZERO;
+        if (qtyOnHand == null)
+            qtyOnHand = Env.ZERO;
+        if (qtyOfReceipt == null || qtyOfReceipt.signum() == 0)
+            return new CostAdjustmentResult(Env.ZERO, Env.ZERO, qtyOnHand, Env.ZERO, Env.ZERO, landedCostTotal);
+        if (precision < 0)
+            precision = DEFAULT_PRECISION;
+        BigDecimal onHand = qtyOnHand.max(Env.ZERO);
+        BigDecimal sold = qtyOfReceipt.subtract(onHand).max(Env.ZERO);
+        BigDecimal inventoryPortion = Env.ZERO;
+        BigDecimal cogsPortion = Env.ZERO;
+        if (qtyOfReceipt.signum() != 0) {
+            inventoryPortion = round(landedCostTotal.multiply(onHand)
+                    .divide(qtyOfReceipt, 10, RoundingMode.HALF_UP), precision);
+            cogsPortion = round(landedCostTotal.subtract(inventoryPortion), precision);
+        }
+        return new CostAdjustmentResult(Env.ZERO, Env.ZERO, onHand, sold, inventoryPortion, cogsPortion);
+    }
+
+    private static BigDecimal round(BigDecimal value, int precision) {
+        if (value == null)
+            return Env.ZERO;
+        if (value.scale() > precision)
+            return value.setScale(precision, RoundingMode.HALF_UP);
+        return value;
+    }
+}

--- a/base/src/org/adempiere/engine/CostAdjustmentEngine.java
+++ b/base/src/org/adempiere/engine/CostAdjustmentEngine.java
@@ -1,0 +1,461 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2026 Adempiere Foundation. All Rights Reserved.          *
+ *****************************************************************************/
+package org.adempiere.engine;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Properties;
+
+import org.adempiere.core.domains.models.I_C_CommissionDetail;
+import org.adempiere.core.domains.models.I_M_Storage;
+import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.MAcctSchema;
+import org.compiere.model.MCommissionAmt;
+import org.compiere.model.MCommissionDetail;
+import org.compiere.model.MConversionRate;
+import org.compiere.model.MCost;
+import org.compiere.model.MCostAdjustmentEvent;
+import org.compiere.model.MCostElement;
+import org.compiere.model.MCostType;
+import org.compiere.model.MDocType;
+import org.compiere.model.MInOutLine;
+import org.compiere.model.MLandedCostAllocation;
+import org.compiere.model.MMatchInv;
+import org.compiere.model.MPeriod;
+import org.compiere.model.MProduct;
+import org.compiere.model.Query;
+import org.compiere.util.CLogger;
+import org.compiere.util.Env;
+import org.compiere.util.TimeUtil;
+
+/**
+ * Service that records late-known costs as auditable adjustment events.
+ *
+ * <ul>
+ * <li>If the original accounting period is OPEN: callers may still use the
+ * standard {@link CostEngine} recalculation path.</li>
+ * <li>If the original period is CLOSED: never touch the original
+ * Fact_Acct / cost detail. Instead create a {@link MCostAdjustmentEvent}
+ * dated in the current open period, split between inventory and COGS.</li>
+ * </ul>
+ *
+ * Covers: negative inventory, late landed costs, vendor price differences,
+ * currency differences and reversals.
+ */
+public class CostAdjustmentEngine {
+
+    private static final CLogger log = CLogger.getCLogger(CostAdjustmentEngine.class);
+
+    /** Singleton */
+    private static CostAdjustmentEngine instance = new CostAdjustmentEngine();
+
+    public static CostAdjustmentEngine get() {
+        return instance;
+    }
+
+    /**
+     * Decide whether a late cost must go through the adjustment-event path.
+     * @return true when original period is closed (must NOT repost original)
+     */
+    public boolean isAdjustmentRequired(Properties ctx, Timestamp originalDateAcct,
+            String docBaseType, int AD_Org_ID, String trxName) {
+        if (originalDateAcct == null)
+            return false;
+        return !MPeriod.isOpen(ctx, originalDateAcct, docBaseType, AD_Org_ID);
+    }
+
+    /**
+     * Resolve an open-period accounting date for the adjustment (today or given date).
+     * Throws if no open period exists — the adjustment must wait for an open period.
+     */
+    public Timestamp resolveOpenAdjustmentDate(Properties ctx, Timestamp preferredDate,
+            String docBaseType, int AD_Org_ID, String trxName) {
+        Timestamp date = preferredDate != null ? preferredDate : new Timestamp(System.currentTimeMillis());
+        // Strip time portion
+        date = TimeUtil.getDay(date);
+        if (date == null)
+            date = new Timestamp(System.currentTimeMillis());
+        if (!MPeriod.isOpen(ctx, date, docBaseType, AD_Org_ID)) {
+            // Fall back to today; if still closed, fail loudly instead of posting into closed period
+            Timestamp today = TimeUtil.getDay(new Timestamp(System.currentTimeMillis()));
+            if (today != null && MPeriod.isOpen(ctx, today, docBaseType, AD_Org_ID))
+                return today;
+            throw new AdempiereException("@PeriodClosed@ (" + date + ")");
+        }
+        return date;
+    }
+
+    /**
+     * Main entry: record a unit-cost correction for a product / cost dimension.
+     *
+     * @param ctx context
+     * @param AD_Org_ID org of the adjustment
+     * @param C_AcctSchema_ID accounting schema
+     * @param M_CostType_ID cost type
+     * @param M_CostElement_ID cost element
+     * @param M_Product_ID product
+     * @param originalDateAcct accounting date of the original transaction
+     * @param originalDocBaseType doc base type of the original document
+     * @param oldUnitCost provisional unit cost
+     * @param newUnitCost final unit cost
+     * @param qtyOnHand qty still on hand affected
+     * @param qtyAlreadySold qty already sold with provisional cost
+     * @param adjustmentType see {@link MCostAdjustmentEvent} constants
+     * @param sourceIds optional source references (inOutLineId, invoiceLineId, landedCostAllocationId, costDetailId)
+     * @param description description
+     * @param trxName trx
+     * @return persisted event (completed) or null when delta is zero
+     */
+    public MCostAdjustmentEvent recordUnitCostChange(Properties ctx, int AD_Org_ID,
+            int C_AcctSchema_ID, int M_CostType_ID, int M_CostElement_ID, int M_Product_ID,
+            Timestamp originalDateAcct, String originalDocBaseType,
+            BigDecimal oldUnitCost, BigDecimal newUnitCost,
+            BigDecimal qtyOnHand, BigDecimal qtyAlreadySold,
+            String adjustmentType, int[] sourceIds, String description, String trxName) {
+        MAcctSchema as = MAcctSchema.get(ctx, C_AcctSchema_ID);
+        int precision = as != null ? as.getCostingPrecision() : CostAdjustmentCalculator.DEFAULT_PRECISION;
+        CostAdjustmentResult result = CostAdjustmentCalculator.calculate(
+                oldUnitCost, newUnitCost, qtyOnHand, qtyAlreadySold, precision);
+        if (result.isZero()) {
+            log.fine("No cost delta — no adjustment event created");
+            return null;
+        }
+        boolean mustAdjust = isAdjustmentRequired(ctx, originalDateAcct, originalDocBaseType, AD_Org_ID, trxName);
+        Timestamp adjustmentDate;
+        if (mustAdjust) {
+            adjustmentDate = resolveOpenAdjustmentDate(ctx, null, originalDocBaseType, AD_Org_ID, trxName);
+        } else {
+            adjustmentDate = originalDateAcct != null ? originalDateAcct
+                    : resolveOpenAdjustmentDate(ctx, null, originalDocBaseType, AD_Org_ID, trxName);
+        }
+
+        MCostAdjustmentEvent event = new MCostAdjustmentEvent(ctx, 0, trxName);
+        event.setAD_Org_ID(AD_Org_ID);
+        event.setM_Product_ID(M_Product_ID);
+        event.setC_AcctSchema_ID(C_AcctSchema_ID);
+        event.setM_CostType_ID(M_CostType_ID);
+        event.setM_CostElement_ID(M_CostElement_ID);
+        event.setCostAdjustmentType(adjustmentType != null ? adjustmentType : MCostAdjustmentEvent.COSTADJUSTMENTTYPE_Manual);
+        event.setOldCostPrice(result.getUnitCostBefore());
+        event.setNewCostPrice(result.getUnitCostAfter());
+        event.setQtyOnHand(result.getQtyOnHand());
+        event.setQtyAlreadySold(result.getQtyAlreadySold());
+        event.setDateAcct(adjustmentDate);
+        event.setDateTrx(adjustmentDate);
+        if (sourceIds != null) {
+            if (sourceIds.length > 0)
+                event.setM_InOutLine_ID(sourceIds[0]);
+            if (sourceIds.length > 1)
+                event.setC_InvoiceLine_ID(sourceIds[1]);
+            if (sourceIds.length > 2)
+                event.setC_LandedCostAllocation_ID(sourceIds[2]);
+            if (sourceIds.length > 3)
+                event.setM_CostDetail_ID(sourceIds[3]);
+        }
+        StringBuilder desc = new StringBuilder(description != null ? description : "");
+        desc.append(" | OrigDate=").append(originalDateAcct)
+            .append(mustAdjust ? " (closed, adjusted in open period " + adjustmentDate + ")" : " (open period)");
+        event.setDescription(desc.toString().length() > 255 ? desc.toString().substring(0, 255) : desc.toString());
+        event.saveEx();
+        event.createSplitLines(result.getInventoryPortion(), result.getCogsPortion(), trxName);
+        try {
+            event.processIt(MCostAdjustmentEvent.DOCACTION_Complete);
+            event.saveEx();
+        } catch (Exception e) {
+            throw new AdempiereException(e);
+        }
+        // Keep the live MCost dimension in sync (current average), without rewriting history
+        updateLiveAverageCost(ctx, AD_Org_ID, C_AcctSchema_ID, M_CostType_ID, M_CostElement_ID,
+                M_Product_ID, result, trxName);
+        return event;
+    }
+
+    /**
+     * Late landed cost arriving after receipt/sale: split proportionally.
+     */
+    public MCostAdjustmentEvent recordLateLandedCost(Properties ctx, MLandedCostAllocation allocation,
+            BigDecimal landedCostTotal, BigDecimal qtyOfReceipt, BigDecimal qtyOnHand, String trxName) {
+        MInOutLine ioLine = allocation != null ? (MInOutLine) allocation.getM_InOutLine() : null;
+        int M_Product_ID = allocation != null ? allocation.getM_Product_ID()
+                : (ioLine != null ? ioLine.getM_Product_ID() : 0);
+        int AD_Org_ID = allocation != null ? allocation.getAD_Org_ID() : 0;
+        MAcctSchema[] schemas = MAcctSchema.getClientAcctSchema(ctx, Env.getAD_Client_ID(ctx), trxName);
+        MCostAdjustmentEvent last = null;
+        for (MAcctSchema as : schemas) {
+            List<MCostType> types = MCostType.get(ctx, trxName);
+            for (MCostType type : types) {
+                CostAdjustmentResult split = CostAdjustmentCalculator.splitLandedCost(
+                        landedCostTotal, qtyOnHand, qtyOfReceipt, as.getCostingPrecision());
+                if (split.isZero())
+                    continue;
+                Timestamp origDate = ioLine != null ? ioLine.getParent().getDateAcct() : allocation.getCreated();
+                String docBaseType = MDocType.DOCBASETYPE_MaterialReceipt;
+                Timestamp adjDate = resolveOpenAdjustmentDate(ctx, null, docBaseType, AD_Org_ID, trxName);
+                MCostAdjustmentEvent event = new MCostAdjustmentEvent(ctx, 0, trxName);
+                event.setAD_Org_ID(AD_Org_ID);
+                event.setM_Product_ID(M_Product_ID);
+                event.setC_AcctSchema_ID(as.getC_AcctSchema_ID());
+                event.setM_CostType_ID(type.getM_CostType_ID());
+                event.setM_CostElement_ID(allocation.getM_CostElement_ID());
+                event.setCostAdjustmentType(MCostAdjustmentEvent.COSTADJUSTMENTTYPE_LandedCost);
+                event.setQtyOnHand(split.getQtyOnHand());
+                event.setQtyAlreadySold(split.getQtyAlreadySold());
+                event.setDateAcct(adjDate);
+                event.setDateTrx(adjDate);
+                event.setM_InOutLine_ID(ioLine != null ? ioLine.getM_InOutLine_ID() : 0);
+                event.setC_InvoiceLine_ID(allocation.getC_InvoiceLine_ID());
+                event.setC_LandedCostAllocation_ID(allocation.getC_LandedCostAllocation_ID());
+                event.setDescription("Late landed cost C_LandedCostAllocation_ID="
+                        + allocation.getC_LandedCostAllocation_ID()
+                        + " orig=" + origDate + " openAdj=" + adjDate);
+                event.saveEx();
+                event.createSplitLines(split.getInventoryPortion(), split.getCogsPortion(), trxName);
+                try {
+                    event.processIt(MCostAdjustmentEvent.DOCACTION_Complete);
+                    event.saveEx();
+                } catch (Exception e) {
+                    throw new AdempiereException(e);
+                }
+                last = event;
+            }
+        }
+        return last;
+    }
+
+    /**
+     * Negative-inventory correction: sale happened before replenishment with a
+     * provisional cost; once the purchase cost is known, adjust COGS in the open period.
+     */
+    public MCostAdjustmentEvent recordNegativeInventoryCorrection(Properties ctx, int AD_Org_ID,
+            int C_AcctSchema_ID, int M_CostType_ID, int M_CostElement_ID, int M_Product_ID,
+            Timestamp provisionalDateAcct, String docBaseType,
+            BigDecimal provisionalUnitCost, BigDecimal finalUnitCost,
+            BigDecimal qtySoldShort, BigDecimal qtyOnHandNow, String trxName) {
+        // Entire shortfall was sold with provisional cost; remaining stock (if any) also revalued
+        return recordUnitCostChange(ctx, AD_Org_ID, C_AcctSchema_ID, M_CostType_ID, M_CostElement_ID,
+                M_Product_ID, provisionalDateAcct, docBaseType, provisionalUnitCost, finalUnitCost,
+                qtyOnHandNow, qtySoldShort,
+                MCostAdjustmentEvent.COSTADJUSTMENTTYPE_NegativeInventory, null,
+                "Negative inventory correction", trxName);
+    }
+
+    /**
+     * Vendor invoice price difference after receipt (MatchInv arriving in a later
+     * period, possibly after the original period closed or after sale).
+     */
+    public MCostAdjustmentEvent recordInvoicePriceDifference(Properties ctx, MMatchInv matchInv,
+            BigDecimal receiptUnitCost, BigDecimal invoiceUnitCost, BigDecimal qtyOnHand,
+            BigDecimal qtyAlreadySold, String trxName) {
+        int M_Product_ID = matchInv.getM_Product_ID();
+        int AD_Org_ID = matchInv.getAD_Org_ID();
+        MAcctSchema[] schemas = MAcctSchema.getClientAcctSchema(ctx, matchInv.getAD_Client_ID(), trxName);
+        MCostAdjustmentEvent last = null;
+        for (MAcctSchema as : schemas) {
+            List<MCostType> types = MCostType.get(ctx, trxName);
+            for (MCostType type : types) {
+                // Average-PO vs Average-Invoice semantics stay in CostEngine; here we record the delta event
+                MInOutLine ioLine = (MInOutLine) matchInv.getM_InOutLine();
+                Timestamp origDate = ioLine != null ? ioLine.getParent().getDateAcct() : matchInv.getDateTrx();
+                MCostElement materialElement = MCostElement.getMaterialCostElement(as);
+                if (materialElement == null)
+                    continue;
+                last = recordUnitCostChange(ctx, AD_Org_ID, as.getC_AcctSchema_ID(),
+                        type.getM_CostType_ID(),
+                        materialElement.getM_CostElement_ID(),
+                        M_Product_ID, origDate, MDocType.DOCBASETYPE_MaterialReceipt,
+                        receiptUnitCost, invoiceUnitCost, qtyOnHand, qtyAlreadySold,
+                        MCostAdjustmentEvent.COSTADJUSTMENTTYPE_LateInvoicePrice,
+                        new int[]{ioLine != null ? ioLine.getM_InOutLine_ID() : 0, matchInv.getC_InvoiceLine_ID(), 0, 0},
+                        "Invoice price difference MatchInv " + matchInv.getDocumentNo(), trxName);
+            }
+        }
+        return last;
+    }
+
+    /**
+     * Currency-difference correction: convert the same foreign amount with the final
+     * rate vs the provisional rate.
+     */
+    public MCostAdjustmentEvent recordCurrencyDifference(Properties ctx, int AD_Org_ID,
+            int C_AcctSchema_ID, int M_CostType_ID, int M_CostElement_ID, int M_Product_ID,
+            Timestamp originalDateAcct, String docBaseType, BigDecimal foreignUnitCost,
+            BigDecimal provisionalRate, BigDecimal finalRate,
+            BigDecimal qtyOnHand, BigDecimal qtyAlreadySold, String trxName) {
+        if (foreignUnitCost == null || provisionalRate == null || finalRate == null)
+            throw new AdempiereException("Invalid currency correction parameters");
+        MAcctSchema as = MAcctSchema.get(ctx, C_AcctSchema_ID);
+        int precision = as != null ? as.getCostingPrecision() : CostAdjustmentCalculator.DEFAULT_PRECISION;
+        BigDecimal oldCost = foreignUnitCost.multiply(provisionalRate).setScale(precision, RoundingMode.HALF_UP);
+        BigDecimal newCost = foreignUnitCost.multiply(finalRate).setScale(precision, RoundingMode.HALF_UP);
+        return recordUnitCostChange(ctx, AD_Org_ID, C_AcctSchema_ID, M_CostType_ID, M_CostElement_ID,
+                M_Product_ID, originalDateAcct, docBaseType, oldCost, newCost,
+                qtyOnHand, qtyAlreadySold,
+                MCostAdjustmentEvent.COSTADJUSTMENTTYPE_ExchangeDifference, null,
+                "Currency difference correction", trxName);
+    }
+
+    // ------------------------------------------------------------------
+    // Commission handling
+    // ------------------------------------------------------------------
+
+    /**
+     * When commission is margin based, a COGS adjustment changes the margin.
+     * Never rewrite a closed commission run: instead create a new detail line in
+     * the first open run (or return the computed delta when no open run exists
+     * so the caller can queue it).
+     *
+     * @param cogsAdjustment positive when cost increased
+     * @param commissionRate e.g. 0.10
+     * @param currencyPrecision precision for money
+     * @return commission delta (negative when cost increased)
+     */
+    public BigDecimal calculateCommissionDelta(BigDecimal cogsAdjustment, BigDecimal commissionRate,
+            int currencyPrecision) {
+        return CostAdjustmentCalculator.commissionDelta(cogsAdjustment, commissionRate, currencyPrecision);
+    }
+
+    /**
+     * Append a commission-adjustment detail to the given commission amount.
+     * The caller must ensure the parent run is in an open period.
+     * @param commissionAmt open-period parent amount line
+     * @param currencyId currency for the detail (taken from source document,
+     *        since C_CommissionAmt carries no currency column)
+     */
+    public MCommissionDetail createCommissionAdjustmentDetail(MCommissionAmt commissionAmt,
+            int currencyId, BigDecimal commissionDelta, BigDecimal qty, String description) {
+        if (commissionAmt == null || commissionDelta == null || commissionDelta.signum() == 0)
+            return null;
+        int effectiveCurrencyId = currencyId > 0 ? currencyId
+                : Env.getContextAsInt(commissionAmt.getCtx(), "$C_Currency_ID");
+        MCommissionDetail detail = new MCommissionDetail(commissionAmt,
+                effectiveCurrencyId, commissionDelta, qty != null ? qty : Env.ONE);
+        if (description != null)
+            detail.setInfo(description.length() > 60 ? description.substring(0, 60) : description);
+        detail.saveEx();
+        // Roll up
+        BigDecimal current = commissionAmt.getCommissionAmt();
+        if (current == null)
+            current = Env.ZERO;
+        commissionAmt.setCommissionAmt(current.add(commissionDelta));
+        commissionAmt.saveEx();
+        return detail;
+    }
+
+    /**
+     * Append a commission-adjustment detail to the given commission amount.
+     * The caller must ensure the parent run is in an open period.
+     * @deprecated use {@link #createCommissionAdjustmentDetail(MCommissionAmt, int, BigDecimal, BigDecimal, String)}
+     */
+    public MCommissionDetail createCommissionAdjustmentDetail(MCommissionAmt commissionAmt,
+            BigDecimal commissionDelta, BigDecimal qty, String description) {
+        return createCommissionAdjustmentDetail(commissionAmt, 0, commissionDelta, qty, description);
+    }
+
+    /**
+     * Find details of a closed commission run affected by a product COGS change.
+     * Used for audit reporting (which invoices need an open-period adjustment).
+     */
+    public List<MCommissionDetail> findClosedCommissionDetails(Properties ctx, int C_CommissionRun_ID,
+            int M_Product_ID, String trxName) {
+        return new Query(ctx, I_C_CommissionDetail.Table_Name,
+                "C_CommissionAmt_ID IN (SELECT C_CommissionAmt_ID FROM C_CommissionAmt WHERE C_CommissionRun_ID=?)"
+                + " AND M_Product_ID=?", trxName)
+                .setParameters(C_CommissionRun_ID, M_Product_ID)
+                .list();
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /** Current on-hand qty from storage (all locators, or one warehouse when given). */
+    public BigDecimal getQtyOnHand(Properties ctx, int M_Product_ID, int M_Warehouse_ID, String trxName) {
+        StringBuilder where = new StringBuilder(I_M_Storage.COLUMNNAME_M_Product_ID + "=?");
+        java.util.ArrayList<Object> params = new java.util.ArrayList<Object>();
+        params.add(M_Product_ID);
+        if (M_Warehouse_ID > 0) {
+            where.append(" AND EXISTS (SELECT 1 FROM M_Locator l WHERE l.M_Locator_ID=M_Storage.M_Locator_ID"
+                    + " AND l.M_Warehouse_ID=?)");
+            params.add(M_Warehouse_ID);
+        }
+        BigDecimal qty = new Query(ctx, I_M_Storage.Table_Name, where.toString(), trxName)
+                .setParameters(params)
+                .sum(I_M_Storage.COLUMNNAME_QtyOnHand);
+        return qty != null ? qty : Env.ZERO;
+    }
+
+    /** Convert amount to schema currency. */
+    public BigDecimal convertToSchemaCurrency(Properties ctx, MAcctSchema as, int C_Currency_ID,
+            Timestamp dateAcct, int C_ConversionType_ID, int AD_Client_ID, int AD_Org_ID,
+            BigDecimal amount, String trxName) {
+        if (amount == null)
+            return Env.ZERO;
+        if (C_Currency_ID == as.getC_Currency_ID())
+            return amount;
+        BigDecimal converted = MConversionRate.convert(ctx, amount, C_Currency_ID, as.getC_Currency_ID(),
+                dateAcct, C_ConversionType_ID, AD_Client_ID, AD_Org_ID);
+        return converted != null ? converted : Env.ZERO;
+    }
+
+    /**
+     * Move the live MCost average forward by the adjustment without rewriting
+     * historical cost details. Keeps future issues valued at the corrected cost.
+     */
+    private void updateLiveAverageCost(Properties ctx, int AD_Org_ID, int C_AcctSchema_ID,
+            int M_CostType_ID, int M_CostElement_ID, int M_Product_ID,
+            CostAdjustmentResult result, String trxName) {
+        try {
+            MProduct product = MProduct.get(ctx, M_Product_ID);
+            MAcctSchema as = MAcctSchema.get(ctx, C_AcctSchema_ID);
+            if (product == null || as == null)
+                return;
+            // Resolve dimension per costing level
+            String costingLevel = product.getCostingLevel(as, AD_Org_ID);
+            int orgId = AD_Org_ID;
+            int warehouseId = 0;
+            int asiId = 0;
+            if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
+                orgId = 0;
+            else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
+                orgId = 0;
+            MCost cost = MCost.getDimension(product, C_AcctSchema_ID, orgId, warehouseId, asiId,
+                    M_CostType_ID, M_CostElement_ID);
+            if (cost == null)
+                return;
+            // New average = corrected unit cost (provisional + delta applied to full affected base)
+            BigDecimal affectedBase = result.getQtyOnHand().add(result.getQtyAlreadySold());
+            if (affectedBase.signum() == 0)
+                return;
+            // Only move average when there is remaining stock; COGS-only corrections
+            // leave the average at the final unit cost for future transactions.
+            cost.setCurrentCostPrice(result.getUnitCostAfter());
+            cost.setCumulatedAmt(cost.getCumulatedAmt().add(result.getInventoryPortion()));
+            cost.setCumulatedQty(cost.getCumulatedQty());
+            cost.setCurrentQty(cost.getCumulatedQty());
+            cost.saveEx(trxName);
+        } catch (Exception e) {
+            // Never fail the adjustment because the live average sync failed; log only
+            log.warning("Could not sync live average cost: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Guard used by costing processes: refuse to delete/recreate history when the
+     * original period is closed. Returns false when the caller must use
+     * {@link #recordUnitCostChange} instead.
+     */
+    public boolean assertRepostingAllowed(Properties ctx, Timestamp dateAcct, String docBaseType,
+            int AD_Org_ID) {
+        if (dateAcct == null)
+            return true;
+        boolean open = MPeriod.isOpen(ctx, dateAcct, docBaseType, AD_Org_ID);
+        if (!open)
+            log.warning("Reposting blocked: period closed for " + dateAcct
+                    + " docBaseType=" + docBaseType + ". Use CostAdjustmentEvent instead.");
+        return open;
+    }
+}

--- a/base/src/org/adempiere/engine/CostAdjustmentResult.java
+++ b/base/src/org/adempiere/engine/CostAdjustmentResult.java
@@ -1,0 +1,96 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2026 Adempiere Foundation. All Rights Reserved.          *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ *****************************************************************************/
+package org.adempiere.engine;
+
+import java.math.BigDecimal;
+
+import org.compiere.util.Env;
+
+/**
+ * Result of a late-cost computation.
+ * Immutable value object: total delta is split between on-hand inventory
+ * (still in stock) and already-sold quantity (COGS).
+ *
+ * @author Adempiere
+ */
+public class CostAdjustmentResult {
+
+    private final BigDecimal unitCostBefore;
+    private final BigDecimal unitCostAfter;
+    private final BigDecimal qtyOnHand;
+    private final BigDecimal qtyAlreadySold;
+    private final BigDecimal inventoryPortion;
+    private final BigDecimal cogsPortion;
+    private final BigDecimal totalDelta;
+    private final boolean costIncrease;
+
+    public CostAdjustmentResult(BigDecimal unitCostBefore, BigDecimal unitCostAfter,
+            BigDecimal qtyOnHand, BigDecimal qtyAlreadySold,
+            BigDecimal inventoryPortion, BigDecimal cogsPortion) {
+        this.unitCostBefore = unitCostBefore == null ? Env.ZERO : unitCostBefore;
+        this.unitCostAfter = unitCostAfter == null ? Env.ZERO : unitCostAfter;
+        this.qtyOnHand = qtyOnHand == null ? Env.ZERO : qtyOnHand;
+        this.qtyAlreadySold = qtyAlreadySold == null ? Env.ZERO : qtyAlreadySold;
+        this.inventoryPortion = inventoryPortion == null ? Env.ZERO : inventoryPortion;
+        this.cogsPortion = cogsPortion == null ? Env.ZERO : cogsPortion;
+        this.totalDelta = this.inventoryPortion.add(this.cogsPortion);
+        this.costIncrease = this.totalDelta.signum() > 0;
+    }
+
+    public BigDecimal getUnitCostBefore() {
+        return unitCostBefore;
+    }
+
+    public BigDecimal getUnitCostAfter() {
+        return unitCostAfter;
+    }
+
+    public BigDecimal getQtyOnHand() {
+        return qtyOnHand;
+    }
+
+    public BigDecimal getQtyAlreadySold() {
+        return qtyAlreadySold;
+    }
+
+    /** Portion attributable to remaining stock (Dr Inventory when positive). */
+    public BigDecimal getInventoryPortion() {
+        return inventoryPortion;
+    }
+
+    /** Portion attributable to already sold stock (Dr COGS when positive). */
+    public BigDecimal getCogsPortion() {
+        return cogsPortion;
+    }
+
+    public BigDecimal getTotalDelta() {
+        return totalDelta;
+    }
+
+    public boolean isCostIncrease() {
+        return costIncrease;
+    }
+
+    public boolean isCostDecrease() {
+        return totalDelta.signum() < 0;
+    }
+
+    public boolean isZero() {
+        return totalDelta.signum() == 0;
+    }
+
+    @Override
+    public String toString() {
+        return "CostAdjustmentResult[before=" + unitCostBefore + ", after=" + unitCostAfter
+                + ", onHand=" + qtyOnHand + ", sold=" + qtyAlreadySold
+                + ", inv=" + inventoryPortion + ", cogs=" + cogsPortion + "]";
+    }
+}

--- a/base/src/org/adempiere/engine/CostEngine.java
+++ b/base/src/org/adempiere/engine/CostEngine.java
@@ -812,8 +812,13 @@ public class CostEngine {
 			
 		Boolean openPeriod = MPeriod.isOpen(model.getCtx(), dateAcct , docBaseType ,  model.getAD_Org_ID());
 		if (!openPeriod)
-		{	
-			System.out.println("Period closed.");
+		{
+			// Closed period must remain immutable: never delete Fact_Acct here.
+			// Callers must record a C_CostAdjustmentEvent in an open period instead.
+			// See CostAdjustmentEngine#assertRepostingAllowed / #recordUnitCostChange.
+			log.warning("Reposting blocked: period closed for " + dateAcct
+					+ " docBaseType=" + docBaseType + " " + model
+					+ ". Use CostAdjustmentEngine instead of reposting.");
 			return false;
 		}	
 

--- a/base/src/org/compiere/acct/Doc_CostAdjustmentEvent.java
+++ b/base/src/org/compiere/acct/Doc_CostAdjustmentEvent.java
@@ -1,0 +1,148 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2026 Adempiere Foundation. All Rights Reserved.          *
+ *****************************************************************************/
+package org.compiere.acct;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.logging.Level;
+
+import org.compiere.model.MAccount;
+import org.compiere.model.MAcctSchema;
+import org.compiere.model.MCostAdjustmentEvent;
+import org.compiere.model.MCostAdjustmentLine;
+import org.compiere.model.MProduct;
+import org.compiere.model.ProductCost;
+import org.compiere.util.Env;
+
+/**
+ * Post Cost Adjustment Event.
+ *
+ * <p>An auditable late-cost event posted <b>only</b> in an open period. It never
+ * rewrites the original closed-period facts.</p>
+ *
+ * <pre>
+ * Cost increase (positive delta):
+ *   Dr Inventory (P_Asset)      inventory portion
+ *   Dr COGS (P_Cogs)            cogs portion
+ *      Cr Cost Adjustment (InvDifferences)   total
+ * Cost decrease (negative delta): mirror entry.
+ * Late landed cost is split between remaining stock (Inventory) and
+ * already-sold stock (COGS) by the CostAdjustmentEngine.
+ * </pre>
+ */
+public class Doc_CostAdjustmentEvent extends Doc {
+
+    /** Document base type for cost adjustment events (no separate C_DocType required) */
+    public static final String DOCTYPE_CostAdjustment = "MCA";
+
+    public Doc_CostAdjustmentEvent(MAcctSchema[] ass, ResultSet rs, String trxName) {
+        super(ass, MCostAdjustmentEvent.class, rs, DOCTYPE_CostAdjustment, trxName);
+    }
+
+    private MCostAdjustmentEvent m_event = null;
+
+    @Override
+    protected String loadDocumentDetails() {
+        m_event = (MCostAdjustmentEvent) getPO();
+        setDateDoc(m_event.getDateTrx());
+        setDateAcct(m_event.getDateAcct());
+        // No DocLines in the classic sense; facts are built from adjustment lines
+        p_lines = new DocLine[0];
+        return null;
+    }
+
+    @Override
+    public BigDecimal getBalance() {
+        return Env.ZERO;
+    }
+
+    @Override
+    public ArrayList<Fact> createFacts(MAcctSchema as) {
+        ArrayList<Fact> facts = new ArrayList<Fact>();
+        if (m_event == null)
+            m_event = (MCostAdjustmentEvent) getPO();
+        // Only post the schema matching the event (multi-schema safe: one event per schema)
+        if (m_event.getC_AcctSchema_ID() != 0 && m_event.getC_AcctSchema_ID() != as.getC_AcctSchema_ID())
+            return facts;
+
+        BigDecimal inventoryAmt = m_event.getInventoryAmt();
+        BigDecimal cogsAmt = m_event.getCOGSAmt();
+        if (inventoryAmt == null)
+            inventoryAmt = Env.ZERO;
+        if (cogsAmt == null)
+            cogsAmt = Env.ZERO;
+        if (inventoryAmt.signum() == 0 && cogsAmt.signum() == 0)
+            return facts;
+
+        Fact fact = new Fact(this, as, Fact.POST_Actual);
+        setC_Currency_ID(as.getC_Currency_ID());
+
+        MProduct product = MProduct.get(getCtx(), m_event.getM_Product_ID());
+        ProductCost pc = new ProductCost(getCtx(), m_event.getM_Product_ID(), 0, getTrxName());
+        MAccount assetAcct = pc.getAccount(ProductCost.ACCTTYPE_P_Asset, as);
+        MAccount cogsAcct = pc.getAccount(ProductCost.ACCTTYPE_P_Cogs, as);
+        // Cost-adjustment clearing: inventory differences account (auditable, period-specific)
+        MAccount adjustmentAcct = getAccount(Doc.ACCTTYPE_InvDifferences, as);
+        if (adjustmentAcct == null)
+            adjustmentAcct = assetAcct;
+
+        String description = "CostAdj " + m_event.getDocumentNo()
+                + " " + (m_event.getCostAdjustmentType() != null ? m_event.getCostAdjustmentType() : "")
+                + " prod=" + (product != null ? product.getValue() : String.valueOf(m_event.getM_Product_ID()));
+
+        // Inventory leg
+        if (inventoryAmt.signum() != 0) {
+            postLeg(fact, as, assetAcct, adjustmentAcct, inventoryAmt, description, "INV");
+            if (p_Error != null)
+                return null;
+        }
+        // COGS leg
+        if (cogsAmt.signum() != 0) {
+            postLeg(fact, as, cogsAcct, adjustmentAcct, cogsAmt, description, "COGS");
+            if (p_Error != null)
+                return null;
+        }
+
+        facts.add(fact);
+        return facts;
+    }
+
+    /**
+     * Post one leg: positive amount = Dr expense/asset, Cr adjustment;
+     * negative amount = mirror.
+     */
+    private void postLeg(Fact fact, MAcctSchema as, MAccount debitAccount, MAccount creditAccount,
+            BigDecimal amount, String description, String legType) {
+        // Resolve nulls
+        if (debitAccount == null || creditAccount == null) {
+            p_Error = "No account for cost adjustment leg " + legType;
+            log.log(Level.SEVERE, p_Error);
+            return;
+        }
+        DocLine dummy = null; // facts without order line reference; use null-safe createLine via fact
+        FactLine dr = null;
+        FactLine cr = null;
+        if (amount.signum() > 0) {
+            dr = fact.createLine(dummy, debitAccount, as.getC_Currency_ID(), amount, null);
+            cr = fact.createLine(dummy, creditAccount, as.getC_Currency_ID(), null, amount);
+        } else {
+            BigDecimal abs = amount.abs();
+            dr = fact.createLine(dummy, creditAccount, as.getC_Currency_ID(), abs, null);
+            cr = fact.createLine(dummy, debitAccount, as.getC_Currency_ID(), null, abs);
+        }
+        if (dr == null || cr == null) {
+            p_Error = "FactLine not created for cost adjustment leg " + legType;
+            log.log(Level.WARNING, p_Error);
+            return;
+        }
+        dr.addDescription(description + " [" + legType + "]");
+        cr.addDescription(description + " [" + legType + "]");
+        dr.setM_Product_ID(m_event.getM_Product_ID());
+        cr.setM_Product_ID(m_event.getM_Product_ID());
+        dr.setAD_Org_ID(m_event.getAD_Org_ID());
+        cr.setAD_Org_ID(m_event.getAD_Org_ID());
+    }
+}

--- a/base/src/org/compiere/model/MCostAdjustmentEvent.java
+++ b/base/src/org/compiere/model/MCostAdjustmentEvent.java
@@ -1,0 +1,270 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2026 Adempiere Foundation. All Rights Reserved.          *
+ *****************************************************************************/
+package org.compiere.model;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Properties;
+
+import org.adempiere.core.domains.models.I_C_CostAdjustmentEvent;
+import org.adempiere.core.domains.models.I_C_CostAdjustmentLine;
+import org.adempiere.core.domains.models.X_C_CostAdjustmentEvent;
+import org.compiere.process.DocAction;
+import org.compiere.process.DocumentEngine;
+import org.compiere.util.DB;
+import org.compiere.util.Env;
+
+/**
+ * Cost Adjustment Event — auditable late-cost event posted in an open period.
+ * Never modifies the original closed-period Fact_Acct; instead it records a new
+ * document with inventory / COGS split lines.
+ */
+public class MCostAdjustmentEvent extends X_C_CostAdjustmentEvent implements DocAction {
+
+    private static final long serialVersionUID = 20260908L;
+
+    /** Adjustment types */
+    public static final String COSTADJUSTMENTTYPE_LateInvoicePrice = "LIP";
+    public static final String COSTADJUSTMENTTYPE_LandedCost = "LC";
+    public static final String COSTADJUSTMENTTYPE_NegativeInventory = "NI";
+    public static final String COSTADJUSTMENTTYPE_ExchangeDifference = "FX";
+    public static final String COSTADJUSTMENTTYPE_Manual = "MAN";
+
+    public MCostAdjustmentEvent(Properties ctx, int C_CostAdjustmentEvent_ID, String trxName) {
+        super(ctx, C_CostAdjustmentEvent_ID, trxName);
+        if (C_CostAdjustmentEvent_ID == 0) {
+            setProcessed(false);
+            setPosted(false);
+            setDocStatus(DOCSTATUS_Drafted);
+            setDocAction(DOCACTION_Complete);
+            setDateTrx(new Timestamp(System.currentTimeMillis()));
+            setDateAcct(getDateTrx());
+            setAdjustmentAmt(Env.ZERO);
+            setInventoryAmt(Env.ZERO);
+            setCOGSAmt(Env.ZERO);
+            setQtyOnHand(Env.ZERO);
+            setQtyAlreadySold(Env.ZERO);
+            setOldCostPrice(Env.ZERO);
+            setNewCostPrice(Env.ZERO);
+        }
+    }
+
+    public MCostAdjustmentEvent(Properties ctx, ResultSet rs, String trxName) {
+        super(ctx, rs, trxName);
+    }
+
+    public MCostAdjustmentLine[] getLines() {
+        List<MCostAdjustmentLine> list = new Query(getCtx(), I_C_CostAdjustmentLine.Table_Name,
+                I_C_CostAdjustmentLine.COLUMNNAME_C_CostAdjustmentEvent_ID + "=?", get_TrxName())
+                .setParameters(getC_CostAdjustmentEvent_ID())
+                .setOrderBy(I_C_CostAdjustmentLine.COLUMNNAME_Line)
+                .list();
+        MCostAdjustmentLine[] ret = new MCostAdjustmentLine[list.size()];
+        list.toArray(ret);
+        return ret;
+    }
+
+    /**
+     * Create inventory / COGS split lines. Must sum to AdjustmentAmt.
+     * @param inventoryAmt portion staying in inventory (may be negative)
+     * @param cogsAmt portion hitting COGS (may be negative)
+     */
+    public void createSplitLines(BigDecimal inventoryAmt, BigDecimal cogsAmt, String trxName) {
+        if (inventoryAmt == null)
+            inventoryAmt = Env.ZERO;
+        if (cogsAmt == null)
+            cogsAmt = Env.ZERO;
+        int lineNo = 10;
+        if (inventoryAmt.signum() != 0) {
+            MCostAdjustmentLine line = new MCostAdjustmentLine(getCtx(), 0, get_TrxName());
+            line.setC_CostAdjustmentEvent_ID(getC_CostAdjustmentEvent_ID());
+            line.setLine(lineNo);
+            line.setAdjustmentLineType(MCostAdjustmentLine.ADJUSTMENTLINETYPE_Inventory);
+            line.setAmt(inventoryAmt);
+            line.setQty(getQtyOnHand());
+            line.saveEx();
+            lineNo += 10;
+        }
+        if (cogsAmt.signum() != 0) {
+            MCostAdjustmentLine line = new MCostAdjustmentLine(getCtx(), 0, get_TrxName());
+            line.setC_CostAdjustmentEvent_ID(getC_CostAdjustmentEvent_ID());
+            line.setLine(lineNo);
+            line.setAdjustmentLineType(MCostAdjustmentLine.ADJUSTMENTLINETYPE_COGS);
+            line.setAmt(cogsAmt);
+            line.setQty(getQtyAlreadySold());
+            line.saveEx();
+        }
+        setInventoryAmt(inventoryAmt);
+        setCOGSAmt(cogsAmt);
+        setAdjustmentAmt(inventoryAmt.add(cogsAmt));
+        saveEx();
+    }
+
+    // --- DocAction boilerplate (minimal complete/void/close) ---
+
+    public boolean processIt(String action) throws Exception {
+        DocumentEngine engine = new DocumentEngine(this, getDocStatus());
+        return engine.processIt(action, getDocAction());
+    }
+
+    public boolean unlockIt() {
+        log.info(toString());
+        setProcessed(false);
+        return true;
+    }
+
+    public boolean invalidateIt() {
+        log.info(toString());
+        setDocAction(DOCACTION_Prepare);
+        return true;
+    }
+
+    public String prepareIt() {
+        log.info(toString());
+        // Must have open period on DateAcct
+        Timestamp dateAcct = getDateAcct() != null ? getDateAcct() : getDateTrx();
+        MDocType dt = MDocType.get(getCtx(), getC_DocType_ID());
+        String docBaseType = dt != null && dt.getDocBaseType() != null ? dt.getDocBaseType() : MDocType.DOCBASETYPE_MaterialReceipt;
+        if (!MPeriod.isOpen(getCtx(), dateAcct, docBaseType, getAD_Org_ID())) {
+            m_processMsg = "@PeriodClosed@";
+            return DOCSTATUS_Invalid;
+        }
+        if (getAdjustmentAmt().signum() == 0 && getLines().length == 0) {
+            m_processMsg = "@NoLines@";
+            return DOCSTATUS_Invalid;
+        }
+        setDocAction(DOCACTION_Complete);
+        return DOCSTATUS_InProgress;
+    }
+
+    public boolean approveIt() {
+        log.info(toString());
+        return true;
+    }
+
+    public boolean rejectIt() {
+        log.info(toString());
+        return true;
+    }
+
+    public String completeIt() {
+        // Re-validate open period at completion time
+        String status = prepareIt();
+        if (!DOCSTATUS_InProgress.equals(status))
+            return status;
+        setProcessed(true);
+        setDocStatus(DOCSTATUS_Completed);
+        setDocAction(DOCACTION_Close);
+        // Posting is done by AcctProcessor via Doc_CostAdjustmentEvent
+        return DOCSTATUS_Completed;
+    }
+
+    public boolean voidIt() {
+        // Void = reversing event in current open period; never delete history
+        if (DOCSTATUS_Completed.equals(getDocStatus()) || DOCSTATUS_Closed.equals(getDocStatus())) {
+            // Reverse by creating a mirror event
+            MCostAdjustmentEvent reversal = new MCostAdjustmentEvent(getCtx(), 0, get_TrxName());
+            PO.copyValues(this, reversal);
+            reversal.setC_CostAdjustmentEvent_ID(0);
+            reversal.setDocumentNo(getDocumentNo() + "^");
+            reversal.setAdjustmentAmt(getAdjustmentAmt().negate());
+            reversal.setInventoryAmt(getInventoryAmt().negate());
+            reversal.setCOGSAmt(getCOGSAmt().negate());
+            reversal.setDescription("Reversal of " + getDocumentNo());
+            reversal.setProcessed(true);
+            reversal.setDocStatus(DOCSTATUS_Voided);
+            reversal.saveEx();
+            // Reverse Fact_Acct of this event only (original periods untouched)
+            MFactAcct.deleteEx(get_Table_ID(), get_ID(), get_TrxName());
+            setPosted(false);
+        }
+        setProcessed(true);
+        setDocStatus(DOCSTATUS_Voided);
+        setDocAction(DOCACTION_None);
+        return true;
+    }
+
+    public boolean closeIt() {
+        log.info(toString());
+        setDocAction(DOCACTION_None);
+        return true;
+    }
+
+    public boolean reverseCorrectIt() {
+        return voidIt();
+    }
+
+    public boolean reverseAccrualIt() {
+        return voidIt();
+    }
+
+    public boolean reActivateIt() {
+        log.info(toString());
+        return false;
+    }
+
+    public String getSummary() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getDocumentNo()).append(": Amt=").append(getAdjustmentAmt())
+                .append(" (Inv=").append(getInventoryAmt())
+                .append(", COGS=").append(getCOGSAmt()).append(")");
+        return sb.toString();
+    }
+
+    public String getDocumentInfo() {
+        return getSummary();
+    }
+
+    public java.io.File createPDF() {
+        return null;
+    }
+
+    public String getProcessMsg() {
+        return m_processMsg;
+    }
+
+    public int getDoc_User_ID() {
+        return getCreatedBy();
+    }
+
+    public int getC_Currency_ID() {
+        MAcctSchema as = MAcctSchema.get(getCtx(), getC_AcctSchema_ID());
+        if (as != null)
+            return as.getC_Currency_ID();
+        return Env.getContextAsInt(getCtx(), "$C_Currency_ID");
+    }
+
+    public BigDecimal getApprovalAmt() {
+        return getAdjustmentAmt();
+    }
+
+    private String m_processMsg = null;
+
+    public String getDocBaseType() {
+        return null;
+    }
+
+    protected boolean beforeSave(boolean newRecord) {
+        if (getDateAcct() == null && getDateTrx() != null)
+            setDateAcct(getDateTrx());
+        if (getDocumentNo() == null || getDocumentNo().length() == 0) {
+            String no = DB.getDocumentNo(getC_DocType_ID() > 0 ? getC_DocType_ID() : 0, get_TrxName(), false, this);
+            if (no != null)
+                setDocumentNo(no);
+        }
+        return true;
+    }
+
+    /** Find events referencing an original cost detail (audit trail). */
+    public static List<MCostAdjustmentEvent> getByCostDetail(Properties ctx, int M_CostDetail_ID, String trxName) {
+        return new Query(ctx, I_C_CostAdjustmentEvent.Table_Name,
+                I_C_CostAdjustmentEvent.COLUMNNAME_M_CostDetail_ID + "=?", trxName)
+                .setParameters(M_CostDetail_ID)
+                .setOrderBy(I_C_CostAdjustmentEvent.COLUMNNAME_C_CostAdjustmentEvent_ID)
+                .list();
+    }
+}

--- a/base/src/org/compiere/model/MCostAdjustmentLine.java
+++ b/base/src/org/compiere/model/MCostAdjustmentLine.java
@@ -1,0 +1,31 @@
+/******************************************************************************
+ * Product: Adempiere ERP & CRM Smart Business Solution                       *
+ *****************************************************************************/
+package org.compiere.model;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+
+import org.adempiere.core.domains.models.X_C_CostAdjustmentLine;
+
+/**
+ * Cost Adjustment Line — one leg of the inventory / COGS split.
+ */
+public class MCostAdjustmentLine extends X_C_CostAdjustmentLine {
+
+    private static final long serialVersionUID = 20260908L;
+
+    public static final String ADJUSTMENTLINETYPE_Inventory = "INV";
+    public static final String ADJUSTMENTLINETYPE_COGS = "COGS";
+
+    public MCostAdjustmentLine(Properties ctx, int C_CostAdjustmentLine_ID, String trxName) {
+        super(ctx, C_CostAdjustmentLine_ID, trxName);
+        if (C_CostAdjustmentLine_ID == 0) {
+            setLine(10);
+        }
+    }
+
+    public MCostAdjustmentLine(Properties ctx, ResultSet rs, String trxName) {
+        super(ctx, rs, trxName);
+    }
+}

--- a/base/src/org/compiere/model/MCostDetail.java
+++ b/base/src/org/compiere/model/MCostDetail.java
@@ -965,12 +965,62 @@ public class MCostDetail extends X_M_CostDetail
 		dateAcct = DB.getSQLValueTSEx(get_TrxName(), sql, param1);
 		setDateAcct(dateAcct);
 	}
-	
+
 	/**
-	 * Restore the Posting to that document can be posting again
+	 * Check whether un-posting / re-posting is allowed for this cost detail.
+	 * Reposting is only allowed when the accounting period of the cost detail
+	 * date is open. Closed periods must use a cost adjustment event instead.
+	 * @return true if the period is open (or no date/doc type can be resolved)
+	 */
+	public boolean isRepostingAllowed()
+	{
+		try {
+			Timestamp dateAcct = getDateAcct();
+			if (dateAcct == null)
+				return true;
+			String docBaseType = null;
+			int docTypeId = 0;
+			if (getC_InvoiceLine_ID() > 0) {
+				docTypeId = DB.getSQLValue(get_TrxName(),
+						"SELECT i.C_DocType_ID FROM C_InvoiceLine il"
+						+ " INNER JOIN C_Invoice i ON (i.C_Invoice_ID=il.C_Invoice_ID)"
+						+ " WHERE il.C_InvoiceLine_ID=?", getC_InvoiceLine_ID());
+			} else if (getM_InOutLine_ID() > 0) {
+				docTypeId = DB.getSQLValue(get_TrxName(),
+						"SELECT i.C_DocType_ID FROM M_InOutLine il"
+						+ " INNER JOIN M_InOut i ON (i.M_InOut_ID=il.M_InOut_ID)"
+						+ " WHERE il.M_InOutLine_ID=?", getM_InOutLine_ID());
+			}
+			if (docTypeId > 0) {
+				MDocType dt = MDocType.get(getCtx(), docTypeId);
+				if (dt != null)
+					docBaseType = dt.getDocBaseType();
+			}
+			if (docBaseType == null)
+				docBaseType = MDocType.DOCBASETYPE_MaterialReceipt;
+			boolean open = MPeriod.isOpen(getCtx(), dateAcct, docBaseType, getAD_Org_ID());
+			if (!open)
+				s_log.warning("rePosted blocked: period closed for M_CostDetail_ID="
+						+ getM_CostDetail_ID() + " DateAcct=" + dateAcct
+						+ ". Create a C_CostAdjustmentEvent in an open period instead.");
+			return open;
+		} catch (Exception e) {
+			s_log.warning("isRepostingAllowed check failed, allowing repost: " + e.getMessage());
+			return true;
+		}
+	}
+
+	/**
+	 * Restore the Posting so that document can be posted again.
+	 * <p>Closed periods are immutable: when the cost detail accounting date
+	 * falls in a closed period this method does nothing. Late costs must be
+	 * recorded as a {@code C_CostAdjustmentEvent} in an open period instead
+	 * (see {@code org.adempiere.engine.CostAdjustmentEngine}).</p>
 	 */
 	private void rePosted()
-	{		
+	{
+		if (!isRepostingAllowed())
+			return;
 		if (getC_InvoiceLine_ID() > 0)
 		{
 			int id = DB.getSQLValue(get_TrxName(), "SELECT M_MatchInv_ID FROM M_MatchInv WHERE C_InvoiceLine_ID=?", getC_InvoiceLine_ID());

--- a/migration/394lts-3.9.4.001/10330_Cost_Adjustment_Event.xml
+++ b/migration/394lts-3.9.4.001/10330_Cost_Adjustment_Event.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Migrations>
+  <Migration EntityType="D" Name="Cost Adjustment Event for negative inventory landed costs closed periods" ReleaseNo="3.9.4" SeqNo="10330">
+    <Comments>Auditable cost adjustment model: C_CostAdjustmentEvent / C_CostAdjustmentLine. Closed periods stay immutable; late costs post in an open period split between Inventory and COGS. See CostAdjustmentEngine + Doc_CostAdjustmentEvent.</Comments>
+    <Step DBType="Postgres" Parse="N" SeqNo="10" StepType="SQL">
+      <SQLStatement>CREATE TABLE C_CostAdjustmentEvent (C_CostAdjustmentEvent_ID NUMERIC(10) NOT NULL, AD_Client_ID NUMERIC(10) NOT NULL, AD_Org_ID NUMERIC(10) NOT NULL, IsActive CHAR(1) DEFAULT 'Y' NOT NULL, Created TIMESTAMP DEFAULT NOW() NOT NULL, CreatedBy NUMERIC(10) NOT NULL, Updated TIMESTAMP DEFAULT NOW() NOT NULL, UpdatedBy NUMERIC(10) NOT NULL, DocumentNo VARCHAR(30), C_DocType_ID NUMERIC(10), DateAcct TIMESTAMP, DateTrx TIMESTAMP, M_Product_ID NUMERIC(10), C_AcctSchema_ID NUMERIC(10), M_CostType_ID NUMERIC(10), M_CostElement_ID NUMERIC(10), CostAdjustmentType CHAR(3) DEFAULT 'MAN', M_InOutLine_ID NUMERIC(10), C_InvoiceLine_ID NUMERIC(10), C_LandedCostAllocation_ID NUMERIC(10), M_CostDetail_ID NUMERIC(10), OldCostPrice NUMERIC DEFAULT 0, NewCostPrice NUMERIC DEFAULT 0, QtyOnHand NUMERIC DEFAULT 0, QtyAlreadySold NUMERIC DEFAULT 0, AdjustmentAmt NUMERIC DEFAULT 0, InventoryAmt NUMERIC DEFAULT 0, COGSAmt NUMERIC DEFAULT 0, Description VARCHAR(255), Processed CHAR(1) DEFAULT 'N' NOT NULL, Posted CHAR(1) DEFAULT 'N' NOT NULL, DocStatus CHAR(2) DEFAULT 'DR', DocAction CHAR(2) DEFAULT 'CO', CONSTRAINT C_CostAdjustmentEvent_Key PRIMARY KEY (C_CostAdjustmentEvent_ID))</SQLStatement>
+      <RollbackStatement>DROP TABLE C_CostAdjustmentEvent</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="N" SeqNo="20" StepType="SQL">
+      <SQLStatement>CREATE TABLE C_CostAdjustmentEvent (C_CostAdjustmentEvent_ID NUMBER(10) NOT NULL, AD_Client_ID NUMBER(10) NOT NULL, AD_Org_ID NUMBER(10) NOT NULL, IsActive CHAR(1) DEFAULT 'Y' NOT NULL, Created DATE DEFAULT SYSDATE NOT NULL, CreatedBy NUMBER(10) NOT NULL, Updated DATE DEFAULT SYSDATE NOT NULL, UpdatedBy NUMBER(10) NOT NULL, DocumentNo NVARCHAR2(30), C_DocType_ID NUMBER(10), DateAcct DATE, DateTrx DATE, M_Product_ID NUMBER(10), C_AcctSchema_ID NUMBER(10), M_CostType_ID NUMBER(10), M_CostElement_ID NUMBER(10), CostAdjustmentType CHAR(3) DEFAULT 'MAN', M_InOutLine_ID NUMBER(10), C_InvoiceLine_ID NUMBER(10), C_LandedCostAllocation_ID NUMBER(10), M_CostDetail_ID NUMBER(10), OldCostPrice NUMBER DEFAULT 0, NewCostPrice NUMBER DEFAULT 0, QtyOnHand NUMBER DEFAULT 0, QtyAlreadySold NUMBER DEFAULT 0, AdjustmentAmt NUMBER DEFAULT 0, InventoryAmt NUMBER DEFAULT 0, COGSAmt NUMBER DEFAULT 0, Description NVARCHAR2(255), Processed CHAR(1) DEFAULT 'N' NOT NULL, Posted CHAR(1) DEFAULT 'N' NOT NULL, DocStatus CHAR(2) DEFAULT 'DR', DocAction CHAR(2) DEFAULT 'CO', CONSTRAINT C_CostAdjustmentEvent_Key PRIMARY KEY (C_CostAdjustmentEvent_ID))</SQLStatement>
+      <RollbackStatement>DROP TABLE C_CostAdjustmentEvent</RollbackStatement>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="30" StepType="SQL">
+      <SQLStatement>CREATE TABLE C_CostAdjustmentLine (C_CostAdjustmentLine_ID NUMERIC(10) NOT NULL, AD_Client_ID NUMERIC(10) NOT NULL, AD_Org_ID NUMERIC(10) NOT NULL, IsActive CHAR(1) DEFAULT 'Y' NOT NULL, Created TIMESTAMP DEFAULT NOW() NOT NULL, CreatedBy NUMERIC(10) NOT NULL, Updated TIMESTAMP DEFAULT NOW() NOT NULL, UpdatedBy NUMERIC(10) NOT NULL, C_CostAdjustmentEvent_ID NUMERIC(10) NOT NULL, Line NUMERIC(10) DEFAULT 10 NOT NULL, AdjustmentLineType CHAR(4) DEFAULT 'INV' NOT NULL, Amt NUMERIC DEFAULT 0 NOT NULL, Qty NUMERIC DEFAULT 0, Description VARCHAR(255), CONSTRAINT C_CostAdjustmentLine_Key PRIMARY KEY (C_CostAdjustmentLine_ID), CONSTRAINT C_CostAdjLine_Event_FK FOREIGN KEY (C_CostAdjustmentEvent_ID) REFERENCES C_CostAdjustmentEvent (C_CostAdjustmentEvent_ID) ON DELETE CASCADE)</SQLStatement>
+      <RollbackStatement>DROP TABLE C_CostAdjustmentLine</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="N" SeqNo="40" StepType="SQL">
+      <SQLStatement>CREATE TABLE C_CostAdjustmentLine (C_CostAdjustmentLine_ID NUMBER(10) NOT NULL, AD_Client_ID NUMBER(10) NOT NULL, AD_Org_ID NUMBER(10) NOT NULL, IsActive CHAR(1) DEFAULT 'Y' NOT NULL, Created DATE DEFAULT SYSDATE NOT NULL, CreatedBy NUMBER(10) NOT NULL, Updated DATE DEFAULT SYSDATE NOT NULL, UpdatedBy NUMBER(10) NOT NULL, C_CostAdjustmentEvent_ID NUMBER(10) NOT NULL, Line NUMBER(10) DEFAULT 10 NOT NULL, AdjustmentLineType CHAR(4) DEFAULT 'INV' NOT NULL, Amt NUMBER DEFAULT 0 NOT NULL, Qty NUMBER DEFAULT 0, Description NVARCHAR2(255), CONSTRAINT C_CostAdjustmentLine_Key PRIMARY KEY (C_CostAdjustmentLine_ID), CONSTRAINT C_CostAdjLine_Event_FK FOREIGN KEY (C_CostAdjustmentEvent_ID) REFERENCES C_CostAdjustmentEvent (C_CostAdjustmentEvent_ID) ON DELETE CASCADE)</SQLStatement>
+      <RollbackStatement>DROP TABLE C_CostAdjustmentLine</RollbackStatement>
+    </Step>
+    <Step DBType="Postgres" Parse="N" SeqNo="50" StepType="SQL">
+      <SQLStatement>CREATE INDEX C_CostAdjEvent_Product ON C_CostAdjustmentEvent (M_Product_ID); CREATE INDEX C_CostAdjEvent_CostDetail ON C_CostAdjustmentEvent (M_CostDetail_ID); CREATE INDEX C_CostAdjLine_Event ON C_CostAdjustmentLine (C_CostAdjustmentEvent_ID)</SQLStatement>
+      <RollbackStatement>DROP INDEX C_CostAdjEvent_Product; DROP INDEX C_CostAdjEvent_CostDetail; DROP INDEX C_CostAdjLine_Event</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="N" SeqNo="60" StepType="SQL">
+      <SQLStatement>CREATE INDEX C_CostAdjEvent_Product ON C_CostAdjustmentEvent (M_Product_ID)</SQLStatement>
+      <RollbackStatement>DROP INDEX C_CostAdjEvent_Product</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="N" SeqNo="70" StepType="SQL">
+      <SQLStatement>CREATE INDEX C_CostAdjEvent_CostDetail ON C_CostAdjustmentEvent (M_CostDetail_ID)</SQLStatement>
+      <RollbackStatement>DROP INDEX C_CostAdjEvent_CostDetail</RollbackStatement>
+    </Step>
+    <Step DBType="Oracle" Parse="N" SeqNo="80" StepType="SQL">
+      <SQLStatement>CREATE INDEX C_CostAdjLine_Event ON C_CostAdjustmentLine (C_CostAdjustmentEvent_ID)</SQLStatement>
+      <RollbackStatement>DROP INDEX C_CostAdjLine_Event</RollbackStatement>
+    </Step>
+  </Migration>
+</Migrations>


### PR DESCRIPTION
…sts, closed periods, margin and commission corrections

Introduce C_CostAdjustmentEvent / C_CostAdjustmentLine as separate economic events posted only in open periods, keeping closed-period Fact_Acct and cost history immutable. Adds CostAdjustmentCalculator, CostAdjustmentEngine, Doc_CostAdjustmentEvent posting, closed-period guards in CostEngine/MCostDetail, and migration DDL.